### PR TITLE
feat(CSI-286): whitespace not trimmed for localContainerName in CSI secret

### DIFF
--- a/pkg/wekafs/wekafs.go
+++ b/pkg/wekafs/wekafs.go
@@ -114,7 +114,9 @@ func (api *ApiStore) fromSecrets(ctx context.Context, secrets map[string]string,
 	}
 
 	localContainerName, ok := secrets["localContainerName"]
-	if !ok {
+	if ok {
+		localContainerName = strings.TrimSpace(strings.TrimSuffix(localContainerName, "\n"))
+	} else {
 		localContainerName = ""
 	}
 	autoUpdateEndpoints := false


### PR DESCRIPTION
### TL;DR

Improved handling of `localContainerName` in the `fromSecrets` function.

### What changed?

- Modified the `fromSecrets` function in `pkg/wekafs/wekafs.go`.
- Added trimming of whitespace and newline characters from `localContainerName`.
- Restructured the conditional logic for handling the presence of `localContainerName` in secrets.

### How to test?

1. Provide secrets with `localContainerName` containing leading/trailing whitespace or newline characters, e.g. when the string is encoded into Base64 together with a trailing newline
2. Call the `fromSecrets` function with these secrets.
3. Verify that the resulting `localContainerName` is properly trimmed.
4. Test with and without `localContainerName` in the secrets to ensure correct behavior in both cases.

### Why make this change?

This change improves the robustness of the `fromSecrets` function by ensuring that `localContainerName` is properly sanitized. It prevents potential issues caused by unintended whitespace or newline characters, which could lead to unexpected behavior in downstream operations that rely on this value.