### PR TITLE
feat(CSI-253): support custom CA certificate in API secret

### DIFF
--- a/examples/common/csi-wekafs-api-secret.yaml
+++ b/examples/common/csi-wekafs-api-secret.yaml
@@ -15,7 +15,7 @@ data:
   # It is recommended to configure at least 2 management endpoints (cluster backend nodes), or a load-balancer if used
   # e.g. 172.31.15.113:14000,172.31.12.91:14000
   endpoints: MTcyLjMxLjQxLjU0OjE0MDAwLDE3Mi4zMS40Ny4xNTI6MTQwMDAsMTcyLjMxLjM4LjI1MDoxNDAwMCwxNzIuMzEuNDcuMTU1OjE0MDAwLDE3Mi4zMS4zMy45MToxNDAwMCwxNzIuMzEuMzguMTU1OjE0MDAwCg==
-  # protocol to use for API connection (may be either http or https, base64-encoded)
+  # protocol to use for API connection (may be either http or https, base64-encoded. NOTE: since Weka 4.3.0, HTTPS is mandatory)
   scheme: aHR0cA==
   # for multiple clusters setup, set specific container name rather than attempt to identify it automatically
   localContainerName: ""
@@ -24,3 +24,7 @@ data:
   # maybe either (true/false), base64-encoded
   # NOTE: if a load balancer is used to access the cluster API, leave this setting as "false"
   autoUpdateEndpoints: ZmFsc2U=
+  # When using HTTPS connection and self-signed or untrusted certificates, provide a CA certificate in PEM format, base64-encoded
+  # caCertificate: <base64-encoded-PEM>
+  caCertificate: ""
+

--- a/pkg/wekafs/wekafs.go
+++ b/pkg/wekafs/wekafs.go
@@ -110,6 +110,10 @@ func (api *ApiStore) fromSecrets(ctx context.Context, secrets map[string]string,
 	if ok {
 		autoUpdateEndpoints = strings.TrimSpace(strings.TrimSuffix(autoUpdateEndpointsStr, "\n")) == "true"
 	}
+	caCertificate, ok := secrets["caCertificate"]
+	if !ok {
+		caCertificate = ""
+	}
 
 	credentials := apiclient.Credentials{
 		Username:            strings.TrimSpace(strings.TrimSuffix(secrets["username"], "\n")),
@@ -119,6 +123,7 @@ func (api *ApiStore) fromSecrets(ctx context.Context, secrets map[string]string,
 		HttpScheme:          strings.TrimSpace(strings.TrimSuffix(secrets["scheme"], "\n")),
 		LocalContainerName:  localContainerName,
 		AutoUpdateEndpoints: autoUpdateEndpoints,
+		CaCertificate:       caCertificate,
 	}
 	return api.fromCredentials(ctx, credentials, hostname)
 }


### PR DESCRIPTION
### TL;DR

Added support for custom CA certificates in WekaFS CSI driver API client.

### What changed?

- Updated `csi-wekafs-api-secret.yaml` to include a new `caCertificate` field for HTTPS connections with self-signed or untrusted certificates.
- Modified `apiclient.go` to handle custom CA certificates when creating a new API client.
- Updated `wekafs.go` to parse the `caCertificate` from secrets and include it in the credentials.

### How to test?

1. Update the `csi-wekafs-api-secret.yaml` file with a base64-encoded PEM format CA certificate in the `caCertificate` field.
2. Deploy the updated secret to your Kubernetes cluster.
3. Verify that the WekaFS CSI driver can successfully connect to the Weka cluster using HTTPS with the custom CA certificate.

> **NOTE**: for this to be tested, we still need the certificate to match endpoint names. IIRC, the certificate that is generated automatically does not have hostnames / IP address SANs.

### Why make this change?

This change enhances security by allowing users to use custom CA certificates when connecting to Weka clusters, especially when using self-signed or untrusted certificates. It also prepares for the mandatory HTTPS requirement in Weka 4.3.0 and later versions.

---

