### PR TITLE
chore(deps): add labels to CSI Docker image

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -56,6 +56,8 @@ jobs:
           labels: |
             revision=${{ steps.auto_version.outputs.version }}
             quay.expires-after=14d
+            version=${{ steps.auto_version.outputs.version }}
+            release=${{ steps.auto_version.outputs.version }}
           provenance: false # https://issues.redhat.com/browse/PROJQUAY-5013 quay doesn't support it
           build-args: |
             VERSION='${{ steps.auto_version.outputs.version }}'

--- a/.github/workflows/push-dev.yaml
+++ b/.github/workflows/push-dev.yaml
@@ -62,6 +62,8 @@ jobs:
           cache-to: type=gha,mode=max
           labels: |
             revision=${{ steps.auto_version.outputs.version }}
+            version=${{ steps.auto_version.outputs.version }}
+            release=${{ steps.auto_version.outputs.version }}
             quay.expires-after=14d
           provenance: false # https://issues.redhat.com/browse/PROJQUAY-5013 quay doesn't support it
           build-args: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -149,6 +149,9 @@ jobs:
           cache-to: type=gha,mode=max
           labels: |
             revision='${{ steps.set_version.outputs.version }}'
+            version=${{ steps.set_version.outputs.version }}
+            release=${{ steps.set_version.outputs.version }}
+
           build-args: |
             VERSION='${{ steps.set_version.outputs.version }}'
           platforms: linux/amd64,linux/arm64

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,12 @@ LABEL description="Weka CSI Driver"
 RUN dnf install -y util-linux libselinux-utils pciutils binutils jq procps less
 RUN mkdir -p /licenses
 COPY LICENSE /licenses
+LABEL maintainer="csi@weka.io"
+LABEL name="WEKA CSI Plugin"
+LABEL vendor="weka.io"
+LABEL summary="This image is used by WEKA CSI Plugin and incorporates both Controller and Node modules"
+LABEL description="Container Storage Interface (CSI) plugin for WEKA - the data platform for AI"
+LABEL url="https://www.weka.io"
 COPY --from=kubectl /bin/kubectl /bin/kubectl
 COPY --from=go-builder /bin/wekafsplugin /wekafsplugin
 COPY --from=go-builder /src/locar /locar


### PR DESCRIPTION
### TL;DR
Added standardized container labels and version metadata to container images

### What changed?
- Added version and release labels to container images in GitHub workflows
- Enhanced Dockerfile with standardized labels including maintainer, name, vendor, summary, description, and URL
- Maintained existing revision and expiration labels

### How to test?
1. Build the container image
2. Inspect the image labels using `docker inspect <image>`
3. Verify all new labels are present and populated correctly:
   - version
   - release
   - maintainer
   - name
   - vendor
   - summary
   - description
   - url

### Why make this change?
Standardized container labels improve container discoverability, provide better metadata for container registries, and ensure consistent versioning information across deployments. This helps with container management, auditing, and compliance requirements.