### PR TITLE
feat(CSI-227): allow host networking via configuration

### DIFF
--- a/charts/csi-wekafsplugin/templates/controllerserver-security-context-constraint.yaml
+++ b/charts/csi-wekafsplugin/templates/controllerserver-security-context-constraint.yaml
@@ -6,6 +6,9 @@ metadata:
 
 allowPrivilegedContainer: true
 allowHostDirVolumePlugin: true
+{{- if .Values.hostNetwork }}
+allowHostNetwork: true
+{{- end }}
 allowedVolumeTypes:
   - hostPath
   - secret

--- a/charts/csi-wekafsplugin/templates/controllerserver-statefulset.yaml
+++ b/charts/csi-wekafsplugin/templates/controllerserver-statefulset.yaml
@@ -52,6 +52,10 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: csi-provisioner
+          {{- if and .Values.hostNetwork (.Capabilities.APIVersions.Has "security.openshift.io/v1/SecurityContextConstraints") }}
+          securityContext:
+              privileged: true
+          {{- end }}
           image: {{ required "csi provisioner sidecar container image." .Values.images.provisionersidecar }}
           args:
             - "--v={{ .Values.logLevel | default 5 }}"
@@ -85,6 +89,10 @@ spec:
               name: pr-metrics
               protocol: TCP
         - name: csi-resizer
+          {{- if and .Values.hostNetwork (.Capabilities.APIVersions.Has "security.openshift.io/v1/SecurityContextConstraints") }}
+          securityContext:
+            privileged: true
+          {{- end }}
           image: {{ required "csi attacher sidercar image." .Values.images.resizersidecar }}
           args:
             - "--v={{ .Values.logLevel | default 5 }}"
@@ -116,6 +124,10 @@ spec:
               name: rs-metrics
               protocol: TCP
         - name: csi-snapshotter
+          {{- if and .Values.hostNetwork (.Capabilities.APIVersions.Has "security.openshift.io/v1/SecurityContextConstraints") }}
+          securityContext:
+            privileged: true
+          {{- end }}
           image: {{ required "csi snapshotter sidecar image." .Values.images.snapshottersidecar }}
           args:
             - "--v=5"

--- a/charts/csi-wekafsplugin/templates/controllerserver-statefulset.yaml
+++ b/charts/csi-wekafsplugin/templates/controllerserver-statefulset.yaml
@@ -30,6 +30,9 @@ spec:
       nodeSelector: {{ toYaml .Values.nodeSelector | nindent 8}}
       {{- end }}
       serviceAccountName: {{ .Release.Name }}-controller
+      {{- if .Values.hostNetwork }}
+      hostNetwork: {{ .Values.hostNetwork }}
+      {{- end }}
       containers:
         - name: csi-attacher
           image: {{ required "csi attacher sidercar image." .Values.images.attachersidecar }}

--- a/charts/csi-wekafsplugin/templates/nodeserver-daemonset.yaml
+++ b/charts/csi-wekafsplugin/templates/nodeserver-daemonset.yaml
@@ -39,6 +39,9 @@ spec:
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName }}
       {{- end }}
+      {{- if .Values.hostNetwork }}
+      hostNetwork: {{ .Values.hostNetwork }}
+      {{- end }}
       initContainers:
         - name: init
           volumeMounts:
@@ -104,7 +107,7 @@ spec:
             - "--concurrency.nodeUnpublishVolume={{ .Values.node.concurrency.nodeUnpublishVolume | default "1" }}"
           {{- end }}
           ports:
-            - containerPort: 9898
+            - containerPort: 9899
               name: healthz
               protocol: TCP
           {{- if .Values.metrics.enabled }}
@@ -171,7 +174,7 @@ spec:
             - name: ADDRESS
               value: unix:///csi/csi.sock
             - name: HEALTH_PORT
-              value: "9898"
+              value: "9899"
 
         - name: csi-registrar
           image: {{ required "Provide the csi node registrar sidecar container image." .Values.images.registrarsidecar }}

--- a/charts/csi-wekafsplugin/templates/nodeserver-security-context-constraint.yaml
+++ b/charts/csi-wekafsplugin/templates/nodeserver-security-context-constraint.yaml
@@ -6,6 +6,9 @@ metadata:
 
 allowPrivilegedContainer: true
 allowHostDirVolumePlugin: true
+{{- if .Values.hostNetwork }}
+allowHostNetwork: true
+{{- end }}
 allowedVolumeTypes:
   - hostPath
   - secret

--- a/charts/csi-wekafsplugin/values.yaml
+++ b/charts/csi-wekafsplugin/values.yaml
@@ -107,6 +107,8 @@ metrics:
 # -- Tracing URL (For Jaeger tracing engine / OpenTelemetry), optional
 # @ignore
 tracingUrl: ""
+# -- Set to true to use host networking
+hostNetwork: false
 pluginConfig:
   # -- CSI Driver support for fsGroupPolicy, may be either "File" or "None". Default is "File"
   # -- WARNING: Changing this value might require uninstall and re-install of the plugin


### PR DESCRIPTION
### TL;DR

This pull request introduces a conditional configuration to enable `hostNetwork` support for the `csi-wekafsplugin` Helm chart. The changes involve adding conditional checks in the templates to apply the `hostNetwork` settings based on the values provided.

### What changed?

- Added conditional statements to `controllerserver-statefulset.yaml` and `nodeserver-daemonset.yaml` to apply `hostNetwork` settings.
- Updated security context constraints templates to allow host networking when the `hostNetwork` value is true.
- Modified port numbers in the `nodeserver-daemonset.yaml` to accommodate the `hostNetwork` setup.

### How to test?

1. Set `hostNetwork: true` in the `values.yaml` file.
2. Deploy the Helm chart.
3. Verify that the necessary resources are deployed with the `hostNetwork` configuration.

### Why make this change?

This change is motivated by the need to support host networking for specific environments where pod networking might be insufficient or problematic, such as Weka clusters running on top of Kubernetes. Allowing conditional `hostNetwork` configuration provides greater flexibility and control over the networking setup of the CSI driver components.

