### PR TITLE
chore(deps): put installation slack link in code block

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -166,5 +166,5 @@ jobs:
           SLACK_USERNAME: csiBot
           SLACK_ICON_EMOJI: ":robot_face:"
           SLACK_TITLE: "New build was pushed"
-          SLACK_MESSAGE: "helm upgrade csi-wekafs -n csi-wekafs --create-namespace -i  ${{ steps.helm-s3-upload.outputs.link }} --set logLevel=6"
-          SLACK_FOOTER: ""
+          SLACK_MESSAGE: "```helm upgrade csi-wekafs -n csi-wekafs --create-namespace -i  ${{ steps.helm-s3-upload.outputs.link }} --set logLevel=6```"
+          SLACK_FOOTER: "Package path: ${{ steps.helm-s3-upload.outputs.link }}"


### PR DESCRIPTION
### TL;DR

Updated the Slack notification message in the GitHub workflow to format the `helm upgrade` command as a code block and to include the package path in the footer.

### What changed?

- Changed `SLACK_MESSAGE` to format the `helm upgrade` command as a code block.
- Updated `SLACK_FOOTER` to include the package path.

### How to test?

Trigger a workflow run and verify the Slack notification format and content.

### Why make this change?

Improving readability and context of Slack notifications.

---

