### PR TITLE
feat(CSI-245): allow specifying client group for NFS

### DIFF
--- a/charts/csi-wekafsplugin/templates/controllerserver-statefulset.yaml
+++ b/charts/csi-wekafsplugin/templates/controllerserver-statefulset.yaml
@@ -224,6 +224,9 @@ spec:
           {{- if .Values.pluginConfig.mountProtocol.interfaceGroupName }}
             - "--interfacegroupname={{ .Values.pluginConfig.mountProtocol.interfaceGroupName }}"
           {{- end }}
+          {{- if .Values.pluginConfig.mountProtocol.clientGroupName }}
+            - "--clientgroupname={{ .Values.pluginConfig.mountProtocol.clientGroupName }}"
+          {{- end }}
           ports:
             - containerPort: 9898
               name: healthz

--- a/charts/csi-wekafsplugin/templates/nodeserver-daemonset.yaml
+++ b/charts/csi-wekafsplugin/templates/nodeserver-daemonset.yaml
@@ -115,6 +115,9 @@ spec:
           {{- if .Values.pluginConfig.mountProtocol.interfaceGroupName }}
             - "--interfacegroupname={{ .Values.pluginConfig.mountProtocol.interfaceGroupName }}"
           {{- end }}
+          {{- if .Values.pluginConfig.mountProtocol.clientGroupName }}
+            - "--clientgroupname={{ .Values.pluginConfig.mountProtocol.clientGroupName }}"
+          {{- end }}
           ports:
             - containerPort: 9899
               name: healthz

--- a/charts/csi-wekafsplugin/values.yaml
+++ b/charts/csi-wekafsplugin/values.yaml
@@ -152,3 +152,5 @@ pluginConfig:
     allowNfsFailback: false
     # -- Specify name of NFS interface group to use for mounting Weka filesystems. If not set, first NFS interface group will be used
     interfaceGroupName: ""
+    # -- Specify existing client group name for NFS configuration. If not set, "WekaCSIPluginClients" group will be created
+    clientGroupName: ""

--- a/cmd/wekafsplugin/main.go
+++ b/cmd/wekafsplugin/main.go
@@ -94,6 +94,7 @@ var (
 	allowNfsFailback                     = flag.Bool("allownfsfailback", false, "Allow NFS failback")
 	useNfs                               = flag.Bool("usenfs", false, "Use NFS for mounting volumes")
 	interfaceGroupName                   = flag.String("interfacegroupname", "", "Name of the NFS interface group to use for mounting volumes")
+	clientGroupName                      = flag.String("clientgroupname", "", "Name of the NFS client group to use for managing NFS permissions")
 	// Set by the build process
 	version = ""
 )
@@ -223,6 +224,7 @@ func handle() {
 		*allowNfsFailback,
 		*useNfs,
 		*interfaceGroupName,
+		*clientGroupName,
 	)
 	driver, err := wekafs.NewWekaFsDriver(
 		*driverName, *nodeID, *endpoint, *maxVolumesPerNode, version, *debugPath, csiMode, *selinuxSupport, config)

