### PR TITLE
fix(CSI-275): version of NFS is only set to V4 during NFS permission creation

### DIFF
--- a/pkg/wekafs/apiclient/nfs.go
+++ b/pkg/wekafs/apiclient/nfs.go
@@ -252,7 +252,7 @@ func EnsureNfsPermission(ctx context.Context, fsName string, group string, versi
 				SquashMode:        NfsPermissionSquashModeNone,
 				AnonGid:           65534,
 				AnonUid:           65534,
-				SupportedVersions: &[]string{string(NfsVersionV4)},
+				SupportedVersions: &[]string{NfsVersionV3.String(), NfsVersionV4.String()},
 			}
 			if err := apiClient.CreateNfsPermission(ctx, req, perm); err != nil {
 				return err


### PR DESCRIPTION
### TL;DR

Enhanced NFS permission handling and version matching in the WekaFS API client.

### What changed?

- Implemented a `Matches` method for `NfsPermission` to compare permissions.
- Modified `FindNfsPermissionsByFilter` to use the new `Matches` method.
- Updated `EnsureNfsPermission` to support both NFSv3 and NFSv4 by default.

### How to test?

1. Create NFS permission having both versions V3 and V4 set on WEKA Cluster. 

2. Attempt to provision a PVC via NFS transport

3. Ensure that provisioning succeeds

### Why make this change?

This change improves the flexibility and accuracy of NFS permission handling. If a permission exists that allows access via both NFSv3 and NFSv4 (and it matches by all the rest of parameters), the CSI plugin will recognize it and not try to create a duplicate permission