### PR TITLE
fix(CSI-243): service accounts for CSI plugin assume ImagePullSecret and cause error messages.

### DIFF
--- a/charts/csi-wekafsplugin/templates/controllerserver-serviceaccount.yaml
+++ b/charts/csi-wekafsplugin/templates/controllerserver-serviceaccount.yaml
@@ -1,7 +1,9 @@
 apiVersion: v1
 kind: ServiceAccount
+{{- if .Values.imagePullSecret}}
 imagePullSecrets:
-  - name: {{ .Release.Name }}-creds
+  - name: {{ .Values.imagePullSecret }}
+{{- end }}
 metadata:
   name: {{ .Release.Name }}-controller
   namespace: {{ .Release.Namespace }}

--- a/charts/csi-wekafsplugin/templates/nodeserver-serviceaccount.yaml
+++ b/charts/csi-wekafsplugin/templates/nodeserver-serviceaccount.yaml
@@ -1,7 +1,9 @@
 apiVersion: v1
 kind: ServiceAccount
+{{- if .Values.imagePullSecret}}
 imagePullSecrets:
-  - name: {{ .Release.Name }}-creds
+  - name: {{ .Values.imagePullSecret }}
+{{- end }}
 metadata:
   name: {{ .Release.Name }}-node
   namespace: {{ .Release.Namespace }}

--- a/charts/csi-wekafsplugin/values.yaml
+++ b/charts/csi-wekafsplugin/values.yaml
@@ -25,6 +25,10 @@ images:
   csidriver: quay.io/weka.io/csi-wekafs
   # -- CSI driver tag
   csidriverTag: *csiDriverVersion
+# -- image pull secret required for image download. Must have permissions to access all images above.
+#    Should be used in case of private registry that requires authentication
+imagePullSecret: ""
+
 # -- Tolerations for all CSI driver components
 globalPluginTolerations: &globalPluginTolerations
   - key: node-role.kubernetes.io/master


### PR DESCRIPTION
### TL;DR

Updated image pull secret configuration for CSI WekaFS plugin

### What changed?

- Modified `controllerserver-serviceaccount.yaml` and `nodeserver-serviceaccount.yaml` to use a configurable image pull secret
- Added `imagePullSecret` parameter in `values.yaml` to specify the name of the image pull secret
- Wrapped image pull secret configuration in conditional statements to only apply when specified

### How to test?

1. Deploy the chart with `imagePullSecret` set to an existing secret name
2. Verify that the controller and node service accounts are created with the specified image pull secret
3. Deploy the chart without setting `imagePullSecret`
4. Confirm that no image pull secret is added to the service accounts

### Why make this change?

This change allows users to specify a custom image pull secret for private registries that require authentication. It provides more flexibility in deployment scenarios where images are stored in private repositories, while maintaining backwards compatibility for deployments that don't require image pull secrets.

In most cases, since CSI plugin components reside in public repository, this will help to avoid "Could not fetch some secrets" errors in Kubernetes

---

