### PR TITLE
feat(CSI-288): validate API user role prior to performing ops

### DIFF
--- a/docs/NFS.md
+++ b/docs/NFS.md
@@ -23,6 +23,8 @@ This allows you to use WekaFS as a storage backend for your Kubernetes cluster w
 - **Network Configuration**: NFS interface group IP addresses must be accessible from the Kubernetes cluster nodes
 - **Security**: NFS transport is less secure than the native WekaFS driver, and may require additional security considerations
 - **QoS**: QoS is not supported for NFS transport
+- **Organizations and Multitenancy**: NFS transport can be used only for filesystems in `Root` organization. 
+    If you need to use a filesystem in a different organization, you must use the native WekaFS driver.
 
 ### Host Network Mode
 Weka CSI Plugin will automatically install in `hostNetwork` mode when using NFS transport. 

--- a/pkg/wekafs/apiclient/apiclient.go
+++ b/pkg/wekafs/apiclient/apiclient.go
@@ -29,13 +29,21 @@ import (
 	"time"
 )
 
+type ApiUserRole string
+
 const (
-	ApiHttpTimeOutSeconds         = 60
-	ApiRetryIntervalSeconds       = 1
-	ApiRetryMaxCount              = 5
-	RetryBackoffExponentialFactor = 1
-	RootOrganizationName          = "Root"
-	TracerName                    = "weka-csi"
+	ApiHttpTimeOutSeconds                     = 60
+	ApiRetryIntervalSeconds                   = 1
+	ApiRetryMaxCount                          = 5
+	RetryBackoffExponentialFactor             = 1
+	RootOrganizationName                      = "Root"
+	TracerName                                = "weka-csi"
+	ApiUserRoleClusterAdmin       ApiUserRole = "ClusterAdmin"
+	ApiUserRoleOrgAdmin           ApiUserRole = "OrgAdmin"
+	ApiUserRoleReadOnly           ApiUserRole = "ReadOnly"
+	ApiUserRoleCSI                ApiUserRole = "CSI"
+	ApiUserRoleS3                 ApiUserRole = "S3"
+	ApiUserRoleRegular            ApiUserRole = "Regular"
 )
 
 // ApiClient is a structure that defines Weka API client
@@ -65,6 +73,8 @@ type ApiClient struct {
 	clientHash                 uint32
 	hostname                   string
 	NfsInterfaceGroups         map[string]*InterfaceGroup
+	ApiUserRole                ApiUserRole
+	ApiOrgId                   int
 }
 
 type ApiEndPoint struct {
@@ -644,6 +654,12 @@ func (a *ApiClient) Login(ctx context.Context) error {
 	}
 	logger.Debug().Msg("Successfully connected to cluster API")
 
+	err = a.ensureSufficientPermissions(ctx)
+	if err != nil {
+		logger.Error().Err(err).Msg("Failed to ensure sufficient permissions for supplied credentials. Cannot continue")
+		return err
+	}
+
 	if a.Credentials.AutoUpdateEndpoints {
 		if err := a.UpdateApiEndpoints(ctx); err != nil {
 			logger.Error().Err(err).Msg("Failed to update actual API endpoints")
@@ -779,6 +795,13 @@ type Credentials struct {
 func (c *Credentials) String() string {
 	return fmt.Sprintf("%s://%s:%s@%s",
 		c.HttpScheme, c.Username, c.Organization, c.Endpoints)
+}
+
+func (a *ApiClient) HasCSIPermissions() bool {
+	if a.ApiUserRole != "" {
+		return a.ApiUserRole == ApiUserRoleCSI || a.ApiUserRole == ApiUserRoleClusterAdmin || a.ApiUserRole == ApiUserRoleOrgAdmin && a.ApiOrgId != 0
+	}
+	return false
 }
 
 func maskPayload(payload string) string {

--- a/pkg/wekafs/nfsmount.go
+++ b/pkg/wekafs/nfsmount.go
@@ -171,6 +171,12 @@ func (m *nfsMount) doMount(ctx context.Context, apiClient *apiclient.ApiClient, 
 		logger.Trace().Msg("No API client for mount, cannot proceed")
 		return errors.New("no API client for mount, cannot do NFS mount")
 	}
+	// to validate that the organization is root, otherwise cannot mount NFS volumes
+	if apiClient.ApiOrgId != 0 {
+		err := errors.New("cannot mount NFS volumes with non-Root organization")
+		logger.Error().Err(err).Int("organization_id", apiClient.ApiOrgId).Msg("Cannot mount NFS volumes with non-Root organization")
+		return err
+	}
 
 	if !m.isInDevMode() {
 


### PR DESCRIPTION
feat(CSI-288): validate API user role prior to performing ops

- Implement user role and organization ID validation for API client
- Add checks for sufficient CSI permissions
- Prevent NFS mounts for non-Root organizations

docs(CSI-288): add limitation for NFS on Root organization only

- Update NFS documentation to clarify that NFS transport is only available for filesystems in the Root organization