### PR TITLE
feat(CSI-268): support NFS target IPs override via API secret

### DIFF
--- a/docs/NFS.md
+++ b/docs/NFS.md
@@ -144,6 +144,16 @@ The Weka CSI Plugin requires AND will set the following NFS permissions on the W
 > Hence, it is **highly recommended** not creating additional permissions for the same filesystem 
 > Also, if multiple client groups are used, it is highly recommended to make sure that IP addresses are not overlapping between client groups. 
 
+## WEKA Cluster Preparation
+Before using the Weka CSI Plugin with NFS transport, the Weka cluster must be prepared for NFS access.
+This includes configuring the NFS protocol on the Weka cluster, creating an NFS interface group, and configuring at least 1 Group IP address
+
+Alternatively, in cloud deployments where setting a Group IP address is not possible, the Weka server IP addresses can be used instead.
+In such case, the IP addresses may be set via the API secret and will be used instead of the Group IP addresses.
+
+This can be set up by providing `nfsTargetIps` parameter in the API secret. Refer to the [API secret example](../examples/common/csi-wekafs-api-secret.yaml) for more information.
+> **WARNING:** Using an NFS load balancer that forwards NFS connection to multiple Weka servers is not supported at this moment.
+
 ## Installation
 By default, Weka CSI Plugin components will not start unless Weka driver is not detected on Kubernetes node.
 This is to prevent a potential misconfiguration where volumes are attempted to be provisioned or published on node while no Weka client is installed.

--- a/examples/common/csi-wekafs-api-secret.yaml
+++ b/examples/common/csi-wekafs-api-secret.yaml
@@ -25,6 +25,13 @@ data:
   # NOTE: if a load balancer is used to access the cluster API, leave this setting as "false"
   autoUpdateEndpoints: ZmFsc2U=
   # When using HTTPS connection and self-signed or untrusted certificates, provide a CA certificate in PEM format, base64-encoded
+  # for cloud deployments or other scenarios where setting an NFS Group IP addresses is not possible,
+  # provide a comma-separated list of NFS target IP addresses in form of <IP> (base64-encoded)
+  # It is recommended to configure all NFS server IP addresses to better share the load/balance the traffic.
+  # NOTE: this setting is optional and should be used only when the NFS Group IP addresses are not set in the cluster
+  # WARNING: providing a load balancer IP address that uses NFS connection redirects to other servers is not supported.
+  # e.g. 10.100.100.1,10.100.100.2
+  nfsTargetIps: ""
   # caCertificate: <base64-encoded-PEM>
   caCertificate: ""
 

--- a/pkg/wekafs/apiclient/apiclient.go
+++ b/pkg/wekafs/apiclient/apiclient.go
@@ -773,6 +773,7 @@ type Credentials struct {
 	LocalContainerName  string
 	AutoUpdateEndpoints bool
 	CaCertificate       string
+	NfsTargetIPs        []string
 }
 
 func (c *Credentials) String() string {

--- a/pkg/wekafs/apiclient/interfacegroup.go
+++ b/pkg/wekafs/apiclient/interfacegroup.go
@@ -188,6 +188,14 @@ func (a *ApiClient) GetNfsInterfaceGroup(ctx context.Context, name string) *Inte
 // GetNfsMountIp returns the IP address of the NFS interface group to be used for NFS mount
 // TODO: need to do it much more sophisticated way to distribute load
 func (a *ApiClient) GetNfsMountIp(ctx context.Context, interfaceGroupName string) (string, error) {
+	// if override is set, use it
+	if len(a.Credentials.NfsTargetIPs) > 0 {
+		ips := a.Credentials.NfsTargetIPs
+		idx := rand.Intn(len(ips))
+		ip := ips[idx]
+		return ip, nil
+	}
+
 	ig := a.GetNfsInterfaceGroup(ctx, interfaceGroupName)
 	if ig == nil {
 		return "", errors.New("no NFS interface group found")

--- a/pkg/wekafs/wekafs.go
+++ b/pkg/wekafs/wekafs.go
@@ -101,6 +101,18 @@ func (api *ApiStore) fromSecrets(ctx context.Context, secrets map[string]string,
 		return ret
 	}()
 
+	var nfsTargetIps []string
+	if _, ok := secrets["nfsTargetIps"]; ok {
+		nfsTargetIpsRaw := strings.TrimSpace(strings.ReplaceAll(strings.TrimSuffix(secrets["nfsTargetIps"], "\n"), "\n", ","))
+		nfsTargetIps = func() []string {
+			var ret []string
+			for _, s := range strings.Split(nfsTargetIpsRaw, ",") {
+				ret = append(ret, strings.TrimSpace(strings.TrimSuffix(s, "\n")))
+			}
+			return ret
+		}()
+	}
+
 	localContainerName, ok := secrets["localContainerName"]
 	if !ok {
 		localContainerName = ""
@@ -124,6 +136,7 @@ func (api *ApiStore) fromSecrets(ctx context.Context, secrets map[string]string,
 		LocalContainerName:  localContainerName,
 		AutoUpdateEndpoints: autoUpdateEndpoints,
 		CaCertificate:       caCertificate,
+		NfsTargetIPs:        nfsTargetIps,
 	}
 	return api.fromCredentials(ctx, credentials, hostname)
 }


### PR DESCRIPTION
### TL;DR

Added support for NFS target IPs in cloud deployments where setting Group IP addresses is not possible.

### What changed?

- Updated `NFS.md` documentation to include information about Weka cluster preparation for NFS access and the new `nfsTargetIps` parameter.
- Modified `csi-wekafs-api-secret.yaml` to include the `nfsTargetIps` field in the API secret.
- Updated `apiclient.go` to include `NfsTargetIPs` in the `Credentials` struct.
- Modified `interfacegroup.go` to use the provided NFS target IPs when available.
- Updated `wekafs.go` to parse and handle the new `nfsTargetIps` parameter from secrets.

### How to test?

1. Deploy the Weka CSI Plugin with NFS failback.
2. Configure the `nfsTargetIps` parameter in the API secret with a comma-separated list of NFS target IP addresses.
3. Create and mount a PVC volume using the Weka CSI Plugin.
4. Verify that the NFS connection is established using one of the provided target IPs.

### Why make this change?

This change enables the Weka CSI Plugin to work in cloud deployments where setting Group IP addresses for NFS access is not feasible. By allowing users to specify NFS target IPs directly, it provides a workaround for environments where setting up floating IPs (Group IP addresses) is not available, ensuring broader compatibility and easier deployment in various cloud scenarios.