### PR TITLE
feat(CSI-295): add affinity for controller and separated nodeSelector for controller and node

### DIFF
--- a/charts/csi-wekafsplugin/templates/_merge.tpl
+++ b/charts/csi-wekafsplugin/templates/_merge.tpl
@@ -1,0 +1,100 @@
+{{/*
+Copyright 2018 The Openstack-Helm Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+{{/*
+Takes a tuple of values and merges into the first (target) one each subsequent
+(source) one in order. If all values to merge are maps, then the tuple can be
+passed as is and the target will be the result, otherwise pass a map with a
+"values" key containing the tuple of values to merge, and the merge result will
+be assigned to the "result" key of the passed map.
+
+When merging maps, for each key in the source, if the target does not define
+that key, the source value is assigned. If both define the key, then the key
+values are merged using this algorithm (recursively) and the result is assigned
+to the target key. Slices are merged by appending them and removing any
+duplicates. Any other values are merged by simply keeping the source, and
+throwing away the target.
+*/}}
+{{- define "helm-toolkit.utils.merge" -}}
+  {{- $local := dict -}}
+  {{- if kindIs "map" $ -}}
+    {{- $_ := set $local "values" $.values -}}
+  {{- else -}}
+    {{- $_ := set $local "values" $ -}}
+  {{- end -}}
+
+  {{- $target := first $local.values -}}
+  {{- range $item := rest $local.values -}}
+    {{- $call := dict "target" $target "source" . -}}
+    {{- $_ := include "helm-toolkit.utils._merge" $call -}}
+    {{- $_ := set $local "result" $call.result -}}
+  {{- end -}}
+
+  {{- if kindIs "map" $ -}}
+    {{- $_ := set $ "result" $local.result -}}
+  {{- end -}}
+{{- end -}}
+
+{{- define "helm-toolkit.utils._merge" -}}
+  {{- $local := dict -}}
+
+  {{- $_ := set $ "result" $.source -}}
+
+  {{/*
+  TODO: Should we `fail` when trying to merge a collection (map or slice) with
+  either a different kind of collection or a scalar?
+  */}}
+
+  {{- if and (kindIs "map" $.target) (kindIs "map" $.source) -}}
+    {{- range $key, $sourceValue := $.source -}}
+      {{- if not (hasKey $.target $key) -}}
+        {{- $_ := set $local "newTargetValue" $sourceValue -}}
+        {{- if kindIs "map" $sourceValue -}}
+          {{- $copy := dict -}}
+          {{- $call := dict "target" $copy "source" $sourceValue -}}
+          {{- $_ := include "helm-toolkit.utils._merge.shallow" $call -}}
+          {{- $_ := set $local "newTargetValue" $copy -}}
+        {{- end -}}
+      {{- else -}}
+        {{- $targetValue := index $.target $key -}}
+        {{- $call := dict "target" $targetValue "source" $sourceValue -}}
+        {{- $_ := include "helm-toolkit.utils._merge" $call -}}
+        {{- $_ := set $local "newTargetValue" $call.result -}}
+      {{- end -}}
+      {{- $_ := set $.target $key $local.newTargetValue -}}
+    {{- end -}}
+    {{- $_ := set $ "result" $.target -}}
+  {{- else if and (kindIs "slice" $.target) (kindIs "slice" $.source) -}}
+    {{- $call := dict "target" $.target "source" $.source -}}
+    {{- $_ := include "helm-toolkit.utils._merge.append_slice" $call -}}
+    {{- $_ := set $ "result" (uniq $call.result) -}}
+  {{- end -}}
+{{- end -}}
+
+{{- define "helm-toolkit.utils._merge.shallow" -}}
+  {{- range $key, $value := $.source -}}
+    {{- $_ := set $.target $key $value -}}
+  {{- end -}}
+{{- end -}}
+
+{{- define "helm-toolkit.utils._merge.append_slice" -}}
+  {{- $local := dict -}}
+  {{- $_ := set $local "result" $.target -}}
+  {{- range $value := $.source -}}
+    {{- $_ := set $local "result" (append $local.result $value) -}}
+  {{- end -}}
+  {{- $_ := set $ "result" $local.result -}}
+{{- end -}}

