### PR TITLE
ci(CSI-213): add NFS sanity

### DIFF
--- a/.github/workflows/sanity.yaml
+++ b/.github/workflows/sanity.yaml
@@ -54,11 +54,21 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
       - run: docker-compose -f tests/csi-sanity/docker-compose-snapshotcaps.yaml up $COMPOSE_DEFAULTS
         env:
-          SANITY_FUNCTION: directory_volume_and_snapshots 
+          SANITY_FUNCTION: directory_volume_and_snapshots
+
+  directory_volume_and_snapshots_nfs:
+    if: success() || failure()
+    needs: directory_volume_and_snapshots
+    runs-on: self-hosted
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
+      - run: docker-compose -f tests/csi-sanity/docker-compose-nfs-snapshotcaps.yaml up $COMPOSE_DEFAULTS
+        env:
+          SANITY_FUNCTION: directory_volume_and_snapshots_nfs
 
   snaphot_volumes_with_2nd_level_shapshots:
     if: success() || failure()
-    needs: directory_volume_and_snapshots
+    needs: directory_volume_and_snapshots_nfs
     runs-on: self-hosted
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
@@ -66,12 +76,32 @@ jobs:
         env:
           SANITY_FUNCTION: snaphot_volumes_with_2nd_level_shapshots  
 
+  snaphot_volumes_with_2nd_level_shapshots_nfs:
+      if: success() || failure()
+      needs: snaphot_volumes_with_2nd_level_shapshots
+      runs-on: self-hosted
+      steps:
+        - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
+        - run: docker-compose -f tests/csi-sanity/docker-compose-nfs-snapshotcaps.yaml up $COMPOSE_DEFAULTS
+          env:
+            SANITY_FUNCTION: snaphot_volumes_with_2nd_level_shapshots_nfs
+
   filesystem_volumes:
     if: success() || failure()
-    needs: snaphot_volumes_with_2nd_level_shapshots
+    needs: snaphot_volumes_with_2nd_level_shapshots_nfs
     runs-on: self-hosted
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
       - run: docker-compose -f tests/csi-sanity/docker-compose-snapshotcaps.yaml up $COMPOSE_DEFAULTS
         env:
           SANITY_FUNCTION: filesystem_volumes 
+
+  filesystem_volumes_nfs:
+    if: success() || failure()
+    needs: filesystem_volumes
+    runs-on: self-hosted
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4
+      - run: docker-compose -f tests/csi-sanity/docker-compose-nfs-snapshotcaps.yaml up $COMPOSE_DEFAULTS
+        env:
+          SANITY_FUNCTION: filesystem_volumes_nfs

