### PR TITLE
chore(deps): update sidecar versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ https://github.com/weka/csi-wekafs
 | WekaIO, Inc. | <csi@weka.io> | <https://weka.io> |
 
 ## Pre-requisite
-- Kubernetes cluster of version 1.18 or later. Although older versions from 1.13 and up should work, they were not tested
+- Kubernetes cluster of version 1.20 or later is recommended. Minimum version is 1.17
 - Access to terminal with `kubectl` installed
 - Weka system pre-configured and Weka client installed and registered in cluster for each Kubernetes node
 

--- a/README.md.gotmpl
+++ b/README.md.gotmpl
@@ -11,7 +11,7 @@
 {{ template "chart.maintainersSection" . }}
 
 ## Pre-requisite
-- Kubernetes cluster of version 1.18 or later. Although older versions from 1.13 and up should work, they were not tested
+- Kubernetes cluster of version 1.20 or later is recommended. Minimum version is 1.17
 - Access to terminal with `kubectl` installed
 - Weka system pre-configured and Weka client installed and registered in cluster for each Kubernetes node
 

--- a/charts/csi-wekafsplugin/values.yaml
+++ b/charts/csi-wekafsplugin/values.yaml
@@ -8,17 +8,17 @@ csiDriverName: "csi.weka.io"
 csiDriverVersion: &csiDriverVersion 2.4.2-SNAPSHOT.68.74cb32a
 images:
   # -- CSI liveness probe sidecar image URL
-  livenessprobesidecar: registry.k8s.io/sig-storage/livenessprobe:v2.12.0
+  livenessprobesidecar: registry.k8s.io/sig-storage/livenessprobe:v2.14.0
   # -- CSI attacher sidecar image URL
-  attachersidecar: registry.k8s.io/sig-storage/csi-attacher:v4.5.0
+  attachersidecar: registry.k8s.io/sig-storage/csi-attacher:v4.7.0
   # -- CSI provisioner sidecar image URL
-  provisionersidecar: registry.k8s.io/sig-storage/csi-provisioner:v4.0.0
+  provisionersidecar: registry.k8s.io/sig-storage/csi-provisioner:v5.1.0
   # -- CSI registrar sidercar
-  registrarsidecar: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.10.0
+  registrarsidecar: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.12.0
   # -- CSI resizer sidecar image URL
-  resizersidecar: registry.k8s.io/sig-storage/csi-resizer:v1.9.3
+  resizersidecar: registry.k8s.io/sig-storage/csi-resizer:v1.12.0
   # -- CSI snapshotter sidecar image URL
-  snapshottersidecar: registry.k8s.io/sig-storage/csi-snapshotter:v6.3.3
+  snapshottersidecar: registry.k8s.io/sig-storage/csi-snapshotter:v8.1.0
   # -- CSI nodeinfo sidecar image URL, used for reading node metadata
   nodeinfo: quay.io/weka.io/kubectl-sidecar:v1.29.2-1
   # -- CSI driver main image URL


### PR DESCRIPTION
### TL;DR

Updated Kubernetes version requirements and CSI sidecar image versions.

### What changed?

- Updated the recommended Kubernetes cluster version to 1.20 or later, with a minimum version of 1.17.
- Upgraded CSI sidecar image versions:
  - livenessprobe: v2.12.0 -> v2.14.0
  - csi-attacher: v4.5.0 -> v4.7.0
  - csi-provisioner: v4.0.0 -> v5.1.0
  - csi-node-driver-registrar: v2.10.0 -> v2.12.0
  - csi-resizer: v1.9.3 -> v1.12.0
  - csi-snapshotter: v6.3.3 -> v8.1.0

### How to test?

1. Deploy the updated chart on a Kubernetes cluster version 1.20 or later.
2. Verify that all CSI components are running correctly with the new sidecar image versions.
3. Test basic CSI operations (e.g., volume provisioning, attaching, and mounting) to ensure compatibility.

### Why make this change?

This update ensures compatibility with newer Kubernetes versions and takes advantage of the latest features and bug fixes in the CSI sidecar components. It also provides clearer guidance on the supported Kubernetes versions for users of the CSI WekaFS plugin.

---

chore(deps): update sidecar versions

chore(deps): update minimum K8s version to 1.17