### PR TITLE
chore(deps): allow WEKAPP tickets in lint

### DIFF
--- a/.github/workflows/lint_pr.yaml
+++ b/.github/workflows/lint_pr.yaml
@@ -46,6 +46,7 @@ jobs:
           scopes: |
             deps
             CSI-\d+
+            WEKAPP-\d+
           # Configure that a scope must always be provided.
           requireScope: true
           # Configure which scopes are disallowed in PR titles (newline-delimited).


### PR DESCRIPTION
### TL;DR
This change introduces an additional scope 'WEKAPP-\d+' to the PR title linting configuration in our GitHub workflow. This ensures that PR titles can include the WEKAPP identifier.

### What changed?
- Updated the lint_pr.yaml file to recognize and accept 'WEKAPP-\d+' as a valid scope in PR titles.

### How to test?
- Create a PR with 'WEKAPP-xxx' in the title and verify that the linting workflow does not flag it as invalid.

### Why make this change?
This update is necessary to allow PRs that include WEKAPP identifiers in their title, facilitating better tracking and categorization of tasks related to the WEKAPP project.

---

