### PR TITLE
feat(CSI-311): add CSI driver version used for provisioning a PV into volumeContext

### DIFF
--- a/cmd/wekafsplugin/main.go
+++ b/cmd/wekafsplugin/main.go
@@ -227,6 +227,7 @@ func handle() {
 		*interfaceGroupName,
 		*clientGroupName,
 		*nfsProtocolVersion,
+		version,
 	)
 	driver, err := wekafs.NewWekaFsDriver(
 		*driverName, *nodeID, *endpoint, *maxVolumesPerNode, version, *debugPath, csiMode, *selinuxSupport, config)

--- a/pkg/wekafs/controllerserver.go
+++ b/pkg/wekafs/controllerserver.go
@@ -264,6 +264,7 @@ func (cs *ControllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 	// set params to have all relevant mount options (default + those received in params) to be passed as part of volumeContext
 	// omit the container_name though as it should only be set via API secret and not via mount options
 	params["mountOptions"] = volume.getMountOptions(ctx).AsVolumeContext()
+	params["provisionedByCsiVersion"] = cs.getConfig().GetVersion()
 
 	if err != nil {
 		if !volExists {

--- a/pkg/wekafs/driverconfig.go
+++ b/pkg/wekafs/driverconfig.go
@@ -38,6 +38,7 @@ type DriverConfig struct {
 	interfaceGroupName            string
 	clientGroupName               string
 	nfsProtocolVersion            string
+	csiVersion                    string
 }
 
 func (dc *DriverConfig) Log() {
@@ -72,6 +73,7 @@ func NewDriverConfig(dynamicVolPath, VolumePrefix, SnapshotPrefix, SeedSnapshotP
 	allowProtocolContainers bool,
 	allowNfsFailback, useNfs bool,
 	interfaceGroupName, clientGroupName, nfsProtocolVersion string,
+	version string,
 ) *DriverConfig {
 
 	var MutuallyExclusiveMountOptions []mutuallyExclusiveMountOptionSet
@@ -116,9 +118,14 @@ func NewDriverConfig(dynamicVolPath, VolumePrefix, SnapshotPrefix, SeedSnapshotP
 		interfaceGroupName:            interfaceGroupName,
 		clientGroupName:               clientGroupName,
 		nfsProtocolVersion:            nfsProtocolVersion,
+		csiVersion:                    version,
 	}
 }
 
 func (dc *DriverConfig) isInDevMode() bool {
 	return dc.debugPath != ""
+}
+
+func (dc *DriverConfig) GetVersion() string {
+	return dc.csiVersion
 }


### PR DESCRIPTION
### TL;DR
Added CSI driver version tracking to provisioned volumes

### What changed?
- Added CSI version to volume context during volume creation
- Introduced version tracking in driver configuration
- Exposed version information through new `GetVersion()` method

### How to test?
1. Deploy the CSI driver
2. Create a new PVC
3. Verify that the provisioned volume includes the `provisionedByCsiVersion` parameter in its volume context

### Why make this change?
This change enables tracking which CSI driver version was used to provision volumes, making it easier to troubleshoot version-specific issues and manage volume compatibility across driver updates.