### PR TITLE
feat(CSI-301): bump locar to version 0.4.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,17 @@
+ARG KUBECTL_VERSION=1.31.2
 FROM golang:1.22-alpine AS go-builder
+ARG TARGETARCH
+ARG TARGETOS
 # https://stackoverflow.com/questions/36279253/go-compiled-binary-wont-run-in-an-alpine-docker-container-on-ubuntu-host
 RUN apk add --no-cache libc6-compat gcc musl-dev
 COPY go.mod /src/go.mod
 COPY go.sum /src/go.sum
 WORKDIR /src
+ARG LOCAR_VERSION=0.4.3
+ADD --chmod=655 https://github.com/weka/locar/releases/download/$LOCAR_VERSION/locar-$LOCAR_VERSION-$TARGETOS-$TARGETARCH locar
 RUN go mod download
 ARG VERSION
-RUN echo Building binaries version $VERSION
+RUN echo Building binaries version $VERSION for architecture $TARGETARCH
 RUN echo Downloading required Go modules
 ADD go.mod /src/go.mod
 # Need to add true in between to avoid "failed to get layer"
@@ -19,15 +24,15 @@ RUN true
 ADD cmd /src/cmd
 RUN true
 
+
 RUN echo Building package
-RUN CGO_ENABLED=0 GOOS="linux" GOARCH="amd64" go build -a -ldflags '-X main.version='$VERSION' -extldflags "-static"' -o "/bin/wekafsplugin" /src/cmd/*
-FROM registry.k8s.io/kubernetes/kubectl:v1.31.2 AS kubectl
+RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -a -ldflags '-X main.version='$VERSION' -extldflags "-static"' -o "/bin/wekafsplugin" /src/cmd/*
+FROM registry.k8s.io/kubernetes/kubectl:v${KUBECTL_VERSION} AS kubectl
 
 FROM alpine:3.18
 LABEL maintainers="WekaIO, LTD"
 LABEL description="Weka CSI Driver"
 
-ADD --chmod=777 https://github.com/tigrawap/locar/releases/download/0.4.0/locar_linux_amd64 /locar
 RUN apk add --no-cache util-linux libselinux libselinux-utils util-linux  \
     pciutils usbutils coreutils binutils findutils  \
     grep bash nfs-utils rpcbind ca-certificates jq
@@ -35,6 +40,7 @@ RUN apk add --no-cache util-linux libselinux libselinux-utils util-linux  \
 RUN update-ca-certificates
 COPY --from=kubectl /bin/kubectl /bin/kubectl
 COPY --from=go-builder /bin/wekafsplugin /wekafsplugin
+COPY --from=go-builder /src/locar /locar
 ARG binary=/bin/wekafsplugin
 EXPOSE 2049 111/tcp 111/udp
 ENTRYPOINT ["/wekafsplugin"]

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ VERSION=$(shell cat charts/csi-wekafsplugin/Chart.yaml | grep appVersion | awk '
 DOCKER_IMAGE_NAME=csi-wekafs
 
 $(CMDS:%=build-%): build-%:
-	docker build --build-arg VERSION=$(VERSION) -t $(DOCKER_IMAGE_NAME):$(VERSION) -f Dockerfile --label revision=$(VERSION) .
+	docker buildx build --build-arg VERSION=$(VERSION) -t $(DOCKER_IMAGE_NAME):$(VERSION) -f Dockerfile --label revision=$(VERSION) .
 
 build: $(CMDS:%=build-%)
 


### PR DESCRIPTION
feat(CSI-300): change Makefile to use docker buildx

- Updated Makefile to use `docker buildx build` instead of `docker build`

feat(CSI-300): change Dockerfile to use TARGETOS, TARGETARCH, LOCAR_VERSION, KUBECTL_VERSION

- Added ARG instructions for KUBECTL_VERSION, TARGETARCH, TARGETOS, and LOCAR_VERSION
- Updated Go build command to use TARGETOS and TARGETARCH
- Changed kubectl image to use dynamic KUBECTL_VERSION
- Replaced hardcoded locar download with a more flexible approach using LOCAR_VERSION, TARGETOS, and TARGETARCH
- Moved locar binary copy from ADD instruction to COPY from go-builder stage