### PR TITLE
feat(CSI-310): drop container_name mount option from volume context

### DIFF
--- a/pkg/wekafs/controllerserver.go
+++ b/pkg/wekafs/controllerserver.go
@@ -262,7 +262,8 @@ func (cs *ControllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 	volExists, volMatchesCapacity, err := volumeExistsAndMatchesCapacity(ctx, volume, capacity)
 
 	// set params to have all relevant mount options (default + those received in params) to be passed as part of volumeContext
-	params["mountOptions"] = volume.getMountOptions(ctx).String()
+	// omit the container_name though as it should only be set via API secret and not via mount options
+	params["mountOptions"] = volume.getMountOptions(ctx).AsVolumeContext()
 
 	if err != nil {
 		if !volExists {

--- a/pkg/wekafs/mountoptions.go
+++ b/pkg/wekafs/mountoptions.go
@@ -8,19 +8,21 @@ import (
 )
 
 const (
-	selinuxContextWekaFs   = "wekafs_csi_volume_t"
-	selinuxContextNfs      = "nfs_t"
-	MountOptionSyncOnClose = "sync_on_close"
-	MountOptionReadOnly    = "ro"
-	MountOptionWriteCache  = "writecache"
-	MountOptionCoherent    = "coherent"
-	MountOptionNfsAsync    = "async"
-	MountOptionNfsHard     = "hard"
-	MountOptionNfsRdirPlus = "rdirplus"
-	MountOptionReadCache   = "readcache"
-	MountProtocolWekafs    = "wekafs"
-	MountProtocolNfs       = "nfs"
-	DefaultNfsMountOptions = MountOptionNfsHard + "," + MountOptionNfsAsync + "," + MountOptionNfsRdirPlus
+	selinuxContextWekaFs     = "wekafs_csi_volume_t"
+	selinuxContextNfs        = "nfs_t"
+	MountOptionSyncOnClose   = "sync_on_close"
+	MountOptionReadOnly      = "ro"
+	MountOptionWriteCache    = "writecache"
+	MountOptionCoherent      = "coherent"
+	MountOptionContainerName = "container_name"
+	MountOptionAcl           = "acl"
+	MountOptionNfsAsync      = "async"
+	MountOptionNfsHard       = "hard"
+	MountOptionNfsRdirPlus   = "rdirplus"
+	MountOptionReadCache     = "readcache"
+	MountProtocolWekafs      = "wekafs"
+	MountProtocolNfs         = "nfs"
+	DefaultNfsMountOptions   = MountOptionNfsHard + "," + MountOptionNfsAsync + "," + MountOptionNfsRdirPlus
 )
 
 type mountOption struct {
@@ -165,6 +167,15 @@ func (opts MountOptions) AsMapKey() string {
 	ret := opts
 	// TODO: if adding any other version-agnostic options, add them here
 	excludedOpts := []string{MountOptionSyncOnClose}
+	for _, o := range excludedOpts {
+		ret = ret.RemoveOption(o)
+	}
+	return ret.String()
+}
+
+func (opts MountOptions) AsVolumeContext() string {
+	ret := opts
+	excludedOpts := []string{MountOptionSyncOnClose, MountOptionContainerName}
 	for _, o := range excludedOpts {
 		ret = ret.RemoveOption(o)
 	}

--- a/pkg/wekafs/nodeserver.go
+++ b/pkg/wekafs/nodeserver.go
@@ -290,6 +290,7 @@ func (ns *NodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 		if mountOptions, ok := params["mountOptions"]; ok {
 			logger.Trace().Str("mount_options", mountOptions).Msg("Updating volume mount options")
 			volume.setMountOptions(ctx, NewMountOptionsFromString(mountOptions))
+			volume.pruneUnsupportedMountOptions(ctx)
 		}
 	}
 

--- a/pkg/wekafs/volume.go
+++ b/pkg/wekafs/volume.go
@@ -102,6 +102,10 @@ func (v *Volume) pruneUnsupportedMountOptions(ctx context.Context) {
 		logger.Error().Str("mount_option", MountOptionReadOnly).Msg("Mount option is not supported via custom mount options, use readOnly volume attachments instead")
 		v.mountOptions = v.mountOptions.RemoveOption(MountOptionReadOnly)
 	}
+	if v.mountOptions.hasOption(MountOptionContainerName) {
+		logger.Error().Str("mount_option", MountOptionContainerName).Msg("Mount option is not supported via custom mount options, container name should only be set via API secret")
+		v.mountOptions = v.mountOptions.RemoveOption(MountOptionContainerName)
+	}
 }
 
 //goland:noinspection GoUnusedParameter

--- a/pkg/wekafs/volumeconstructors.go
+++ b/pkg/wekafs/volumeconstructors.go
@@ -97,6 +97,9 @@ func NewVolumeFromControllerCreateRequest(ctx context.Context, req *csi.CreateVo
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Could not obtain volume parameters from request")
 	}
+
+	volume.pruneUnsupportedMountOptions(ctx)
+
 	logger.Trace().Object("volume_info", volume).Str("origin", origin).Msg("Successfully initialized object")
 	return volume, nil
 }


### PR DESCRIPTION
feat(CSI-310): drop container_name mount option from volume context

Prevents container_name from being propagated via volume context and removes it if explicitly set in StorageClass mountOptions. The container_name parameter should only be set via API secret.

feat(CSI-310): drop container_name mount option from volume context

feat(CSI-310): drop container_name if explicitly set in SC mountOptions