### PR TITLE
feat(CSI-300): add arm64 support

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -32,6 +32,9 @@ jobs:
           fi
 
       # DOCKER BUILD & PUSH
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Login to Quay.io
@@ -56,6 +59,7 @@ jobs:
           provenance: false # https://issues.redhat.com/browse/PROJQUAY-5013 quay doesn't support it
           build-args: |
             VERSION='${{ steps.auto_version.outputs.version }}'
+          platforms: linux/amd64,linux/arm64
 
       # HELM
       - name: Get Helm chart version
@@ -66,12 +70,11 @@ jobs:
       - name: Update Helm chart version
         uses: mikefarah/yq@master
         with:
-          cmd: | 
+          cmd: |
             BASEDIR=charts/csi-wekafsplugin
             DRIVER_VERSION="$(echo ${{ steps.version.outputs.version }} | sed 's/^v//1')"
             CHART_VERSION="${{ steps.helm_version.outputs.helm_version }}"
             APP_VERSION="${{ steps.version.outputs.version }}"
-            
             yq -i '.version = "'$CHART_VERSION'"' $BASEDIR/Chart.yaml
             yq -i '.appVersion = "'$APP_VERSION'"' $BASEDIR/Chart.yaml
             yq -i '.sources[0] = "https://github.com/weka/csi-wekafs/tree/v$CHART_VERSION/charts/csi-wekafsplugin"' $BASEDIR/Chart.yaml
@@ -88,7 +91,7 @@ jobs:
           options: -v ${{ github.workspace }}:/data
           run: |
             cd /data
-            helm-docs -s file -c charts -o ../../README.md -t ../README.md.gotmpl 
+            helm-docs -s file -c charts -o ../../README.md -t ../README.md.gotmpl
             helm-docs -s file -c charts
 
       - name: Set up Helm
@@ -142,7 +145,7 @@ jobs:
           S3_BUCKET_NAME=${{ secrets.S3_BUCKET_NAME }}
           URL="https://$S3_BUCKET_NAME.s3.$AWS_REGION.amazonaws.com"
           echo "filename=$FILENAME" >> $GITHUB_OUTPUT
-          echo "url=$URL" >> $GITHUB_OUTPUT          
+          echo "url=$URL" >> $GITHUB_OUTPUT
 
       - name: Install AWS CLI
         id: install-aws-cli
@@ -157,7 +160,7 @@ jobs:
           export AWS_SECRET_ACCESS_KEY="${{ secrets.AWS_SECRET_ACCESS_KEY}}"
           export AWS_REGION="${{ secrets.AWS_REGION }}"
           aws s3 cp ${{ steps.helm-package.outputs.filename }} "s3://${{ vars.AWS_BUCKET }}/"
-          echo "link=https://${{ vars.AWS_BUCKET }}.s3.${AWS_REGION}.amazonaws.com/${{ steps.helm-package.outputs.filename }}" >> $GITHUB_OUTPUT 
+          echo "link=https://${{ vars.AWS_BUCKET }}.s3.${AWS_REGION}.amazonaws.com/${{ steps.helm-package.outputs.filename }}" >> $GITHUB_OUTPUT
         if: steps.helm-test.outputs.passed == 'true'
 
       - uses: rtCamp/action-slack-notify@v2

--- a/.github/workflows/push-dev.yaml
+++ b/.github/workflows/push-dev.yaml
@@ -37,14 +37,19 @@ jobs:
           fi
 
       # DOCKER BUILD & PUSH
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+
       - name: Login to Quay.io
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
           registry: quay.io
+
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
@@ -61,6 +66,7 @@ jobs:
           provenance: false # https://issues.redhat.com/browse/PROJQUAY-5013 quay doesn't support it
           build-args: |
             VERSION='${{ steps.auto_version.outputs.version }}'
+          platforms: linux/amd64,linux/arm64
 
       # HELM
       - name: Get Helm chart version
@@ -68,6 +74,7 @@ jobs:
         run: |
           out="$(echo "${{ steps.auto_version.outputs.version }}" | sed 's/^v//1')"
           echo "helm_version=$out" >> $GITHUB_OUTPUT
+
       - name: Update Helm chart version
         uses: mikefarah/yq@master
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -133,7 +133,11 @@ jobs:
           cat changelog1 > charts/csi-wekafsplugin/CHANGELOG.md
           mv CHANGELOG.md RELEASE.md
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
       - uses: docker/setup-buildx-action@v3
+
       - uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
@@ -152,6 +156,7 @@ jobs:
             revision='${{ steps.set_version.outputs.version }}'
           build-args: |
             VERSION='${{ steps.set_version.outputs.version }}'
+          platforms: linux/amd64,linux/arm64
 
       - name: helm-docs
         uses: addnab/docker-run-action@v3

--- a/README.md.gotmpl
+++ b/README.md.gotmpl
@@ -14,6 +14,7 @@
 - Kubernetes cluster of version 1.20 or later is recommended. Minimum version is 1.17
 - Access to terminal with `kubectl` installed
 - Weka system pre-configured and Weka client installed and registered in cluster for each Kubernetes node
+- Both AMD64 and ARM64 platforms are supported
 
 ## Deployment
 - [Helm public repo](https://artifacthub.io/packages/helm/csi-wekafs/csi-wekafsplugin) (recommended)


### PR DESCRIPTION
### TL;DR

Added multi-architecture support for AMD64 and ARM64 platforms in Docker builds and updated GitHub Actions workflows.

### What changed?

- Added QEMU setup in GitHub Actions workflows for multi-architecture support
- Included `platforms: linux/amd64,linux/arm64` in Docker build steps
- Updated README to mention support for both AMD64 and ARM64 platforms
- Made minor formatting improvements in workflow files

### How to test?

1. Build the Docker image for both AMD64 and ARM64 platforms
2. Verify that the image can be pulled and run on both architectures
3. Deploy the Helm chart on a Kubernetes cluster with mixed AMD64 and ARM64 nodes
4. Ensure that the CSI driver functions correctly on both architectures

### Why make this change?

This change expands the compatibility of the CSI WekaFS Plugin to support ARM64 architecture, in addition to the existing AMD64 support. This allows for greater flexibility in deployment across different hardware platforms and cloud environments, potentially improving performance and cost-efficiency for users with ARM-based infrastructure.