### PR TITLE
fix(CSI-236): for OCP installations, only 1 machineConfigPolicy was created

### DIFF
--- a/charts/csi-wekafsplugin/templates/selinux-policy-machineconfig.yaml
+++ b/charts/csi-wekafsplugin/templates/selinux-policy-machineconfig.yaml
@@ -1,5 +1,5 @@
 {{- if .Capabilities.APIVersions.Has "security.openshift.io/v1/SecurityContextConstraints" }}
-{{ range  .Values.machineConfigLabels }}
+{{- range .Values.machineConfigLabels }}
 kind: MachineConfig
 apiVersion: machineconfiguration.openshift.io/v1
 metadata:
@@ -34,5 +34,6 @@ spec:
             WantedBy=multi-user.target
           name: csi-wekafs-selinux-policy.service
           enabled: true
+---
 {{- end }}
 {{- end }}


### PR DESCRIPTION
### TL;DR

Fixed missing divider between YAML documents when created in loop, causing only last document to be applied.
### What changed?

Added the missing separator

### How to test?

ONLY on OpenShift cluster:
Ensure that when multiple machineConfigLabels are specified in values.yaml, a `50-csi-wekafs-selinux-policy-{label}` is created for each label

