### PR TITLE
fix(CSI-273): remove rdirplus from mountoptions

### DIFF
--- a/pkg/wekafs/mountoptions.go
+++ b/pkg/wekafs/mountoptions.go
@@ -178,7 +178,7 @@ func (opts MountOptions) setSelinux(selinuxSupport bool, mountProtocol string) {
 }
 
 func (opts MountOptions) AsNfs() MountOptions {
-	ret := NewMountOptionsFromString("hard,rdirplus")
+	ret := NewMountOptionsFromString("hard")
 	for _, o := range opts.getOpts() {
 		switch o.option {
 		case "writecache":


### PR DESCRIPTION
### TL;DR

Removed "rdirplus" from default NFS mount options.

### What changed?

Modified the `AsNfs()` function in `pkg/wekafs/mountoptions.go` to initialize the `ret` variable with only the "hard" option instead of "hard,rdirplus".

### How to test?

1. Configure Weka CSI plugin to using NFS protocol.
2. Create and publish a `snapshot-backed` PVC
3. Attach the PVC to a pod (via NFS) and ensure no `stale file handle` error occurs when accessing the volume contents from within the pod.

### Why make this change?

The "rdirplus" option is an optimization that currently is not supported in conjunction with bind mount inside `.snapshots` directory