### PR TITLE
feat(CSI-259): report mount transport in node topology

### DIFF
--- a/docs/NFS.md
+++ b/docs/NFS.md
@@ -47,6 +47,24 @@ the Weka CSI Plugin will translate them to NFS alternatives. Unknown or unsuppor
 ### QoS and Performance
 QoS is not supported for NFS transport. Performance is limited by the NFS protocol and the network configuration.
 
+### Scheduling Workloads by Transport Protocol
+Weka CSI Plugin node server populates the transport protocol in the node topology.
+This allows you to use node affinity rules to force workloads to use WekaFS transport on nodes where the Weka client is installed.
+For example, in hybrid deployments where some nodes have the Weka client installed and some do not, 
+the administrator would prefer storage-intensive workloads to run on nodes with the Weka client installed, while more generic workloads can run on other nodes.
+
+In order to force a workload to a certain transport type, a nodeSelector can be applied to the workload manifest.
+#### An example of a nodeSelector for WekaFS transport:
+```yaml
+nodeSelector:
+  topology.weka.com/transport: wekafs
+```
+#### An example of a nodeSelector for NFS transport:
+```yaml
+nodeSelector:
+  topology.weka.com/transport: nfs
+```
+
 ### Switching from NFS to WekaFS transport
 To switch between NFS and WekaFS transport, you need to:
 1. Install the Weka client on Kubernetes node

--- a/pkg/wekafs/interfaces.go
+++ b/pkg/wekafs/interfaces.go
@@ -6,6 +6,11 @@ import (
 	"time"
 )
 
+const (
+	dataTransportNfs    DataTransport = "nfs"
+	dataTransportWekafs DataTransport = "wekafs"
+)
+
 type AnyServer interface {
 	getMounter() AnyMounter
 	getApiStore() *ApiStore
@@ -24,12 +29,13 @@ type AnyMounter interface {
 	gcInactiveMounts()
 	schedulePeriodicMountGc()
 	getGarbageCollector() *innerPathVolGc
+	getTransport() DataTransport
 }
 
 type mountsMapPerFs map[string]AnyMount
 type mountsMap map[string]mountsMapPerFs
 type nfsMountsMap map[string]int // we only follow the mountPath and number of references
-
+type DataTransport string
 type UnmountFunc func()
 
 type AnyMount interface {

--- a/pkg/wekafs/nfsmounter.go
+++ b/pkg/wekafs/nfsmounter.go
@@ -162,3 +162,7 @@ func (m *nfsMounter) schedulePeriodicMountGc() {
 		}
 	}()
 }
+
+func (m *nfsMounter) getTransport() DataTransport {
+	return dataTransportNfs
+}

--- a/pkg/wekafs/nodeserver.go
+++ b/pkg/wekafs/nodeserver.go
@@ -41,6 +41,7 @@ const (
 	TopologyKeyNode                  = "topology.wekafs.csi/node"
 	TopologyLabelNode                = "topology.csi.weka.io/node"
 	TopologyLabelWeka                = "topology.csi.weka.io/global"
+	TopologyLabelTransport           = "topology.csi.weka.io/transport"
 	WekaKernelModuleName             = "wekafsgw"
 	NodeServerAdditionalMountOptions = MountOptionWriteCache + "," + MountOptionSyncOnClose
 )
@@ -564,9 +565,10 @@ func (ns *NodeServer) NodeGetInfo(ctx context.Context, req *csi.NodeGetInfoReque
 	}()
 	topology := &csi.Topology{
 		Segments: map[string]string{
-			TopologyKeyNode:   ns.nodeID, // required exactly same way as this is how node is accessed by K8s
-			TopologyLabelNode: ns.nodeID,
-			TopologyLabelWeka: "true",
+			TopologyKeyNode:        ns.nodeID, // required exactly same way as this is how node is accessed by K8s
+			TopologyLabelNode:      ns.nodeID,
+			TopologyLabelWeka:      "true",
+			TopologyLabelTransport: string(ns.getMounter().getTransport()),
 		},
 	}
 

--- a/pkg/wekafs/wekafsmounter.go
+++ b/pkg/wekafs/wekafsmounter.go
@@ -170,3 +170,7 @@ func (m *wekafsMounter) schedulePeriodicMountGc() {
 		}
 	}()
 }
+
+func (m *wekafsMounter) getTransport() DataTransport {
+	return dataTransportWekafs
+}


### PR DESCRIPTION
### TL;DR

Added support for scheduling workloads by transport protocol (NFS or WekaFS) using node topology.

### What changed?

- Updated `NFS.md` documentation to include information about scheduling workloads by transport protocol.
- Added constants for NFS and WekaFS data transport types.
- Implemented `getTransport()` method for both NFS and WekaFS mounters.
- Modified `NodeGetInfo` function to include transport type in node topology.

### How to test?

1. Deploy the updated Weka CSI Plugin in a hybrid cluster having both nodes with weka client installed and not installed, while setting `pluginConfig.mountProtocol.allowNfsFailback=true`
2. Create a PVC and a pod with a nodeSelector specifying the desired transport:
   ```yaml
   nodeSelector:
     topology.weka.com/transport: wekafs
   ```
   or
   ```yaml
   nodeSelector:
     topology.weka.com/transport: nfs
   ```
3. Verify that the pod is scheduled on a node with the specified transport type.

### Why make this change?

This change allows administrators to optimize workload placement based on the available transport protocol. In hybrid deployments where some nodes have the Weka client installed and others don't, storage-intensive workloads can be directed to nodes with WekaFS transport, while more generic workloads can use NFS transport. This flexibility enhances performance and resource utilization in diverse Kubernetes environments.