### PR TITLE
feat(CSI-252): implement kubelet PVC stats

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-version v1.7.0
 	github.com/kubernetes-csi/csi-lib-utils v0.19.0
+	github.com/pkg/errors v0.9.1
 	github.com/pkg/xattr v0.4.10
 	github.com/prometheus/client_golang v1.20.2
 	github.com/rs/zerolog v1.33.0

--- a/go.sum
+++ b/go.sum
@@ -54,6 +54,7 @@ github.com/opencontainers/runc v1.1.13 h1:98S2srgG9vw0zWcDpFMn5TRrh8kLxa/5OFUstu
 github.com/opencontainers/runc v1.1.13/go.mod h1:R016aXacfp/gwQBYw2FDGa9m+n6atbLWrYY8hNMT/sA=
 github.com/opencontainers/runtime-spec v1.2.0 h1:z97+pHb3uELt/yiAWD691HNHQIF07bE7dzrbT927iTk=
 github.com/opencontainers/runtime-spec v1.2.0/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/xattr v0.4.10 h1:Qe0mtiNFHQZ296vRgUjRCoPHPqH7VdTOrZx3g0T+pGA=
 github.com/pkg/xattr v0.4.10/go.mod h1:di8WF84zAKk8jzR1UBTEWh9AUlIZZ7M/JNt8e9B6ktU=


### PR DESCRIPTION
### TL;DR

Implemented NodeGetVolumeStats functionality and added new node service capabilities.

### What changed?

- Implemented `NodeGetVolumeStats` method in the `NodeServer` struct.
- Added `getVolumeStats` helper function to fetch filesystem statistics.
- Updated `NewNodeServer` to include new node service capabilities:
  - SINGLE_NODE_MULTI_WRITER
  - GET_VOLUME_STATS
  - VOLUME_CONDITION

### How to test?

1. Mount a Weka volume to a node.
2. Call the `NodeGetVolumeStats` method with the volume ID and path.
3. Verify that the method returns correct capacity, used, and available bytes.
4. Test error cases by providing invalid volume IDs or non-existent paths.
5. Verify that the new node service capabilities are reported correctly.

### Why make this change?

This change enhances the CSI driver's functionality by implementing volume statistics retrieval. It allows Kubernetes to query volume usage information, which is crucial for monitoring and managing storage resources. The added node service capabilities also improve the driver's feature set, making it more compliant with CSI specifications and providing better support for various storage operations.

Following this improvement, the following metrics become available for Weka CSI volumes:

```
kubelet_volume_stats_capacity_bytes
kubelet_volume_stats_available_bytes
kubelet_volume_stats_used_bytes
kubelet_volume_stats_inodes
kubelet_volume_stats_inodes_free
kubelet_volume_stats_inodes_used
```

---

