### PR TITLE
refactor(CSI-272): move NFS client registration to APIClient startup rather than on each mount

### DIFF
--- a/pkg/wekafs/apiclient/interfacegroup.go
+++ b/pkg/wekafs/apiclient/interfacegroup.go
@@ -188,7 +188,7 @@ func (a *ApiClient) GetNfsInterfaceGroup(ctx context.Context, name string) *Inte
 
 // GetNfsMountIp returns the IP address of the NFS interface group to be used for NFS mount
 // TODO: need to do it much more sophisticated way to distribute load
-func (a *ApiClient) GetNfsMountIp(ctx context.Context, interfaceGroupName string) (string, error) {
+func (a *ApiClient) GetNfsMountIp(ctx context.Context) (string, error) {
 	// if override is set, use it
 	if len(a.Credentials.NfsTargetIPs) > 0 && a.Credentials.NfsTargetIPs[0] != "" {
 		ips := a.Credentials.NfsTargetIPs
@@ -197,7 +197,7 @@ func (a *ApiClient) GetNfsMountIp(ctx context.Context, interfaceGroupName string
 		return ip, nil
 	}
 
-	ig := a.GetNfsInterfaceGroup(ctx, interfaceGroupName)
+	ig := a.GetNfsInterfaceGroup(ctx, a.NfsInterfaceGroupName)
 	if ig == nil {
 		return "", errors.New("no NFS interface group found")
 	}

--- a/pkg/wekafs/apiclient/interfacegroup_test.go
+++ b/pkg/wekafs/apiclient/interfacegroup_test.go
@@ -32,12 +32,12 @@ func TestGetNfsMountIp(t *testing.T) {
 	// Mock GetInterfaceGroupsByType method
 
 	// Test case: Valid interface group
-	ip, err := apiClient.GetNfsMountIp(context.Background(), "")
+	ip, err := apiClient.GetNfsMountIp(context.Background())
 	assert.NoError(t, err)
 	assert.NotEmpty(t, ip)
 
 	// Test case: Valid interface group
-	ip, err = apiClient.GetNfsMountIp(context.Background(), "NFS")
+	ip, err = apiClient.GetNfsMountIp(context.Background())
 	assert.NoError(t, err)
 	assert.NotEmpty(t, ip)
 

--- a/pkg/wekafs/apiclient/nfs.go
+++ b/pkg/wekafs/apiclient/nfs.go
@@ -473,26 +473,26 @@ func (a *ApiClient) CreateNfsClientGroup(ctx context.Context, r *NfsClientGroupC
 	return err
 }
 
-func (a *ApiClient) EnsureCsiPluginNfsClientGroup(ctx context.Context, clientGroupName string) (grp *NfsClientGroup, created bool, err error) {
+func (a *ApiClient) EnsureCsiPluginNfsClientGroup(ctx context.Context) (grp *NfsClientGroup, created bool, err error) {
 	op := "EnsureCsiPluginNfsClientGroup"
 	ctx, span := otel.Tracer(TracerName).Start(ctx, op)
 	defer span.End()
 	ctx = log.With().Str("trace_id", span.SpanContext().TraceID().String()).Str("span_id", span.SpanContext().SpanID().String()).Str("op", op).Logger().WithContext(ctx)
 	logger := log.Ctx(ctx)
 	var ret *NfsClientGroup
-	if clientGroupName == "" {
-		clientGroupName = NfsClientGroupName
+	if a.NfsClientGroupName == "" {
+		a.NfsClientGroupName = NfsClientGroupName
 	}
-	logger.Trace().Str("client_group_name", clientGroupName).Msg("Getting client group by name")
-	ret, err = a.GetNfsClientGroupByName(ctx, clientGroupName)
+	logger.Trace().Str("client_group_name", a.NfsClientGroupName).Msg("Getting client group by name")
+	ret, err = a.GetNfsClientGroupByName(ctx, a.NfsClientGroupName)
 	if err != nil {
 		if err != ObjectNotFoundError {
 			logger.Error().Err(err).Msg("Failed to get client group by name")
 			return ret, false, err
 		} else {
-			logger.Trace().Str("client_group_name", clientGroupName).Msg("Existing client group not found, creating client group")
+			logger.Trace().Str("client_group_name", a.NfsClientGroupName).Msg("Existing client group not found, creating client group")
 
-			err = a.CreateNfsClientGroup(ctx, NewNfsClientGroupCreateRequest(clientGroupName), ret)
+			err = a.CreateNfsClientGroup(ctx, NewNfsClientGroupCreateRequest(a.NfsClientGroupName), ret)
 			return ret, err == nil, nil
 		}
 	}
@@ -655,12 +655,12 @@ func (r *NfsClientGroupRule) IsEligibleForIP(ip string) bool {
 	return network.ContainsIPAddress(ip)
 }
 
-func (a *ApiClient) GetNfsClientGroupRules(ctx context.Context, clientGroupName string, rules *[]NfsClientGroupRule) error {
+func (a *ApiClient) GetNfsClientGroupRules(ctx context.Context, rules *[]NfsClientGroupRule) error {
 	op := "GetNfsClientGroupRules"
 	ctx, span := otel.Tracer(TracerName).Start(ctx, op)
 	defer span.End()
 	ctx = log.With().Str("trace_id", span.SpanContext().TraceID().String()).Str("span_id", span.SpanContext().SpanID().String()).Str("op", op).Logger().WithContext(ctx)
-	cg, _, err := a.EnsureCsiPluginNfsClientGroup(ctx, clientGroupName)
+	cg, _, err := a.EnsureCsiPluginNfsClientGroup(ctx)
 	if err != nil {
 		return err
 	}
@@ -821,7 +821,7 @@ func (a *ApiClient) EnsureNfsClientGroupRuleForIp(ctx context.Context, cg *NfsCl
 	return false, err
 }
 
-func (a *ApiClient) EnsureNfsPermissions(ctx context.Context, ip string, fsName string, version NfsVersionString, clientGroupName string) error {
+func (a *ApiClient) EnsureNfsPermissions(ctx context.Context, fsName string, version NfsVersionString, clientGroupName string) error {
 	op := "EnsureNfsPermissions"
 	ctx, span := otel.Tracer(TracerName).Start(ctx, op)
 	defer span.End()
@@ -834,29 +834,16 @@ func (a *ApiClient) EnsureNfsPermissions(ctx context.Context, ip string, fsName 
 	}
 	var created bool
 
-	logger.Debug().Str("ip", ip).Str("filesystem", fsName).Str("client_group_name", clientGroupCaption).Msg("Ensuring NFS permissions")
-	// Ensure client group
-	logger.Trace().Msg("Ensuring CSI Plugin NFS Client Group")
-	cg, created, err := a.EnsureCsiPluginNfsClientGroup(ctx, clientGroupName)
+	cg, err := a.GetNfsClientGroupByName(ctx, clientGroupCaption)
 	if err != nil {
-		logger.Error().Err(err).Msg("Failed to ensure NFS client group")
+		logger.Error().Err(err).Str("client_group_name", clientGroupCaption).Msg("Failed to get NFS client group by name")
 		return err
 	}
-	updateConfigRequired = updateConfigRequired || created
 
-	// Ensure client group rule
-	logger.Trace().Str("ip_address", ip).Msg("Ensuring NFS Client Group Rule for IP")
-	created, err = a.EnsureNfsClientGroupRuleForIp(ctx, cg, ip)
-	if err != nil {
-		logger.Error().Err(err).Str("ip_address", ip).Msg("Failed to ensure NFS client group rule for IP")
-		return err
-	}
-	updateConfigRequired = updateConfigRequired || created
 	// Ensure NFS permission
 	logger.Trace().Str("filesystem", fsName).Str("client_group", cg.Name).Msg("Ensuring NFS Export for client group")
 	created, err = EnsureNfsPermission(ctx, fsName, cg.Name, version, a)
-	updateConfigRequired = updateConfigRequired || created
-	if updateConfigRequired {
+	if created {
 		logger.Trace().Msg("Waiting for NFS configuration to be applied")
 		time.Sleep(5 * time.Second)
 	}

--- a/pkg/wekafs/apiclient/nfs_test.go
+++ b/pkg/wekafs/apiclient/nfs_test.go
@@ -214,14 +214,16 @@ func TestNfsClientGroup(t *testing.T) {
 
 func TestEnsureCsiPluginNfsClientGroup(t *testing.T) {
 	apiClient := GetApiClientForTest(t)
-	result, _, err := apiClient.EnsureCsiPluginNfsClientGroup(context.Background(), NfsClientGroupName)
+	ctx := context.Background()
+	result, _, err := apiClient.EnsureCsiPluginNfsClientGroup(ctx)
 	assert.NoError(t, err)
 	assert.NotNil(t, result)
 }
 
 func TestNfsClientGroupRules(t *testing.T) {
 	apiClient := GetApiClientForTest(t)
-	cg, _, err := apiClient.EnsureCsiPluginNfsClientGroup(context.Background(), NfsClientGroupName)
+	ctx := context.Background()
+	cg, _, err := apiClient.EnsureCsiPluginNfsClientGroup(ctx)
 	assert.NoError(t, err)
 	assert.NotNil(t, cg)
 
@@ -247,7 +249,7 @@ outerLoop:
 		assert.NoError(t, err)
 	}
 	rules := &[]NfsClientGroupRule{}
-	err = apiClient.GetNfsClientGroupRules(context.Background(), NfsClientGroupName, rules)
+	err = apiClient.GetNfsClientGroupRules(ctx, rules)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, rules)
 	for _, rule := range *rules {
@@ -262,7 +264,8 @@ func TestNfsEnsureNfsPermissions(t *testing.T) {
 	apiClient := GetApiClientForTest(t)
 
 	// Test EnsureNfsPermission
-	err := apiClient.EnsureNfsPermissions(context.Background(), "172.16.5.147", "default", NfsVersionV4, NfsClientGroupName)
+	ctx := context.Background()
+	err := apiClient.EnsureNfsPermissions(ctx, "default", NfsVersionV4, NfsClientGroupName)
 	assert.NoError(t, err)
 }
 

--- a/pkg/wekafs/nfsmounter.go
+++ b/pkg/wekafs/nfsmounter.go
@@ -18,7 +18,6 @@ type nfsMounter struct {
 	debugPath             string
 	selinuxSupport        *bool
 	gc                    *innerPathVolGc
-	interfaceGroupName    string
 	clientGroupName       string
 	nfsProtocolVersion    string
 	exclusiveMountOptions []mutuallyExclusiveMountOptionSet
@@ -38,7 +37,6 @@ func newNfsMounter(driver *WekaFsDriver) *nfsMounter {
 	mounter.gc = initInnerPathVolumeGc(mounter)
 	mounter.gc.config = driver.config
 	mounter.schedulePeriodicMountGc()
-	mounter.interfaceGroupName = driver.config.interfaceGroupName
 	mounter.clientGroupName = driver.config.clientGroupName
 	mounter.nfsProtocolVersion = driver.config.nfsProtocolVersion
 
@@ -51,15 +49,14 @@ func (m *nfsMounter) NewMount(fsName string, options MountOptions) AnyMount {
 	}
 	uniqueId := getStringSha1AsB32(fsName + ":" + options.String())
 	wMount := &nfsMount{
-		mounter:            m,
-		kMounter:           m.kMounter,
-		fsName:             fsName,
-		debugPath:          m.debugPath,
-		mountPoint:         "/run/weka-fs-mounts/" + getAsciiPart(fsName, 64) + "-" + uniqueId,
-		mountOptions:       options,
-		interfaceGroupName: m.interfaceGroupName,
-		clientGroupName:    m.clientGroupName,
-		protocolVersion:    apiclient.NfsVersionString(fmt.Sprintf("V%s", m.nfsProtocolVersion)),
+		mounter:         m,
+		kMounter:        m.kMounter,
+		fsName:          fsName,
+		debugPath:       m.debugPath,
+		mountPoint:      "/run/weka-fs-mounts/" + getAsciiPart(fsName, 64) + "-" + uniqueId,
+		mountOptions:    options,
+		clientGroupName: m.clientGroupName,
+		protocolVersion: apiclient.NfsVersionString(fmt.Sprintf("V%s", m.nfsProtocolVersion)),
 	}
 	return wMount
 }


### PR DESCRIPTION
### TL;DR
Refactored NFS client group registration and management to improve performance and reduce API calls

### What changed?
- Added `NfsInterfaceGroupName` and `NfsClientGroupName` fields to ApiClient struct
- Introduced new `RegisterNfsClientGroup` method to handle NFS client registration
- Simplified NFS mount IP retrieval by removing redundant parameter
- Moved NFS client group registration logic to API client initialization
- Updated related test cases to reflect new structure

### How to test?
1. Clean up the WEKA cluster to make sure no CSI NFS ClientGroup exists.
2. Deploy CSI driver with NFS enabled
3. Create a PVC
4. Verify NFS client group is automatically registered
5. Verify mount operations succeed with proper permissions
5. Run updated test suite: `TestNfsClientGroup`, `TestEnsureCsiPluginNfsClientGroup`, and `TestNfsClientGroupRules`

### Why make this change?
The previous implementation had performed NFS client group registration attempt on each mount, causing lots of redundant API calls and reducing overall performance of volume provisioning and publishing. This change breaks the process into 2 parts:
1. Plugin registration in client group is performed during API client initialization (only on first volume create / publish (ensure client group and add the node IP address to client group)
2. ensure client group permission while NFS permission is ensured during mount (match between client group and filesystem) on each mount