### PR TITLE
chore(deps): combine chmod with ADD in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,8 +25,7 @@ RUN CGO_ENABLED=0 GOOS="linux" GOARCH="amd64" go build -a -ldflags '-X main.vers
 FROM alpine:3.18
 LABEL maintainers="WekaIO, LTD"
 LABEL description="Weka CSI Driver"
-ADD https://github.com/tigrawap/locar/releases/download/0.4.0/locar_linux_amd64 /locar
-RUN chmod +x /locar
+ADD --chmod=777 https://github.com/tigrawap/locar/releases/download/0.4.0/locar_linux_amd64 /locar
 RUN apk add --no-cache util-linux libselinux libselinux-utils util-linux  \
     pciutils usbutils coreutils binutils findutils  \
     grep bash nfs-utils rpcbind ca-certificates

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22-alpine as go-builder
+FROM golang:1.22-alpine AS go-builder
 # https://stackoverflow.com/questions/36279253/go-compiled-binary-wont-run-in-an-alpine-docker-container-on-ubuntu-host
 RUN apk add --no-cache libc6-compat gcc musl-dev
 COPY go.mod /src/go.mod


### PR DESCRIPTION
### TL;DR

Optimized Dockerfile for Weka CSI Driver

### What changed?

- Updated the `FROM` statement syntax for the go-builder stage
- Simplified the `locar` binary addition using a single `ADD` command with chmod
- Removed separate `RUN chmod` command for `locar`

### How to test?

1. Build the Docker image using the updated Dockerfile
2. Verify that the image builds successfully without errors
3. Run a container from the built image and ensure all components, especially the `locar` binary, are present and executable

### Why make this change?

- Improves Dockerfile readability and maintainability
- Reduces the number of layers in the final image by combining commands
- Ensures consistent permissions for the `locar` binary using a single `ADD` command

---

chore(deps): combine chmod with ADD in Dockerfile

chore(deps): fix Dockerfile warning for FROM as