### PR TITLE
feat(CSI-303): add livenessProbe to attacher sidecar

### DIFF
--- a/charts/csi-wekafsplugin/templates/controllerserver-deployment.yaml
+++ b/charts/csi-wekafsplugin/templates/controllerserver-deployment.yaml
@@ -22,7 +22,7 @@ spec:
       annotations:
         prometheus.io/scrape: 'true'
         prometheus.io/path: '/metrics'
-        prometheus.io/port: '{{ .Values.metrics.controllerPort | default 9090 }},{{ .Values.metrics.provisionerPort | default 9091 }},{{ .Values.metrics.resizerPort | default 9092 }},{{ .Values.metrics.snapshotterPort | default 9093 }}'
+        prometheus.io/port: '{{ .Values.metrics.controllerPort | default 9090 }},{{ .Values.metrics.provisionerPort | default 9091 }},{{ .Values.metrics.resizerPort | default 9092 }},{{ .Values.metrics.snapshotterPort | default 9093 }},{{ .Values.metrics.attacherPort | default 9095 }}'
     {{- end }}
     spec:
       {{- if or .Values.controller.affinity .Values.affinity }}
@@ -176,15 +176,30 @@ spec:
             - "--csi-address=$(ADDRESS)"
             - "--v={{ .Values.logLevel | default 5 }}"
             - "--timeout=60s"
+            {{- if .Values.controller.configureAttacherLeaderElection }}
             - "--leader-election"
             - "--leader-election-namespace={{ .Release.Namespace }}"
+            {{- end }}
             - "--worker-threads={{ .Values.controller.maxConcurrentRequests }}"
+            {{- if or .Values.metrics.enabled .Values.controller.configureAttacherLeaderElection }}
+            - "--http-endpoint=:{{ .Values.metrics.attacherPort | default 9095 }}"
+            {{- end }}
           env:
             - name: ADDRESS
               value: unix:///csi/csi.sock
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+          {{- if .Values.controller.configureAttacherLeaderElection }}
+          livenessProbe:
+            httpGet:
+              port: {{ .Values.metrics.attacherPort | default 9095 }}
+              path: /healthz/leader-election
+          ports:
+            - containerPort: {{ .Values.metrics.attacherPort | default 9095 }}
+              name: pr-metrics
+              protocol: TCP
+          {{- end }}
         - name: csi-provisioner
           {{- if and .Values.hostNetwork (.Capabilities.APIVersions.Has "security.openshift.io/v1/SecurityContextConstraints") }}
           securityContext:

--- a/charts/csi-wekafsplugin/values.yaml
+++ b/charts/csi-wekafsplugin/values.yaml
@@ -69,6 +69,8 @@ controller:
   configureResizerLeaderElection: true
   # -- Configure snapshotter sidecar for leader election
   configureSnapshotterLeaderElection: true
+  # -- Configure attacher sidecar for leader election
+  configureAttacherLeaderElection: true
   # -- optional nodeSelector for controller components only
   nodeSelector: {}
   # -- optional affinity for controller components only
@@ -121,6 +123,8 @@ metrics:
   snapshotterPort: 9093
   # -- Metrics port for Node Serer
   nodePort: 9094
+  # -- Attacher metrics port
+  attacherPort: 9095
 # -- Tracing URL (For Jaeger tracing engine / OpenTelemetry), optional
 # @ignore
 tracingUrl: ""


### PR DESCRIPTION
### TL;DR

Added support for attacher metrics and leader election configuration in the CSI WekaFS plugin.

### What changed?

- Added `configureAttacherLeaderElection` option in the controller section of `values.yaml`
- Included attacher metrics port (default 9095) in the Prometheus annotations
- Updated the csi-attacher container configuration in the controller deployment:
  - Added conditional leader election flags
  - Added HTTP endpoint for metrics
  - Included liveness probe for leader election health check
- Added `attacherPort` (default 9095) to the metrics section in `values.yaml`

### How to test?

1. Deploy the chart with `controller.configureAttacherLeaderElection` set to true
2. Verify that the attacher container in the controller deployment has the leader election flags and liveness probe
3. Check if the Prometheus annotations include the attacher metrics port
4. Access the attacher metrics endpoint at `http://<pod-ip>:9095/metrics`

### Why make this change?

This change enhances the CSI WekaFS plugin by:
1. Allowing users to configure leader election for the attacher sidecar, improving high availability and fault tolerance
2. Exposing attacher metrics, enabling better monitoring and observability of the CSI plugin's performance
3. Providing a health check endpoint for the attacher's leader election, ensuring proper functioning in distributed environments