### PR TITLE
feat(CSI-287): acl not passed to NFS mount in ControllerCreateVolume flow

### DIFF
--- a/pkg/wekafs/mountoptions.go
+++ b/pkg/wekafs/mountoptions.go
@@ -16,11 +16,13 @@ const (
 	MountOptionCoherent    = "coherent"
 	MountOptionNfsAsync    = "async"
 	MountOptionNfsHard     = "hard"
+	MountOptionNfsRdirplus = "rdirplus"
 	MountOptionReadCache   = "readcache"
 	MountProtocolWekafs    = "wekafs"
 	MountProtocolNfs       = "nfs"
-	DefaultNfsMountOptions = MountOptionNfsHard + "," + MountOptionNfsAsync
 )
+
+var DefaultNfsMountOptions = strings.Join([]string{MountOptionNfsHard, MountOptionNfsAsync, MountOptionNfsRdirplus}, ",")
 
 type mountOption struct {
 	option string
@@ -193,6 +195,8 @@ func (opts MountOptions) AsNfs() MountOptions {
 	ret := NewMountOptionsFromString(DefaultNfsMountOptions)
 	for _, o := range opts.getOpts() {
 		switch o.option {
+		case "acl":
+			ret.AddOption("user_xattr")
 		case "writecache":
 			ret.AddOption("async")
 		case "coherent":
@@ -215,6 +219,10 @@ func (opts MountOptions) AsNfs() MountOptions {
 		default:
 			continue
 		}
+	}
+	if ret.getOptionValue("vers") == "3" {
+		// cannot set "acl" on nfsv3
+		ret.RemoveOption("user_xattr")
 	}
 	return ret
 }


### PR DESCRIPTION
### TL;DR

Enhanced NFS mount options and improved compatibility with ACLs.

### What changed?

- Added `rdirplus` to the default NFS mount options.
- Converted `DefaultNfsMountOptions` from a constant to a variable using `strings.Join`.
- In the `AsNfs` method:
  - Added support for the `acl` option, which now translates to `user_xattr` for NFS mounts.
  - Implemented logic to remove `user_xattr` option when NFS version 3 is used, as it doesn't support ACLs.

### How to test?

1. Mount a WekaFS filesystem using both WekaFS and NFS protocols.
2. Verify that the `rdirplus` option is present in the NFS mount options.
3. Test ACL functionality:
   - Set ACLs on a WekaFS mount and verify they are preserved when accessed via NFS (for NFS v4).
   - Confirm that `user_xattr` is not present in mount options when using NFS v3.

### Why make this change?

- The `rdirplus` option can improve NFS performance by allowing the server to return file attributes along with directory entries.
- Adding support for ACLs in NFS mounts (via `user_xattr`) ensures better compatibility between WekaFS and NFS access methods.
- Removing `user_xattr` for NFS v3 prevents potential issues, as this version doesn't support ACLs.

These changes aim to enhance performance and maintain consistent behavior across different protocols and NFS versions.