--- a/pkg/wekafs/apiclient/nfs_test.go
+++ b/pkg/wekafs/apiclient/nfs_test.go
@@ -203,14 +203,14 @@ func TestNfsClientGroup(t *testing.T) {
 
 func TestEnsureCsiPluginNfsClientGroup(t *testing.T) {
 	apiClient := GetApiClientForTest(t)
-	result, err := apiClient.EnsureCsiPluginNfsClientGroup(context.Background())
+	result, err := apiClient.EnsureCsiPluginNfsClientGroup(context.Background(), NfsClientGroupName)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestNfsClientGroupRules(t *testing.T) {
 	apiClient := GetApiClientForTest(t)
-	cg, err := apiClient.EnsureCsiPluginNfsClientGroup(context.Background())
+	cg, err := apiClient.EnsureCsiPluginNfsClientGroup(context.Background(), NfsClientGroupName)
 	assert.NoError(t, err)
 	assert.NotNil(t, cg)
 
@@ -236,7 +236,7 @@ outerLoop:
 		assert.NoError(t, err)
 	}
 	rules := &[]NfsClientGroupRule{}
-	err = apiClient.GetNfsClientGroupRules(context.Background(), rules)
+	err = apiClient.GetNfsClientGroupRules(context.Background(), NfsClientGroupName, rules)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, rules)
 	for _, rule := range *rules {
@@ -251,7 +251,7 @@ func TestNfsEnsureNfsPermissions(t *testing.T) {
 	apiClient := GetApiClientForTest(t)
 
 	// Test EnsureNfsPermission
-	err := apiClient.EnsureNfsPermissions(context.Background(), "172.16.5.147", "default")
+	err := apiClient.EnsureNfsPermissions(context.Background(), "172.16.5.147", "default", NfsClientGroupName)
 	assert.NoError(t, err)
 }
 

--- a/pkg/wekafs/driverconfig.go
+++ b/pkg/wekafs/driverconfig.go
@@ -35,14 +35,11 @@ type DriverConfig struct {
 	allowProtocolContainers       bool
 	allowNfsFailback              bool
 	useNfs                        bool
-	interfaceGroupName            *string
+	interfaceGroupName            string
+	clientGroupName               string
 }
 
 func (dc *DriverConfig) Log() {
-	igName := "<<default>>"
-	if dc.interfaceGroupName != nil {
-		igName = *dc.interfaceGroupName
-	}
 	log.Info().Str("dynamic_vol_path", dc.DynamicVolPath).
 		Str("volume_prefix", dc.VolumePrefix).Str("snapshot_prefix", dc.SnapshotPrefix).Str("seed_snapshot_prefix", dc.SnapshotPrefix).
 		Bool("allow_auto_fs_creation", dc.allowAutoFsCreation).Bool("allow_auto_fs_expansion", dc.allowAutoFsExpansion).
@@ -60,7 +57,8 @@ func (dc *DriverConfig) Log() {
 		Bool("allow_protocol_containers", dc.allowProtocolContainers).
 		Bool("allow_nfs_failback", dc.allowNfsFailback).
 		Bool("use_nfs", dc.useNfs).
-		Str("interface_group_name", igName).
+		Str("interface_group_name", dc.interfaceGroupName).
+		Str("client_group_name", dc.clientGroupName).
 		Msg("Starting driver with the following configuration")
 
 }
@@ -72,7 +70,7 @@ func NewDriverConfig(dynamicVolPath, VolumePrefix, SnapshotPrefix, SeedSnapshotP
 	grpcRequestTimeoutSeconds int,
 	allowProtocolContainers bool,
 	allowNfsFailback, useNfs bool,
-	interfaceGroupName string,
+	interfaceGroupName, clientGroupName string,
 ) *DriverConfig {
 
 	var MutuallyExclusiveMountOptions []mutuallyExclusiveMountOptionSet
@@ -95,11 +93,6 @@ func NewDriverConfig(dynamicVolPath, VolumePrefix, SnapshotPrefix, SeedSnapshotP
 	concurrency["NodePublishVolume"] = maxNodePublishVolumeReqs
 	concurrency["NodeUnpublishVolume"] = maxNodeUnpublishVolumeReqs
 
-	igName := &[]string{interfaceGroupName}[0]
-	if interfaceGroupName == "" {
-		igName = nil
-	}
-
 	return &DriverConfig{
 		DynamicVolPath:                dynamicVolPath,
 		VolumePrefix:                  VolumePrefix,
@@ -119,7 +112,8 @@ func NewDriverConfig(dynamicVolPath, VolumePrefix, SnapshotPrefix, SeedSnapshotP
 		allowProtocolContainers:       allowProtocolContainers,
 		allowNfsFailback:              allowNfsFailback,
 		useNfs:                        useNfs,
-		interfaceGroupName:            igName,
+		interfaceGroupName:            interfaceGroupName,
+		clientGroupName:               clientGroupName,
 	}
 }
 

--- a/pkg/wekafs/nfsmount.go
+++ b/pkg/wekafs/nfsmount.go
@@ -25,6 +25,7 @@ type nfsMount struct {
 	lastUsed           time.Time
 	mountIpAddress     string
 	interfaceGroupName *string
+	clientGroupName    string
 }
 
 func (m *nfsMount) getMountPoint() string {
@@ -131,7 +132,7 @@ func (m *nfsMount) doMount(ctx context.Context, apiClient *apiclient.ApiClient, 
 		}
 
 		nodeIP := apiclient.GetNodeIpAddress()
-		if apiClient.EnsureNfsPermissions(ctx, nodeIP, m.fsName) != nil {
+		if apiClient.EnsureNfsPermissions(ctx, nodeIP, m.fsName, m.clientGroupName) != nil {
 			logger.Error().Msg("Failed to ensure NFS permissions")
 			return errors.New("failed to ensure NFS permissions")
 		}

--- a/pkg/wekafs/nfsmounter.go
+++ b/pkg/wekafs/nfsmounter.go
@@ -17,6 +17,7 @@ type nfsMounter struct {
 	selinuxSupport     *bool
 	gc                 *innerPathVolGc
 	interfaceGroupName *string
+	clientGroupName    string
 }
 
 func (m *nfsMounter) getGarbageCollector() *innerPathVolGc {
@@ -32,7 +33,8 @@ func newNfsMounter(driver *WekaFsDriver) *nfsMounter {
 	mounter := &nfsMounter{mountMap: mountsMap{}, debugPath: driver.debugPath, selinuxSupport: selinuxSupport}
 	mounter.gc = initInnerPathVolumeGc(mounter)
 	mounter.schedulePeriodicMountGc()
-	mounter.interfaceGroupName = driver.config.interfaceGroupName
+	mounter.interfaceGroupName = &driver.config.interfaceGroupName
+	mounter.clientGroupName = driver.config.clientGroupName
 
 	return mounter
 }
@@ -54,6 +56,7 @@ func (m *nfsMounter) NewMount(fsName string, options MountOptions) AnyMount {
 			mountPoint:         "/run/weka-fs-mounts/" + getAsciiPart(fsName, 64) + "-" + uniqueId,
 			mountOptions:       options,
 			interfaceGroupName: m.interfaceGroupName,
+			clientGroupName:    m.clientGroupName,
 		}
 		m.mountMap[fsName][options.String()] = wMount
 	}


### PR DESCRIPTION
### TL;DR

Added support for specifying a custom NFS client group name in the WekaFS CSI plugin.

### What changed?

- Introduced a new `clientGroupName` parameter in the plugin configuration.
- Updated the controller and node server templates to include the new `clientGroupName` parameter.
- Modified the `EnsureCsiPluginNfsClientGroup` function to use the specified client group name or default to "WekaCSIPluginClients".
- Updated related functions to pass and use the `clientGroupName` parameter.

### How to test?

1. Deploy the WekaFS CSI plugin with a custom client group name:
   ```yaml
   pluginConfig:
     mountProtocol:
       clientGroupName: "CustomNFSClientGroup"
   ```
2. Create a PersistentVolumeClaim and a Pod that uses it.
3. Verify that the NFS client group with the specified name is created and used for managing NFS permissions.
4. Check if the volume is successfully mounted and accessible in the Pod.

### Why make this change?

This change allows users to specify an existing NFS client group or create a custom one for the WekaFS CSI plugin. It provides more flexibility in NFS configuration and permissions management, especially in environments where specific naming conventions or pre-existing client groups need to be used.

---