--- a/charts/csi-wekafsplugin/templates/controllerserver-statefulset.yaml
+++ b/charts/csi-wekafsplugin/templates/controllerserver-statefulset.yaml
@@ -26,8 +26,15 @@ spec:
         prometheus.io/port: '{{ .Values.metrics.controllerPort | default 9090 }},{{ .Values.metrics.provisionerPort | default 9091 }},{{ .Values.metrics.resizerPort | default 9092 }},{{ .Values.metrics.snapshotterPort | default 9093 }}'
     {{- end }}
     spec:
-      {{- if .Values.nodeSelector }}
-      nodeSelector: {{ toYaml .Values.nodeSelector | nindent 8}}
+      {{- if or .Values.controller.affinity .Values.affinity }}
+      {{- $affinity := mustMergeOverwrite .Values.affinity .Values.controller.affinity }}
+      affinity:
+        {{- toYaml $affinity | nindent 8}}
+      {{- end }}
+      {{- if or .Values.nodeSelector .Values.controller.nodeSelector}}
+      {{ $nodeselector := mustMergeOverwrite .Values.nodeSelector .Values.controller.nodeSelector }}
+      nodeSelector:
+        {{- toYaml $nodeselector | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ .Release.Name }}-controller
       {{- if or .Values.hostNetwork .Values.pluginConfig.mountProtocol.useNfs .Values.pluginConfig.mountProtocol.allowNfsFailback}}

--- a/charts/csi-wekafsplugin/templates/controllerserver-statefulset.yaml
+++ b/charts/csi-wekafsplugin/templates/controllerserver-statefulset.yaml
@@ -27,14 +27,16 @@ spec:
     {{- end }}
     spec:
       {{- if or .Values.controller.affinity .Values.affinity }}
-      {{- $affinity := mustMergeOverwrite .Values.affinity .Values.controller.affinity }}
+      {{- $controllerAffinity := dict  -}}
+      {{- $_ := include "helm-toolkit.utils.merge" (tuple $controllerAffinity .Values.controller.affinity .Values.affinity) }}
       affinity:
-        {{- toYaml $affinity | nindent 8}}
+        {{- toYaml $controllerAffinity | nindent 8}}
       {{- end }}
       {{- if or .Values.nodeSelector .Values.controller.nodeSelector}}
-      {{ $nodeselector := mustMergeOverwrite .Values.nodeSelector .Values.controller.nodeSelector }}
+      {{- $nodeSelector := dict -}}
+      {{- $_ := include "helm-toolkit.utils.merge" (tuple $nodeSelector .Values.controller.nodeSelector .Values.nodeSelector) }}
       nodeSelector:
-        {{- toYaml $nodeselector | nindent 8 }}
+        {{- toYaml $nodeSelector | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ .Release.Name }}-controller
       {{- if or .Values.hostNetwork .Values.pluginConfig.mountProtocol.useNfs .Values.pluginConfig.mountProtocol.allowNfsFailback}}

--- a/charts/csi-wekafsplugin/templates/nodeserver-daemonset.yaml
+++ b/charts/csi-wekafsplugin/templates/nodeserver-daemonset.yaml
@@ -20,20 +20,15 @@ spec:
         prometheus.io/port: '{{ .Values.metrics.nodePort | default 9090 }}'
     {{- end }}
     spec:
-      {{- if (eq .Values.selinuxSupport "mixed")}}
+      {{- if or .Values.node.affinity .Values.affinity }}
+      {{- $affinity := mustMergeOverwrite .Values.affinity .Values.node.affinity }}
       affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-              - matchExpressions:
-                  - key: {{ .Values.selinuxNodeLabel |default "csi.weka.io/selinux_enabled" }}
-                    operator: In
-                    values:
-                      - "true"
+        {{- toYaml $affinity | nindent 8}}
       {{- end }}
-      {{- if .Values.nodeSelector }}
+      {{- if or .Values.nodeSelector .Values.node.nodeSelector}}
+      {{ $nodeselector := mustMergeOverwrite .Values.nodeSelector .Values.node.nodeSelector }}
       nodeSelector:
-      {{- toYaml .Values.nodeSelector | nindent 8}}
+        {{- toYaml $nodeselector | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ .Release.Name }}-node
       {{- if .Values.priorityClassName }}

--- a/charts/csi-wekafsplugin/templates/nodeserver-daemonset.yaml
+++ b/charts/csi-wekafsplugin/templates/nodeserver-daemonset.yaml
@@ -21,14 +21,16 @@ spec:
     {{- end }}
     spec:
       {{- if or .Values.node.affinity .Values.affinity }}
