### PR TITLE
chore(CSI-72): add expiration to docker images on quay

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -51,8 +51,9 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           labels: |
-            revision='${{ steps.auto_version.outputs.version }}'
+            revision=${{ steps.auto_version.outputs.version }}
             quay.expires-after=14d
+          provenance: false # https://issues.redhat.com/browse/PROJQUAY-5013 quay doesn't support it
           build-args: |
             VERSION='${{ steps.auto_version.outputs.version }}'
 

--- a/.github/workflows/push-dev.yaml
+++ b/.github/workflows/push-dev.yaml
@@ -53,8 +53,9 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           labels: |
-            revision='${{ steps.auto_version.outputs.version }}'
+            revision=${{ steps.auto_version.outputs.version }}
             quay.expires-after=14d
+          provenance: false # https://issues.redhat.com/browse/PROJQUAY-5013 quay doesn't support it
           build-args: |
             VERSION='${{ steps.auto_version.outputs.version }}'
 


### PR DESCRIPTION
quay doesn't support provenance https://issues.redhat.com/browse/PROJQUAY-5013