### PR TITLE
docs(CSI-300): improve documentation on ARM support and add links

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,10 @@ https://github.com/weka/csi-wekafs
 - Kubernetes cluster of version 1.20 or later is recommended. Minimum version is 1.17
 - Access to terminal with `kubectl` installed
 - Weka system pre-configured and Weka client installed and registered in cluster for each Kubernetes node
-- Both AMD64 and ARM64 platforms are supported
+- Starting with version 2.6.0 of WEKA CSI Plugin, both AMD64 and ARM64 platforms are supported.
+  > **NOTE**: For more information on WEKA client software support state of ARM64, please refer to the [WEKA documentation revision history](https://docs.weka.io/readme/documentation-revision-history).
+  >
+  > On platforms not currently supported by WEKA software, NFS failback mode can be used. For additional information on NFS transport configuration, please refer to the [NFS documentation](docs/NFS.md)
 
 ## Deployment
 - [Helm public repo](https://artifacthub.io/packages/helm/csi-wekafs/csi-wekafsplugin) (recommended)

--- a/README.md.gotmpl
+++ b/README.md.gotmpl
@@ -14,7 +14,10 @@
 - Kubernetes cluster of version 1.20 or later is recommended. Minimum version is 1.17
 - Access to terminal with `kubectl` installed
 - Weka system pre-configured and Weka client installed and registered in cluster for each Kubernetes node
-- Both AMD64 and ARM64 platforms are supported
+- Starting with version 2.6.0 of WEKA CSI Plugin, both AMD64 and ARM64 platforms are supported.
+  > **NOTE**: For more information on WEKA client software support state of ARM64, please refer to the [WEKA documentation revision history](https://docs.weka.io/readme/documentation-revision-history).
+  >
+  > On platforms not currently supported by WEKA software, NFS failback mode can be used. For additional information on NFS transport configuration, please refer to the [NFS documentation](docs/NFS.md)
 
 ## Deployment
 - [Helm public repo](https://artifacthub.io/packages/helm/csi-wekafs/csi-wekafsplugin) (recommended)


### PR DESCRIPTION
### TL;DR
Added clarification about ARM64 platform support and NFS failback mode in the README

### What changed?
- Updated platform support documentation to specify that ARM64 support starts from version 2.6.0
- Added reference to WEKA documentation for ARM64 support status
- Introduced information about NFS failback mode for unsupported platforms
- Added link to NFS documentation for transport configuration

### How to test?
1. Review the updated README.md
2. Verify links to documentation are working:
   - WEKA documentation revision history
   - NFS documentation

### Why make this change?
To provide clearer guidance about platform compatibility and offer alternative solutions through NFS failback mode for users on unsupported platforms. This helps users better understand their deployment options based on their infrastructure.