### PR TITLE
fix(CSI-241): disregard sync_on_close in mountmap per FS

### DIFF
--- a/pkg/wekafs/mountoptions.go
+++ b/pkg/wekafs/mountoptions.go
@@ -145,6 +145,16 @@ func (opts MountOptions) Hash() uint32 {
 	return h.Sum32()
 }
 
+func (opts MountOptions) AsMapKey() string {
+	ret := opts
+	// TODO: if adding any other version-agnostic options, add them here
+	excludedOpts := []string{MountOptionSyncOnClose}
+	for _, o := range excludedOpts {
+		ret = ret.RemoveOption(o)
+	}
+	return ret.String()
+}
+
 func (opts MountOptions) setSelinux(selinuxSupport bool) {
 	if selinuxSupport {
 		o := newMountOptionFromString(fmt.Sprintf("fscontext=\"system_u:object_r:%s_t:s0\"", selinuxContext))


### PR DESCRIPTION
### TL;DR

Introduced a new `AsMapKey()` method for `MountOptions` to create version-agnostic map keys.

### What changed?

- Added a new `AsMapKey()` method to the `MountOptions` struct in `mountoptions.go`.
- This method creates a version of the mount options that excludes certain options (currently only `MountOptionSyncOnClose`) to be used as a map key.
- Updated `mounter.go` to use `AsMapKey()` instead of `String()` when accessing or modifying the `mountMap`.

### How to test?
Covered by unit testing

### Why make this change?

This change allows for more consistent handling of mount options across different versions of the Weka cluster / client. By excluding version-specific options like `MountOptionSyncOnClose` from the map key, we can avoid unnecessary duplication of mounts and ensure that mounts with the same essential options are treated as identical, regardless of version-specific differences.

---

