### PR TITLE
fix(CSI-256): avoid multiple mounts to same filesystem on same mountpoint

### DIFF
--- a/pkg/wekafs/interfaces.go
+++ b/pkg/wekafs/interfaces.go
@@ -28,6 +28,7 @@ type AnyMounter interface {
 
 type mountsMapPerFs map[string]AnyMount
 type mountsMap map[string]mountsMapPerFs
+type nfsMountsMap map[string]int // we only follow the mountPath and number of references
 
 type UnmountFunc func()
 

--- a/pkg/wekafs/interfaces.go
+++ b/pkg/wekafs/interfaces.go
@@ -42,4 +42,5 @@ type AnyMount interface {
 	getMountPoint() string
 	getMountOptions() MountOptions
 	getLastUsed() time.Time
+	locateMountIP() error // used only for NFS
 }

--- a/pkg/wekafs/nfsmount.go
+++ b/pkg/wekafs/nfsmount.go
@@ -63,6 +63,17 @@ func (m *nfsMount) decRef(ctx context.Context) error {
 	return nil
 }
 
+func (m *nfsMount) locateMountIP() error {
+	if m.mountIpAddress == "" {
+		ipAddr, err := GetMountIpFromActualMountPoint(m.mountPoint)
+		if err != nil {
+			return err
+		}
+		m.mountIpAddress = ipAddr
+	}
+	return nil
+}
+
 func (m *nfsMount) doUnmount(ctx context.Context) error {
 	logger := log.Ctx(ctx).With().Str("mount_point", m.getMountPoint()).Str("filesystem", m.fsName).Logger()
 	logger.Trace().Strs("mount_options", m.getMountOptions().Strings()).Msg("Performing umount via k8s native mounter")

--- a/pkg/wekafs/nfsmount.go
+++ b/pkg/wekafs/nfsmount.go
@@ -46,11 +46,11 @@ func (m *nfsMount) isInDevMode() bool {
 }
 
 func (m *nfsMount) isMounted() bool {
-	return PathExists(m.mountPoint) && PathIsWekaMount(context.Background(), m.mountPoint)
+	return PathExists(m.getMountPoint()) && PathIsWekaMount(context.Background(), m.mountPoint)
 }
 
 func (m *nfsMount) incRef(ctx context.Context, apiClient *apiclient.ApiClient) error {
-	if err := m.doMount(ctx, apiClient, m.mountOptions); err != nil {
+	if err := m.doMount(ctx, apiClient, m.getMountOptions()); err != nil {
 		return err
 	}
 	return nil
@@ -64,9 +64,9 @@ func (m *nfsMount) decRef(ctx context.Context) error {
 }
 
 func (m *nfsMount) doUnmount(ctx context.Context) error {
-	logger := log.Ctx(ctx).With().Str("mount_point", m.mountPoint).Str("filesystem", m.fsName).Logger()
-	logger.Trace().Strs("mount_options", m.mountOptions.Strings()).Msg("Performing umount via k8s native mounter")
-	err := m.kMounter.Unmount(m.mountPoint)
+	logger := log.Ctx(ctx).With().Str("mount_point", m.getMountPoint()).Str("filesystem", m.fsName).Logger()
+	logger.Trace().Strs("mount_options", m.getMountOptions().Strings()).Msg("Performing umount via k8s native mounter")
+	err := m.kMounter.Unmount(m.getMountPoint())
 	if err != nil {
 		logger.Error().Err(err).Msg("Failed to unmount")
 	} else {
@@ -87,9 +87,9 @@ func (m *nfsMount) ensureMountIpAddress(ctx context.Context, apiClient *apiclien
 }
 
 func (m *nfsMount) doMount(ctx context.Context, apiClient *apiclient.ApiClient, mountOptions MountOptions) error {
-	logger := log.Ctx(ctx).With().Str("mount_point", m.mountPoint).Str("filesystem", m.fsName).Logger()
+	logger := log.Ctx(ctx).With().Str("mount_point", m.getMountPoint()).Str("filesystem", m.fsName).Logger()
 	var mountOptionsSensitive []string
-	if err := os.MkdirAll(m.mountPoint, DefaultVolumePermissions); err != nil {
+	if err := os.MkdirAll(m.getMountPoint(), DefaultVolumePermissions); err != nil {
 		return err
 	}
 	if !m.isInDevMode() {
@@ -117,12 +117,12 @@ func (m *nfsMount) doMount(ctx context.Context, apiClient *apiclient.ApiClient, 
 
 		mountTarget := m.mountIpAddress + ":/" + m.fsName
 		logger.Trace().
-			Strs("mount_options", m.mountOptions.Strings()).
+			Strs("mount_options", m.getMountOptions().Strings()).
 			Str("mount_target", mountTarget).
 			Str("mount_ip_address", m.mountIpAddress).
 			Msg("Performing mount")
 
-		err = m.kMounter.MountSensitive(mountTarget, m.mountPoint, "nfs", mountOptions.Strings(), mountOptionsSensitive)
+		err = m.kMounter.MountSensitive(mountTarget, m.getMountPoint(), "nfs", mountOptions.Strings(), mountOptionsSensitive)
 		if err != nil {
 			if os.IsNotExist(err) {
 				logger.Error().Err(err).Msg("Mount target not found")
@@ -144,8 +144,8 @@ func (m *nfsMount) doMount(ctx context.Context, apiClient *apiclient.ApiClient, 
 		if err := os.MkdirAll(fakePath, DefaultVolumePermissions); err != nil {
 			Die(fmt.Sprintf("Failed to create directory %s, while running in debug mode", fakePath))
 		}
-		logger.Trace().Strs("mount_options", m.mountOptions.Strings()).Str("debug_path", m.debugPath).Msg("Performing mount")
+		logger.Trace().Strs("mount_options", m.getMountOptions().Strings()).Str("debug_path", m.debugPath).Msg("Performing mount")
 
-		return m.kMounter.Mount(fakePath, m.mountPoint, "", []string{"bind"})
+		return m.kMounter.Mount(fakePath, m.getMountPoint(), "", []string{"bind"})
 	}
 }

--- a/pkg/wekafs/nfsmount.go
+++ b/pkg/wekafs/nfsmount.go
@@ -26,7 +26,7 @@ type nfsMount struct {
 }
 
 func (m *nfsMount) getMountPoint() string {
-	return m.mountPoint
+	return fmt.Sprintf("%s-%s", m.mountPoint, m.mountIpAddress)
 }
 
 func (m *nfsMount) getRefCount() int {

--- a/pkg/wekafs/nfsmounter.go
+++ b/pkg/wekafs/nfsmounter.go
@@ -91,6 +91,12 @@ func (m *nfsMounter) unmountWithOptions(ctx context.Context, fsName string, opti
 	options = options.AsNfs()
 	options.Merge(options, m.exclusiveMountOptions)
 	mnt := m.NewMount(fsName, options)
+	// since we are not aware of the IP address of the mount, we need to find the mount point by listing the mounts
+	err := mnt.locateMountIP()
+	if err != nil {
+		log.Ctx(ctx).Error().Err(err).Msg("Failed to locate mount IP")
+		return err
+	}
 
 	log.Ctx(ctx).Trace().Strs("mount_options", opts.Strings()).Str("filesystem", fsName).Msg("Received an unmount request")
 	return mnt.decRef(ctx)

--- a/pkg/wekafs/utilities.go
+++ b/pkg/wekafs/utilities.go
@@ -303,6 +303,24 @@ func PathIsWekaMount(ctx context.Context, path string) bool {
 	return false
 }
 
+func GetMountIpFromActualMountPoint(mountPointBase string) (string, error) {
+	file, err := os.Open("/proc/mounts")
+	if err != nil {
+		return "", errors.New("failed to open /proc/mounts")
+	}
+	defer func() { _ = file.Close() }()
+	var actualMountPoint string
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+		if len(fields) >= 3 && strings.HasPrefix(fields[1], fmt.Sprintf("%s-", mountPointBase)) {
+			actualMountPoint = fields[1]
+			return strings.TrimLeft(actualMountPoint, mountPointBase+"-"), nil
+		}
+	}
+	return "", errors.New("mount point not found")
+}
+
 func validateVolumeId(volumeId string) error {
 	// Volume New format:
 	// VolID format is as following:

--- a/pkg/wekafs/wekafsmount.go
+++ b/pkg/wekafs/wekafsmount.go
@@ -179,3 +179,7 @@ func (m *wekafsMount) doMount(ctx context.Context, apiClient *apiclient.ApiClien
 		return m.kMounter.Mount(fakePath, m.getMountPoint(), "", []string{"bind"})
 	}
 }
+
+func (m *wekafsMount) locateMountIP() error {
+	return nil
+}


### PR DESCRIPTION
fix(CSI-256): replace all references of m.mountPoint with m.getMountPoint()

fix(CSI-256): construct mountPoint to have an IP address

fix(CSI-256): implement AnyMount.locateMountIp()

fix(CSI-256): locate actual mount IP upon unmountWithOptions

fix(CSI-256): add a simple mount refCount logic for NFS