### PR TITLE
fix(CSI-224,WEKAPP-417375): race condition on multiple volume deletion in parallel

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,8 @@ RUN apk add util-linux libselinux libselinux-utils util-linux pciutils usbutils 
 # Update CA certificates
 RUN apk add ca-certificates
 RUN update-ca-certificates
+ADD https://github.com/tigrawap/locar/releases/download/0.4.0/locar_linux_amd64 /locar
+RUN chmod +x /locar
 COPY --from=go-builder /bin/wekafsplugin /wekafsplugin
 ARG binary=/bin/wekafsplugin
 ENTRYPOINT ["/wekafsplugin"]

--- a/pkg/wekafs/gc.go
+++ b/pkg/wekafs/gc.go
@@ -2,8 +2,10 @@ package wekafs
 
 import (
 	"context"
+	"fmt"
 	"github.com/rs/zerolog/log"
 	"github.com/wekafs/csi-wekafs/pkg/wekafs/apiclient"
+	"go.opentelemetry.io/otel"
 	"io"
 	"os"
 	"path/filepath"
@@ -11,6 +13,7 @@ import (
 )
 
 const garbagePath = ".__internal__wekafs-async-delete"
+const garbageCollectionMaxThreads = 32
 
 type innerPathVolGc struct {
 	isRunning  map[string]bool
@@ -26,42 +29,38 @@ func initInnerPathVolumeGc(mounter *wekaMounter) *innerPathVolGc {
 	return &gc
 }
 
-func (gc *innerPathVolGc) triggerGc(ctx context.Context, fs string, apiClient *apiclient.ApiClient) {
-	gc.Lock()
-	defer gc.Unlock()
-	if gc.isRunning[fs] {
-		gc.isDeferred[fs] = true
-		return
-	}
-	gc.isRunning[fs] = true
-	go gc.purgeLeftovers(ctx, fs, apiClient)
-}
-
 func (gc *innerPathVolGc) triggerGcVolume(ctx context.Context, volume *Volume) {
+	op := "triggerGcVolume"
+	ctx, span := otel.Tracer(TracerName).Start(ctx, op)
+	defer span.End()
+	ctx = log.With().Str("trace_id", span.SpanContext().TraceID().String()).Str("span_id", span.SpanContext().SpanID().String()).Str("op", op).Logger().WithContext(ctx)
+	logger := log.Ctx(ctx).With().Str("volume_id", volume.GetId()).Logger()
+	logger.Info().Msg("Triggering garbage collection of volume")
 	fsName := volume.FilesystemName
-	gc.Lock()
-	defer gc.Unlock()
-	if gc.isRunning[fsName] {
-		gc.isDeferred[fsName] = true
-		return
-	}
-	gc.isRunning[fsName] = true
-	gc.isDeferred[fsName] = true
-	go gc.purgeVolume(ctx, volume)
+	gc.moveVolumeToTrash(ctx, volume) // always do it synchronously
+	go gc.initiateGarbageCollection(ctx, fsName, volume.apiClient)
 }
 
-func (gc *innerPathVolGc) purgeVolume(ctx context.Context, volume *Volume) {
+func (gc *innerPathVolGc) moveVolumeToTrash(ctx context.Context, volume *Volume) {
+	op := "moveVolumeToTrash"
+	ctx, span := otel.Tracer(TracerName).Start(ctx, op)
+	defer span.End()
+	ctx = log.With().Str("trace_id", span.SpanContext().TraceID().String()).Str("span_id", span.SpanContext().SpanID().String()).Str("op", op).Logger().WithContext(ctx)
 	logger := log.Ctx(ctx).With().Str("volume_id", volume.GetId()).Logger()
 	logger.Debug().Msg("Starting garbage collection of volume")
 	fsName := volume.FilesystemName
-	defer gc.finishGcCycle(ctx, fsName, volume.apiClient)
+	defer gc.initiateGarbageCollection(ctx, fsName, volume.apiClient)
 	path, err, unmount := gc.mounter.Mount(ctx, fsName, volume.apiClient)
 	defer unmount()
+	if err != nil {
+		logger.Error().Err(err).Msg("Failed to mount filesystem for GC processing")
+		return
+	}
 	volumeTrashLoc := filepath.Join(path, garbagePath)
 	if err := os.MkdirAll(volumeTrashLoc, DefaultVolumePermissions); err != nil {
-		logger.Error().Err(err).Msg("Failed to create garbage collector directory")
+		logger.Error().Str("garbage_collection_path", volumeTrashLoc).Err(err).Msg("Failed to create garbage collector directory")
 	} else {
-		logger.Debug().Str("garbage_collection_path", volumeTrashLoc).Msg("Successfuly created garbage collection directory")
+		logger.Debug().Str("garbage_collection_path", volumeTrashLoc).Msg("Successfully created garbage collection directory")
 	}
 	fullPath := filepath.Join(path, volume.GetFullPath(ctx))
 	logger.Debug().Str("full_path", fullPath).Str("volume_trash_location", volumeTrashLoc).Msg("Moving volume contents to trash")
@@ -75,65 +74,110 @@ func (gc *innerPathVolGc) purgeVolume(ctx context.Context, volume *Volume) {
 	// so if the volume is dir/v1/<filesystem>/this/is/a/path/to/volume, we might move only the `volume`
 	// but otherwise it could be risky as if we have multiple volumes we might remove other data too, e.g.
 	// vol1: dir/v1/<filesystem>/this/is/a/path/to/volume, vol2: dir/v1/<filesystem>/this/is/a/path/to/another_volume
-
-	logger.Trace().Str("purge_path", volumeTrashLoc).Msg("Purging deleted volume data")
-	if err != nil {
-		logger.Error().Err(err).Msg("Failed to mount filesystem for GC processing")
-		return
-	}
-	if err := purgeDirectory(ctx, volumeTrashLoc); err != nil {
-		logger.Error().Err(err).Str("purge_path", volumeTrashLoc).Msg("Failed to remove directory")
-		return
-	}
-
-	logger.Debug().Msg("Volume purged")
+	// 2024-07-29: apparently seems this is not a real problem since static volumes are not deleted this way
+	//             and dynamic volumes are always created inside the /csi-volumes
+	logger.Debug().Str("full_path", fullPath).Str("volume_trash_location", volumeTrashLoc).Msg("Volume contents moved to trash")
 }
 
-func purgeDirectory(ctx context.Context, path string) error {
-	logger := log.Ctx(ctx).With().Str("path", path).Logger()
-	if !PathExists(path) {
-		logger.Error().Str("path", path).Msg("Failed to remove existing directory")
-		return nil
-	}
-	for !pathIsEmptyDir(path) { // to make sure that if new files still appeared during invocation
-		files, err := os.ReadDir(path)
+func deleteDirectoryWorker(paths <-chan string, wg *sync.WaitGroup) {
+	defer wg.Done()
+	for path := range paths {
+		err := os.RemoveAll(path)
 		if err != nil {
-			logger.Error().Err(err).Msg("GC failed to read directory contents")
+			fmt.Printf("Failed to remove %s: %s\n", path, err)
+		}
+	}
+}
+
+func deleteDirectoryTree(ctx context.Context, path string) error {
+	op := "purgeDirectory"
+	ctx, span := otel.Tracer(TracerName).Start(ctx, op)
+	defer span.End()
+	ctx = log.With().Str("trace_id", span.SpanContext().TraceID().String()).Str("span_id", span.SpanContext().SpanID().String()).Str("op", op).Logger().WithContext(ctx)
+	logger := log.Ctx(ctx).With().Str("path", path).Logger()
+	paths := make(chan string, garbageCollectionMaxThreads)
+	var wg sync.WaitGroup
+
+	// Start deleteDirectoryWorker goroutines
+	for i := 0; i < garbageCollectionMaxThreads; i++ {
+		wg.Add(1)
+		go deleteDirectoryWorker(paths, &wg)
+	}
+
+	// Walk the directory tree and send paths to the workers
+	err := filepath.Walk(path, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
 			return err
 		}
-		for _, f := range files {
-			fp := filepath.Join(path, f.Name())
-			if f.IsDir() {
-				if err := purgeDirectory(ctx, fp); err != nil {
-					logger.Error().Err(err).Msg("")
-					return err
-				}
-			} else if err := os.Remove(fp); err != nil {
-				logger.Error().Err(err).Msg("Failed to remove directory that was used mount point")
-			}
-		}
+		paths <- path
+		return nil
+	})
+	if err != nil {
+		close(paths)
+		logger.Trace().Msg("Waiting for deletion workers to finish")
+		wg.Wait()
+		return err
 	}
-	return os.Remove(path)
+
+	// Close the paths channel and wait for all workers to finish
+	close(paths)
+	wg.Wait()
+
+	return nil
 }
 
 func (gc *innerPathVolGc) purgeLeftovers(ctx context.Context, fs string, apiClient *apiclient.ApiClient) {
-	defer gc.finishGcCycle(ctx, fs, apiClient)
+	op := "purgeLeftovers"
+	ctx, span := otel.Tracer(TracerName).Start(ctx, op)
+	defer span.End()
+	ctx = log.With().Str("trace_id", span.SpanContext().TraceID().String()).Str("span_id", span.SpanContext().SpanID().String()).Str("op", op).Logger().WithContext(ctx)
+	logger := log.Ctx(ctx)
+	gc.Lock()
+	gc.isRunning[fs] = true
+	gc.Unlock()
 	path, err, unmount := gc.mounter.Mount(ctx, fs, apiClient)
 	defer unmount()
 	if err != nil {
 		log.Ctx(ctx).Error().Err(err).Str("filesystem", fs).Str("path", path).Msg("Failed mounting FS for garbage collection")
 		return
 	}
-}
+	volumeTrashLoc := filepath.Join(path, garbagePath)
 
-func (gc *innerPathVolGc) finishGcCycle(ctx context.Context, fs string, apiClient *apiclient.ApiClient) {
+	err = deleteDirectoryTree(ctx, volumeTrashLoc)
+	if err != nil {
+		fmt.Printf("Error: %s\n", err)
+	} else {
+		fmt.Println("Directory tree deleted successfully")
+	}
+
+	logger.Debug().Msg("Garbage collection completed")
 	gc.Lock()
+	defer gc.Unlock()
 	gc.isRunning[fs] = false
 	if gc.isDeferred[fs] {
 		gc.isDeferred[fs] = false
-		go gc.triggerGc(ctx, fs, apiClient)
+		go gc.purgeLeftovers(ctx, fs, apiClient)
 	}
-	gc.Unlock()
+}
+
+func (gc *innerPathVolGc) initiateGarbageCollection(ctx context.Context, fs string, apiClient *apiclient.ApiClient) {
+	op := "initiateGarbageCollection"
+	ctx, span := otel.Tracer(TracerName).Start(ctx, op)
+	defer span.End()
+	ctx = log.With().Str("trace_id", span.SpanContext().TraceID().String()).Str("span_id", span.SpanContext().SpanID().String()).Str("op", op).Logger().WithContext(ctx)
+	logger := log.Ctx(ctx)
+	logger.Trace().Msg("Initiating garbage collection")
+	gc.Lock()
+	defer gc.Unlock()
+	if gc.isRunning[fs] {
+		logger.Trace().Msg("Garbage collection already running, deferring next run")
+		gc.isDeferred[fs] = true
+		return
+	}
+	if !gc.isDeferred[fs] {
+		logger.Trace().Msg("Garbage collection not running, starting")
+		go gc.purgeLeftovers(ctx, fs, apiClient)
+	}
 }
 
 // pathIsEmptyDir is a simple check to determine if directory is empty or not.

--- a/pkg/wekafs/gc.go
+++ b/pkg/wekafs/gc.go
@@ -102,8 +102,8 @@ func (gc *innerPathVolGc) purgeLeftovers(ctx context.Context, fs string, apiClie
 		output, err := deleteCmd.CombinedOutput()
 		if err != nil {
 			logger.Error().Err(err).Msg("Error running locar")
+			logger.Trace().Str("output", string(output)).Msg("Locar output")
 		}
-		logger.Trace().Str("output", string(output)).Msg("Output of locar")
 	} else {
 		logger.Debug().Msg("Using default deletion method")
 		if err := os.RemoveAll(volumeTrashLoc); err != nil {

--- a/pkg/wekafs/gc.go
+++ b/pkg/wekafs/gc.go
@@ -10,10 +10,12 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"time"
 )
 
 const garbagePath = ".__internal__wekafs-async-delete"
-const garbageCollectionMaxThreads = 32
+
+//const garbageCollectionMaxThreads = 32
 
 type innerPathVolGc struct {
 	isRunning  map[string]bool
@@ -89,41 +91,94 @@ func deleteDirectoryWorker(paths <-chan string, wg *sync.WaitGroup) {
 	}
 }
 
-func deleteDirectoryTree(ctx context.Context, path string) error {
-	op := "purgeDirectory"
+//func deleteDirectoryTree(ctx context.Context, path string) error {
+//	op := "deleteDirectoryTree"
+//	ctx, span := otel.Tracer(TracerName).Start(ctx, op)
+//	defer span.End()
+//	ctx = log.With().Str("trace_id", span.SpanContext().TraceID().String()).Str("span_id", span.SpanContext().SpanID().String()).Str("op", op).Logger().WithContext(ctx)
+//	logger := log.Ctx(ctx).With().Str("path", path).Logger()
+//	paths := make(chan string, garbageCollectionMaxThreads)
+//	var wg sync.WaitGroup
+//
+//	// Start deleteDirectoryWorker goroutines
+//	for i := 0; i < garbageCollectionMaxThreads; i++ {
+//		wg.Add(1)
+//		go deleteDirectoryWorker(paths, &wg)
+//	}
+//
+//	// Walk the directory tree and send paths to the workers
+//	err := filepath.Walk(path, func(path string, info os.FileInfo, err error) error {
+//		if err != nil {
+//			return err
+//		}
+//		paths <- path
+//		return nil
+//	})
+//	if err != nil {
+//		close(paths)
+//		logger.Trace().Msg("Waiting for deletion workers to finish")
+//		wg.Wait()
+//		return err
+//	}
+//
+//	// Close the paths channel and wait for all workers to finish
+//	close(paths)
+//	wg.Wait()
+//
+//	return nil
+//}
+
+func deleteDirectoryRecursively(ctx context.Context, path string, wg *sync.WaitGroup, errChan chan<- error, sem chan struct{}) {
+	op := "deleteDirectoryRecursively"
 	ctx, span := otel.Tracer(TracerName).Start(ctx, op)
 	defer span.End()
 	ctx = log.With().Str("trace_id", span.SpanContext().TraceID().String()).Str("span_id", span.SpanContext().SpanID().String()).Str("op", op).Logger().WithContext(ctx)
 	logger := log.Ctx(ctx).With().Str("path", path).Logger()
-	paths := make(chan string, garbageCollectionMaxThreads)
-	var wg sync.WaitGroup
 
-	// Start deleteDirectoryWorker goroutines
-	for i := 0; i < garbageCollectionMaxThreads; i++ {
-		wg.Add(1)
-		go deleteDirectoryWorker(paths, &wg)
-	}
-
-	// Walk the directory tree and send paths to the workers
-	err := filepath.Walk(path, func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-		paths <- path
-		return nil
-	})
+	dir, err := os.Open(path)
 	if err != nil {
-		close(paths)
-		logger.Trace().Msg("Waiting for deletion workers to finish")
-		wg.Wait()
-		return err
+		errChan <- fmt.Errorf("failed to open directory %s: %v", path, err)
+		return
 	}
+	defer dir.Close()
 
-	// Close the paths channel and wait for all workers to finish
-	close(paths)
-	wg.Wait()
-
-	return nil
+	for {
+		names, err := dir.Readdirnames(100) // Read directory entries in chunks
+		if err != nil {
+			if err != io.EOF {
+				logger.Error().Err(err).Msg("Failed to read directory entries")
+				errChan <- fmt.Errorf("failed to read directory entries: %v", err)
+			}
+			break
+		}
+		if len(names) == 0 {
+			break
+		}
+		logger.Trace().Int("num_entries", len(names)).Msg("Processing directory entries")
+		for _, name := range names {
+			subPath := filepath.Join(path, name)
+			go func(p string) {
+				logger.Trace().Str("sub_path", p).Msg("Processing subpath, acquiring semaphore")
+				sem <- struct{}{} // Acquire semaphore
+				logger.Trace().Str("sub_path", p).Msg("Processing subpath, acquired semaphore")
+				wg.Add(1)
+				defer wg.Done()
+				defer func() { <-sem }() // Release semaphore
+				fi, err := os.Lstat(p)
+				if err != nil {
+					logger.Error().Err(err).Str("path", p).Msg("Failed to stat path")
+					errChan <- fmt.Errorf("failed to stat %s: %v", p, err)
+					return
+				}
+				if fi.IsDir() {
+					deleteDirectoryRecursively(ctx, p, wg, errChan, sem) // Recurse into subdirectory
+					if err := os.Remove(p); err != nil {
+						errChan <- fmt.Errorf("failed to remove entry %s: %v", p, err)
+					}
+				}
+			}(subPath)
+		}
+	}
 }
 
 func (gc *innerPathVolGc) purgeLeftovers(ctx context.Context, fs string, apiClient *apiclient.ApiClient) {
@@ -143,12 +198,32 @@ func (gc *innerPathVolGc) purgeLeftovers(ctx context.Context, fs string, apiClie
 	}
 	volumeTrashLoc := filepath.Join(path, garbagePath)
 
-	err = deleteDirectoryTree(ctx, volumeTrashLoc)
-	if err != nil {
-		fmt.Printf("Error: %s\n", err)
-	} else {
-		fmt.Println("Directory tree deleted successfully")
+	var wg sync.WaitGroup
+	errChan := make(chan error, 10000)
+	sem := make(chan struct{}, 1000)
+	go deleteDirectoryRecursively(ctx, volumeTrashLoc, &wg, errChan, sem)
+
+	time.Sleep(3 * time.Second) // Wait for some time to allow the workers to start
+	wg.Wait()
+
+	if err := os.Remove(path); err != nil {
+		errChan <- fmt.Errorf("failed to remove file %s: %v", path, err)
 	}
+
+	close(errChan)
+	for err := range errChan {
+		if err != nil {
+			logger.Warn().Err(err).Msg("Error occured during deletion")
+		}
+	}
+
+	//
+	//err = deleteDirectoryTree(ctx, volumeTrashLoc)
+	//if err != nil {
+	//	logger.Error().Err(err).Msg("Failed to remove directory tree")
+	//} else {
+	//	logger.Trace().Msg("Directory tree deleted successfully")
+	//}
 
 	logger.Debug().Msg("Garbage collection completed")
 	gc.Lock()

--- a/pkg/wekafs/utilities.go
+++ b/pkg/wekafs/utilities.go
@@ -270,6 +270,17 @@ func PathExists(p string) bool {
 	return true
 }
 
+func fileExists(filename string) bool {
+	_, err := os.Stat(filename)
+	if err == nil {
+		return true
+	}
+	if os.IsNotExist(err) {
+		return false
+	}
+	return false
+}
+
 func PathIsWekaMount(ctx context.Context, path string) bool {
 	file, err := os.Open("/proc/mounts")
 	if err != nil {


### PR DESCRIPTION
### TL;DR

Refactored garbage collection initiation and handling in the WekaFS package for better traceability, logging, and performance.

### What changed?

- Introduced OpenTelemetry tracing to GC functions.
- Improved logging for GC initiation and directory deletion processes.
- Replaced synchronous volume purge with move to trash followed by async GC initiation.
- Enhanced directory deletion using worker pool mechanism to limit concurrent deletions.
- Updated variable names and function names for better clarity.

### How to test?

- Run unit tests available for the `wekafs` package.
- Perform integration testing by deploying in staging environment and monitor logs and traces for GC operations.
- Create dozens of PVCs and load them with thousands of files. Delete all PVCs at once, follow up on garbage collection process

### Why make this change?

- Improved traceability and debugging with OpenTelemetry spans and enriched logging.
- Increased performance during directory deletions using a worker pool mechanism.
- Cleaned up code for better readability and maintainability.