-      {{- $affinity := mustMergeOverwrite .Values.affinity .Values.node.affinity }}
+      {{- $nodeAffinity := dict  -}}
+      {{- $_ := include "helm-toolkit.utils.merge" (tuple $nodeAffinity .Values.node.affinity .Values.affinity) }}
       affinity:
-        {{- toYaml $affinity | nindent 8}}
+        {{- toYaml $nodeAffinity | nindent 8}}
       {{- end }}
       {{- if or .Values.nodeSelector .Values.node.nodeSelector}}
-      {{ $nodeselector := mustMergeOverwrite .Values.nodeSelector .Values.node.nodeSelector }}
+      {{- $nodeSelector := dict -}}
+      {{- $_ := include "helm-toolkit.utils.merge" (tuple $nodeSelector .Values.node.nodeSelector .Values.nodeSelector) }}
       nodeSelector:
-        {{- toYaml $nodeselector | nindent 8 }}
+        {{- toYaml $nodeSelector | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ .Release.Name }}-node
       {{- if .Values.priorityClassName }}

--- a/charts/csi-wekafsplugin/values.yaml
+++ b/charts/csi-wekafsplugin/values.yaml
@@ -38,9 +38,13 @@ controllerPluginTolerations: *globalPluginTolerations
 # -- Tolerations for CSI node component only (by default same as global)
 nodePluginTolerations: *globalPluginTolerations
 # -- Optional nodeSelector for CSI plugin deployment on certain Kubernetes nodes only
+#    This nodeselector will be applied to all CSI plugin components
 nodeSelector: {}
+# -- Optional affinity for CSI plugin deployment
+#    This affinity will be applied to all CSI plugin components
+affinity: {}
 # -- Optional setting for OCP platform only, which machineconfig pools to apply the Weka SELinux policy on
-# NOTE: by default, the policy will be installed both on workers and control plane nodes
+#    NOTE: by default, the policy will be installed both on workers and control plane nodes
 machineConfigLabels:
   - "worker"
   - "master"
@@ -65,6 +69,10 @@ controller:
   configureResizerLeaderElection: true
   # -- Configure snapshotter sidecar for leader election
   configureSnapshotterLeaderElection: true
+  # -- optional nodeSelector for controller components only
+  nodeSelector: {}
+  # -- optional affinity for controller components only
+  affinity: {}
 # Node-specific parameters, please do not change unless explicitly guided
 node:
   # -- Maximum concurrent requests from sidecars (global)
@@ -75,6 +83,10 @@ node:
     nodeUnpublishVolume: 5
   # -- Return GRPC Unavailable if request waits in queue for that long time (seconds)
   grpcRequestTimeoutSeconds: 30
+  # -- optional nodeSelector for node components only
+  nodeSelector: {}
+  # -- optional affinity for node components only
+  affinity: {}
 # -- Log level of CSI plugin
 logLevel: 5
 # -- Use JSON structured logging instead of human-readable logging format (for exporting logs to structured log parser)


### PR DESCRIPTION
### TL;DR

Added support for component-specific affinity and nodeSelector configurations in the CSI WekaFS plugin chart.

### What changed?

- Introduced new `affinity` and `nodeSelector` fields for both controller and node components.
- Updated the controllerserver-statefulset.yaml and nodeserver-daemonset.yaml templates to use these new configurations.
- Added a new `_merge.tpl` file with utility functions for merging configurations.
- Modified the values.yaml file to include the new configuration options.

### How to test?

1. Update the chart with the new changes.
2. Deploy the chart with custom affinity and nodeSelector configurations for controller and node components.
3. Verify that the pods are scheduled according to the specified affinity and nodeSelector rules.
4. Test both global and component-specific configurations to ensure they are applied correctly.

### Why make this change?

This change provides more flexibility in deploying the WEKA CSI plugin. It allows users to define specific scheduling rules for controller and node components separately, which can be useful for optimizing resource allocation and meeting specific infrastructure requirements. The addition of the merge utility also improves the maintainability and extensibility of the chart.


### Note regarding scheduling of components

Both controller and node components of the WEKA CSI plugin require connection to WEKA cluster, both via REST API and via data-plane (e.g. ability to mount WEKA filesystem) and require a WEKA client component on the particular node (or NFS configuration)