--- a/pkg/wekafs/apiclient/filesystem.go
+++ b/pkg/wekafs/apiclient/filesystem.go
@@ -222,6 +222,9 @@ func (a *ApiClient) EnsureNoNfsPermissionsForFilesystem(ctx context.Context, fsN
 	if err != nil {
 		logger.Error().Err(err).Str("filesystem", fsName).Msg("Failed to list NFS permissions")
 	}
+	if len(*permissions) > 0 {
+		logger.Debug().Int("permissions", len(*permissions)).Str("filesystem", fsName).Msg("Found stale NFS permissions, deleting")
+	}
 	for _, p := range *permissions {
 		err = a.DeleteNfsPermission(ctx, &NfsPermissionDeleteRequest{Uid: p.Uid})
 		if err != nil {

--- a/tests/csi-sanity/_docker_run_sanity.sh
+++ b/tests/csi-sanity/_docker_run_sanity.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-rm -rf /tmp/weka-csi-test/sanity-workspace/
+rm -rf /tmp/weka-csi-test/sanity-workspace
 rm -rf /tmp/weka-csi-test/filesystems
 rm -rf /tmp/csi-test-staging
 
@@ -13,7 +13,7 @@ if \
   csi-sanity -csi.stagingdir /tmp/csi-test-staging \
     --csi.controllerendpoint /tmp/weka-csi-test/controller-no-snaps.sock \
     --csi.endpoint /tmp/weka-csi-test/node-no-snaps.sock \
-    -csi.mountdir=/tmp/weka-csi-test/sanity-workspace/ \
+    -csi.mountdir=/tmp/weka-csi-test/sanity-workspace \
     -ginkgo.reportPassed \
     -ginkgo.failFast \
     -ginkgo.progress \
@@ -37,7 +37,7 @@ if \
     --csi.controllerendpoint /tmp/weka-csi-test/controller-no-snaps.sock \
     --csi.endpoint /tmp/weka-csi-test/node-no-snaps.sock \
     -csi.secrets /test/wekafs-api-secret.yaml \
-    -csi.mountdir=/tmp/weka-csi-test/sanity-workspace/ \
+    -csi.mountdir=/tmp/weka-csi-test/sanity-workspace \
     -ginkgo.seed 0 \
     -ginkgo.failFast \
     -ginkgo.progress \
@@ -60,7 +60,7 @@ if \
     --csi.controllerendpoint /tmp/weka-csi-test/controller-no-snaps.sock \
     --csi.endpoint /tmp/weka-csi-test/node-no-snaps.sock \
     -csi.secrets /test/wekafs-api-secret.yaml \
-    -csi.mountdir=/tmp/weka-csi-test/sanity-workspace/ \
+    -csi.mountdir=/tmp/weka-csi-test/sanity-workspace \
     -csi.testvolumeparameters /test/wekafs-fs.yaml \
     -ginkgo.seed 0 \
     -ginkgo.failFast \
@@ -82,7 +82,7 @@ if \
     --csi.controllerendpoint /tmp/weka-csi-test/controller.sock \
     --csi.endpoint /tmp/weka-csi-test/node.sock \
     -csi.secrets /test/wekafs-api-secret.yaml \
-    -csi.mountdir=/tmp/weka-csi-test/sanity-workspace/ \
+    -csi.mountdir=/tmp/weka-csi-test/sanity-workspace \
     -ginkgo.seed 0 \
     -ginkgo.failFast \
     -ginkgo.progress \
@@ -105,7 +105,7 @@ if \
     --csi.controllerendpoint /tmp/weka-csi-test/controller.sock \
     --csi.endpoint /tmp/weka-csi-test/node.sock \
     -csi.secrets /test/wekafs-api-secret.yaml \
-    -csi.mountdir=/tmp/weka-csi-test/sanity-workspace/ \
+    -csi.mountdir=/tmp/weka-csi-test/sanity-workspace \
     -ginkgo.seed 0 \
     -ginkgo.failFast \
     -ginkgo.progress \
@@ -127,7 +127,7 @@ if \
     --csi.controllerendpoint /tmp/weka-csi-test/controller.sock \
     --csi.endpoint /tmp/weka-csi-test/node.sock \
     -csi.secrets /test/wekafs-api-secret.yaml \
-    -csi.mountdir=/tmp/weka-csi-test/sanity-workspace/ \
+    -csi.mountdir=/tmp/weka-csi-test/sanity-workspace \
     -ginkgo.seed 0 \
     -ginkgo.failFast \
     -ginkgo.progress \

--- a/tests/csi-sanity/docker-compose-nfs-snapshotcaps.yaml
+++ b/tests/csi-sanity/docker-compose-nfs-snapshotcaps.yaml
@@ -1,0 +1,40 @@
+version: '3.8'
+
+services:
+  plugin_controller:
+    image: sanity
+    command: wekafsplugin -nodeid 1 -v 6 --allowinsecurehttps --endpoint=unix://tmp/weka-csi-test/controller.sock -metricsport=9091  --csimode=controller -enablemetrics -allowautofscreation -allowautofsexpansion -allowsnapshotsoflegacyvolumes -alwaysallowsnapshotvolumes -usenfs -interfacegroupname=NFS
+    volumes:
+      - test-volume:/tmp/weka-csi-test
+    privileged: true
+    network_mode: host
+    healthcheck:
+      test: test -f /tmp/weka-csi-test/controller.sock
+      start_period: 1s
+      timeout: 1s
+      retries: 10
+      interval: 3s
+  plugin_node:
+    image: sanity
+    command: wekafsplugin -nodeid 1 -v 6 --allowinsecurehttps --endpoint=unix://tmp/weka-csi-test/node.sock -metricsport=9092 --csimode=node -enablemetrics -allowautofscreation -allowautofsexpansion -allowsnapshotsoflegacyvolumes -alwaysallowsnapshotvolumes -usenfs -interfacegroupname=NFS
+    volumes:
+      - test-volume:/tmp/weka-csi-test
+    privileged: true
+    network_mode: host
+    healthcheck:
+      test: test -f /tmp/weka-csi-test/node.sock
+      start_period: 1s
+      timeout: 1s
+      retries: 10
+      interval: 3s
+  sanity:
+    image: sanity
+    command: run_sanity ${SANITY_FUNCTION} ${SANITY_VERBOSITY}
+    network_mode: host
+    volumes:
+      - test-volume:/tmp/weka-csi-test
+    depends_on:
+      - plugin_controller
+      - plugin_node
+volumes:
+  test-volume:

--- a/tests/csi-sanity/docker-compose.yaml
+++ b/tests/csi-sanity/docker-compose.yaml
@@ -33,6 +33,22 @@ services:
     privileged: true
     ports:
       - "9004:9090"
+  plugin_controller_nfs:
+    build: .
+    command: wekafsplugin -nodeid 1 -v 9 --allowinsecurehttps --endpoint=unix://tmp/weka-csi-test/controller-nfs.sock --debugpath=/tmp/weka-csi-test/filesystems --csimode=controller -enablemetrics -allowautofscreation -allowautofsexpansion -allowsnapshotsoflegacyvolumes -alwaysallowsnapshotvolumes -usenfs
+    volumes:
+      - test-volume:/tmp/weka-csi-test
+    privileged: true
+    ports:
+      - "9005:9090"
+  plugin_node_nfs:
+    build: .
+    command: wekafsplugin -nodeid 1 -v 9 --allowinsecurehttps --endpoint=unix://tmp/weka-csi-test/node.sock --debugpath=/tmp/weka-csi-test/filesystems --csimode=node -enablemetrics -allowautofscreation -allowautofsexpansion -allowsnapshotsoflegacyvolumes  -alwaysallowsnapshotvolumes -usenfs
+    volumes:
+      - test-volume:/tmp/weka-csi-test
+    privileged: true
+    ports:
+      - "9006:9090"
   sanity:
     build: .
     command: run_sanity

--- a/tests/csi-sanity/ga-Dockerfile
+++ b/tests/csi-sanity/ga-Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22-alpine
+FROM golang:1.22-alpine AS builder
 
 WORKDIR /app
 
@@ -6,7 +6,7 @@ COPY go.mod .
 COPY go.sum .
 RUN go mod download
 
-RUN go install -v github.com/kubernetes-csi/csi-test/v5/cmd/csi-sanity@v5.0.0
+RUN go install -v github.com/kubernetes-csi/csi-test/v5/cmd/csi-sanity@v5.3.1
 
 COPY cmd cmd
 COPY pkg pkg
@@ -14,12 +14,12 @@ COPY pkg pkg
 RUN CGO_ENABLED=0 GOOS="linux" GOARCH="amd64" go build -a -ldflags '-X main.version='$VERSION' -extldflags "-static"' -o wekafsplugin ./cmd/wekafsplugin/main.go
 
 
-FROM golang:1.21-alpine
+FROM golang:1.22-alpine
 
 ADD tests/csi-sanity/wekafs-dirv1.yaml /test/wekafs-dirv1.yaml
 ADD tests/csi-sanity/wekafs-fs.yaml /test/wekafs-fs.yaml
 ADD tests/csi-sanity/wekafs-snapvol.yaml /test/wekafs-snapvol.yaml
 ADD tests/csi-sanity/wekafs-api-secret.yaml /test/wekafs-api-secret.yaml
 ADD tests/csi-sanity/ga_docker_run_sanity.sh /usr/bin/run_sanity
-COPY --from=0 /go/bin/csi-sanity /usr/local/bin/csi-sanity
-COPY --from=0 /app/wekafsplugin  /usr/local/bin/wekafsplugin
+COPY --from=builder /go/bin/csi-sanity /usr/local/bin/csi-sanity
+COPY --from=builder /app/wekafsplugin  /usr/local/bin/wekafsplugin

--- a/tests/csi-sanity/ga_docker_run_sanity.sh
+++ b/tests/csi-sanity/ga_docker_run_sanity.sh
@@ -1,92 +1,129 @@
 #!/usr/bin/env sh
 
 mkdir -p  /tmp/weka-csi-test/filesystems/default/test/my/path
-rm -rf /tmp/weka-csi-test/sanity-workspace/
-rm -rf /tmp/weka-csi-test/filesystems
-rm -rf /tmp/csi-test-staging
+
+cleanup() {
+  echo "CLEANING UP"
+  rm -rf /tmp/weka-csi-test/sanity-workspace
+  rm -rf /tmp/weka-csi-test/filesystems
+  rm -rf /tmp/csi-test-staging
+}
 
 # ---------------------- LEGACY DIR VOLUME NO API BINDING (NO SNAPSHOT SUPPORT) ----------------------
 legacy_sanity() {
-echo "LEGACY SANITY STARTED"
-
-csi-sanity -csi.stagingdir /tmp/csi-test-staging \
-  --csi.controllerendpoint /tmp/weka-csi-test/controller-no-snaps.sock \
-  --csi.endpoint /tmp/weka-csi-test/node-no-snaps.sock \
-  -csi.mountdir=/tmp/weka-csi-test/sanity-workspace/ \
-  -ginkgo.always-emit-ginkgo-writer \
-  -ginkgo.progress  $1\
-  -ginkgo.seed 0 \
-  -csi.testvolumeparameters /test/wekafs-dirv1.yaml
+  echo "LEGACY SANITY STARTED"
+  cleanup
+  csi-sanity -csi.stagingdir /tmp/csi-test-staging \
+    --csi.controllerendpoint /tmp/weka-csi-test/controller-no-snaps.sock \
+    --csi.endpoint /tmp/weka-csi-test/node-no-snaps.sock \
+    -csi.mountdir=/tmp/weka-csi-test/sanity-workspace \
+    -ginkgo.always-emit-ginkgo-writer \
+    -ginkgo.progress $1\
+    -ginkgo.seed 0 \
+    -ginkgo.skip="NodeExpandVolume" \
+    -ginkgo.skip="NodeStageVolume" \
+    -ginkgo.skip="NodeUnstageVolume" \
+    -csi.testvolumeparameters /test/wekafs-dirv1.yaml
 }
 
 # ---------------------- DIR VOLUME WITH API BINDING EXCLUDING SNAPSHOTS ----------------------
 directory_volume_no_snapshots() {
-echo "DIRECTORY VOLUME NO SNAPSHOTS STARTED"
-
-csi-sanity -csi.stagingdir /tmp/csi-test-staging \
-  --csi.controllerendpoint /tmp/weka-csi-test/controller-no-snaps.sock \
-  --csi.endpoint /tmp/weka-csi-test/node-no-snaps.sock \
-  -csi.secrets /test/wekafs-api-secret.yaml \
-  -csi.mountdir=/tmp/weka-csi-test/sanity-workspace/ \
-  -ginkgo.seed 0 \
-  -ginkgo.progress  $1\
-  -csi.testvolumeparameters /test/wekafs-dirv1.yaml
+  echo "DIRECTORY VOLUME NO SNAPSHOTS STARTED"
+  cleanup
+  csi-sanity -csi.stagingdir /tmp/csi-test-staging \
+    --csi.controllerendpoint /tmp/weka-csi-test/controller-no-snaps.sock \
+    --csi.endpoint /tmp/weka-csi-test/node-no-snaps.sock \
+    -csi.secrets /test/wekafs-api-secret.yaml \
+    -csi.mountdir=/tmp/weka-csi-test/sanity-workspace \
+    -ginkgo.seed 0 \
+    -ginkgo.skip="NodeExpandVolume" \
+    -ginkgo.skip="NodeStageVolume" \
+    -ginkgo.skip="NodeUnstageVolume" \
+    -ginkgo.progress $1\
+    -csi.testvolumeparameters /test/wekafs-dirv1.yaml
 }
 
 # ---------------------- FS VOLUME WITH API BINDING EXCLUDING SNAPSHOTS ----------------------
 fs_volume_no_snapshots() {
-echo "FS VOLUME NO SNAPSHOTS STARTED"
-
-csi-sanity -csi.stagingdir /tmp/csi-test-staging \
-  --csi.controllerendpoint /tmp/weka-csi-test/controller-no-snaps.sock \
-  --csi.endpoint /tmp/weka-csi-test/node-no-snaps.sock \
-  -csi.secrets /test/wekafs-api-secret.yaml \
-  -csi.mountdir=/tmp/weka-csi-test/sanity-workspace/ \
-  -csi.testvolumeparameters /test/wekafs-fs.yaml \
-  -ginkgo.seed 0 \
-  -ginkgo.progress  $1
+  echo "FS VOLUME NO SNAPSHOTS STARTED"
+  cleanup
+  csi-sanity -csi.stagingdir /tmp/csi-test-staging \
+    --csi.controllerendpoint /tmp/weka-csi-test/controller-no-snaps.sock \
+    --csi.endpoint /tmp/weka-csi-test/node-no-snaps.sock \
+    -csi.secrets /test/wekafs-api-secret.yaml \
+    -csi.mountdir=/tmp/weka-csi-test/sanity-workspace \
+    -csi.testvolumeparameters /test/wekafs-fs.yaml \
+    -ginkgo.seed 0 \
+    -ginkgo.skip="NodeExpandVolume" \
+    -ginkgo.skip="NodeStageVolume" \
+    -ginkgo.skip="NodeUnstageVolume" \
+    -ginkgo.progress $1
 }
 
 # ---------------------- DIR VOLUME WITH API BINDING AND SNAPSHOTS ----------------------
 directory_volume_and_snapshots() {
-echo "DIRECTORY VOLUME AND SNAPSHOTS STARTED"
+  echo "DIRECTORY VOLUME AND SNAPSHOTS STARTED"
+  cleanup
+  csi-sanity -csi.stagingdir /tmp/csi-test-staging \
+    --csi.controllerendpoint /tmp/weka-csi-test/controller.sock \
+    --csi.endpoint /tmp/weka-csi-test/node.sock \
+    -csi.secrets /test/wekafs-api-secret.yaml \
+    -csi.mountdir=/tmp/weka-csi-test/sanity-workspace \
+    -ginkgo.seed 0 \
+    -ginkgo.skip="NodeExpandVolume" \
+    -ginkgo.skip="NodeStageVolume" \
+    -ginkgo.skip="NodeUnstageVolume" \
+    -ginkgo.progress $1\
+    -csi.testvolumeparameters /test/wekafs-dirv1.yaml
+}
 
-csi-sanity -csi.stagingdir /tmp/csi-test-staging \
-  --csi.controllerendpoint /tmp/weka-csi-test/controller.sock \
-  --csi.endpoint /tmp/weka-csi-test/node.sock \
-  -csi.secrets /test/wekafs-api-secret.yaml \
-  -csi.mountdir=/tmp/weka-csi-test/sanity-workspace/ \
-  -ginkgo.seed 0 \
-  -ginkgo.progress  $1\
-  -csi.testvolumeparameters /test/wekafs-dirv1.yaml
+directory_volume_and_snapshots_nfs() {
+  echo "RUNNING IN NFS MODE"
+  directory_volume_and_snapshots "$@"
 }
 
 # ---------------------- SNAPSHOT VOLUME WITH API BINDING AND SNAPSHOTS ----------------------
 snaphot_volumes_with_2nd_level_shapshots() {
-echo "SNAPSHOT VOLUMES WITH 2nd LEVEL SNAPSHOTS STARTED"
-
-csi-sanity -csi.stagingdir /tmp/csi-test-staging \
-  --csi.controllerendpoint /tmp/weka-csi-test/controller.sock \
-  --csi.endpoint /tmp/weka-csi-test/node.sock \
-  -csi.secrets /test/wekafs-api-secret.yaml \
-  -csi.mountdir=/tmp/weka-csi-test/sanity-workspace/ \
-  -ginkgo.seed 0 \
-  -ginkgo.progress  $1\
-  -csi.testvolumeparameters /test/wekafs-snapvol.yaml
+  echo "SNAPSHOT VOLUMES WITH 2nd LEVEL SNAPSHOTS STARTED"
+  cleanup
+  csi-sanity -csi.stagingdir /tmp/csi-test-staging \
+    --csi.controllerendpoint /tmp/weka-csi-test/controller.sock \
+    --csi.endpoint /tmp/weka-csi-test/node.sock \
+    -csi.secrets /test/wekafs-api-secret.yaml \
+    -csi.mountdir=/tmp/weka-csi-test/sanity-workspace \
+    -ginkgo.seed 0 \
+    -ginkgo.skip="NodeExpandVolume" \
+    -ginkgo.skip="NodeStageVolume" \
+    -ginkgo.skip="NodeUnstageVolume" \
+    -ginkgo.progress $1\
+    -csi.testvolumeparameters /test/wekafs-snapvol.yaml
+}
+# ---------------------- SNAPSHOT VOLUME WITH API BINDING AND SNAPSHOTS ----------------------
+snaphot_volumes_with_2nd_level_shapshots_nfs() {
+  echo "RUNNING IN NFS MODE"
+  snaphot_volumes_with_2nd_level_shapshots "$@"
 }
 
 # ---------------------- FILESYSTEM VOLUME WITH API BINDING AND SNAPSHOTS ----------------------
 filesystem_volumes() {
-echo "FILESYSTEM VOLUMES STARTED"
+  echo "FILESYSTEM VOLUMES STARTED"
+  cleanup
+  csi-sanity -csi.stagingdir /tmp/csi-test-staging \
+    --csi.controllerendpoint /tmp/weka-csi-test/controller.sock \
+    --csi.endpoint /tmp/weka-csi-test/node.sock \
+    -csi.secrets /test/wekafs-api-secret.yaml \
+    -csi.mountdir=/tmp/weka-csi-test/sanity-workspace \
+    -ginkgo.seed 0 \
+    -ginkgo.skip="NodeExpandVolume" \
+    -ginkgo.skip="NodeStageVolume" \
+    -ginkgo.skip="NodeUnstageVolume" \
+    -ginkgo.progress $1\
+    -csi.testvolumeparameters /test/wekafs-fs.yaml
+}
 
-csi-sanity -csi.stagingdir /tmp/csi-test-staging \
-  --csi.controllerendpoint /tmp/weka-csi-test/controller.sock \
-  --csi.endpoint /tmp/weka-csi-test/node.sock \
-  -csi.secrets /test/wekafs-api-secret.yaml \
-  -csi.mountdir=/tmp/weka-csi-test/sanity-workspace/ \
-  -ginkgo.seed 0 \
-  -ginkgo.progress  $1\
-  -csi.testvolumeparameters /test/wekafs-fs.yaml
+filesystem_volumes_nfs() {
+  echo "RUNNING IN NFS MODE"
+  filesystem_volumes "$@"
 }
 
 "$@"

--- a/tests/csi-sanity/wekafs-snapvol.yaml
+++ b/tests/csi-sanity/wekafs-snapvol.yaml
@@ -1,4 +1,4 @@
-filesystemName: default
+filesystemName: snapvolFilesystem
 permissions: "0775"
 ownerUid: "1001"
 ownerGid: "1002"


### PR DESCRIPTION
### TL;DR

Added NFS support to CSI sanity tests and improved secret handling in GitHub Actions workflow.

### What changed?

- Added a new job `directory_volume_and_snapshots_nfs` to the GitHub Actions workflow
- Created a new Docker Compose file `docker-compose-nfs-snapshotcaps.yaml` for NFS-specific tests
- Updated the main Docker Compose file to include NFS-enabled plugin services
- Added a new function `directory_volume_and_snapshots_nfs()` to the sanity test script

### How to test?

1. Run the updated GitHub Actions workflow
2. Verify that the new `directory_volume_and_snapshots_nfs` job completes successfully
3. Check the logs for the NFS-specific tests to ensure they're running as expected
4. Confirm that the secret handling steps are working correctly by examining the workflow logs

### Why make this change?

This change introduces NFS support to the CSI sanity tests, allowing for more comprehensive testing of the CSI driver's functionality. 