### PR TITLE
feat(CSI-244): match subnets if existing in client rule

### DIFF
--- a/pkg/wekafs/apiclient/nfs.go
+++ b/pkg/wekafs/apiclient/nfs.go
@@ -495,6 +495,15 @@ func (r *NfsClientGroupRule) EQ(other ApiObject) bool {
 	return ObjectsAreEqual(r, other)
 }
 
+func (r *NfsClientGroupRule) IsSupersetOf(other *NfsClientGroupRule) bool {
+	if r.IsIPRule() && other.IsIPRule() {
+		n1 := r.GetNetwork()
+		n2 := other.GetNetwork()
+		return n1.ContainsIPAddress(n2.IP.String())
+	}
+	return false
+}
+
 func (r *NfsClientGroupRule) getImmutableFields() []string {
 	return []string{"Rule"}
 }
@@ -565,6 +574,9 @@ func (a *ApiClient) FindNfsClientGroupRulesByFilter(ctx context.Context, query *
 
 	for _, r := range ret {
 		if r.EQ(query) {
+			*resultSet = append(*resultSet, r)
+		} else if r.IsSupersetOf(query) {
+			// if we have a rule that covers the IP address by bigger network segment, also add it
 			*resultSet = append(*resultSet, r)
 		}
 	}

--- a/pkg/wekafs/apiclient/nfs_test.go
+++ b/pkg/wekafs/apiclient/nfs_test.go
@@ -312,3 +312,33 @@ func TestInterfaceGroup(t *testing.T) {
 	//	}
 	//}
 }
+
+func TestIsSupersetOf(t *testing.T) {
+	// Test case 1: IP rule superset
+	rule1 := &NfsClientGroupRule{
+		Type: NfsClientGroupRuleTypeIP,
+		Rule: "192.168.1.0/24",
+	}
+	rule2 := &NfsClientGroupRule{
+		Type: NfsClientGroupRuleTypeIP,
+		Rule: "192.168.1.1",
+	}
+	assert.True(t, rule1.IsSupersetOf(rule2))
+
+	// Test case 2: IP rule not superset
+	rule3 := &NfsClientGroupRule{
+		Type: NfsClientGroupRuleTypeIP,
+		Rule: "192.168.2.0/24",
+	}
+	assert.False(t, rule1.IsSupersetOf(rule3))
+
+	// Test case 3: Non-IP rule
+	rule4 := &NfsClientGroupRule{
+		Type: NfsClientGroupRuleTypeDNS,
+		Rule: "example.com",
+	}
+	assert.False(t, rule1.IsSupersetOf(rule4))
+
+	// Test case 4: Same rule
+	assert.True(t, rule1.IsSupersetOf(rule1))
+}


### PR DESCRIPTION
### TL;DR

Improved NFS client group rule matching to include superset IP networks.

### What changed?

- Added `IsSupersetOf` method to `NfsClientGroupRule` to check if a rule covers a larger IP range.
- Updated `FindNfsClientGroupRulesByFilter` to include rules that are supersets of the query.
- Implemented `GetMaskBits` method for `Network` to calculate CIDR notation.
- Enhanced `ContainsIPAddress` method to handle cases where CIDR parsing fails.
- Added unit tests for the new `IsSupersetOf` functionality.

### How to test?

1. Run the new unit tests in `nfs_test.go`.
2. Test the `FindNfsClientGroupRulesByFilter` function with various IP ranges and ensure it returns both exact matches and superset rules.
3. Verify that the `ContainsIPAddress` method correctly identifies IP addresses within a given network range.

### Why make this change?

This change improves the flexibility and accuracy of NFS client group rule matching. By including superset IP networks, the system can now identify and apply rules that cover a broader range of IP addresses, enhancing the overall functionality of the NFS access control system.

When having an extremely large Kubernetes clusters, adding node IP addresses to client group could harm the rule matching performance or hit limits on max. number of rules. This allows using a subnet addresses (those should be configured by administrator)

---

