### PR TITLE
fix(CSI-296): node registration fails after switch transport from NFS to Wekafs due to label conflict

### DIFF
--- a/charts/csi-wekafsplugin/templates/nodeserver-daemonset.yaml
+++ b/charts/csi-wekafsplugin/templates/nodeserver-daemonset.yaml
@@ -62,7 +62,7 @@ spec:
             - bash
           args:
             - -c
-            - kubectl get node $NODENAME -o json | jq '.metadata' > /etc/nodeinfo/metadata
+            - kubectl label node $NODENAME "topology.csi.weka.io/transport-" ; kubectl get node $NODENAME -o json | jq '.metadata' > /etc/nodeinfo/metadata
       containers:
         - name: wekafs
           securityContext:


### PR DESCRIPTION
### TL;DR

Added a node labeling step to the nodeserver daemonset initialization process.

### What changed?

Modified the init container's command in the nodeserver daemonset to include a step that removes the `topology.csi.weka.io/transport` label from the node before fetching and storing the node metadata.

### How to test?

1. Deploy the updated chart with allowNfsFailback = true (without weka client installed on node)
2. Verify that nodes are labeled with "topology.csi.weka.io/transport" set to "nfs"
3. Ensure that the node has a running weka client and restart the node. The label should set to "wekafs"

### Why make this change?

This change prepares nodes for potential topology-change operations in the CSI WekaFS plugin. Since CSI cannot modify existing labels upon node registration, having to remove the existing label prior to setting up a new one