### PR TITLE
feat(CSI-315): partial support of encrypted volumes for FS backing

### DIFF
--- a/charts/csi-wekafsplugin/templates/NOTES.txt
+++ b/charts/csi-wekafsplugin/templates/NOTES.txt
@@ -43,3 +43,12 @@ https://github.com/weka/csi-wekafs/tree/master/examples
 | REFER TO WEKA CUSTOMER SUCCESS TEAM FOR RECOMMENDED CONFIGURATION AND BEST PRACTICES                     |
 ------------------------------------------------------------------------------------------------------------
 {{- end }}
+{{- if .Values.pluginConfig.encryption.allowEncryptionWithoutKms }}
+
+-------------------------------------------------- WARNING -------------------------------------------------
+| WARNING: FILESYSTEM ENCRYPTION IS ALLOWED WITHOUT KMS SERVER CONFIGURATION.                              |
+| THIS CONFIGURATION IS STRONGLY DISCOURAGED AND SHOULD BE USED FOR TESTING PURPOSES ONLY.                 |
+| RUNNING PRODUCTION WORKLOADS WITH FILESYSTEMS ENCRYPTED WITHOUT A KMS SERVER CONFIGURED ON WEKA CLUSTER  |
+| IS NOT CONSIDERED SECURE, NOT SUPPORTED AND MAY LEAD TO DATA LOSS IN CASE OF A CLUSTER RECOVERY          |
+------------------------------------------------------------------------------------------------------------
+{{- end }}

--- a/charts/csi-wekafsplugin/templates/controllerserver-deployment.yaml
+++ b/charts/csi-wekafsplugin/templates/controllerserver-deployment.yaml
@@ -126,6 +126,9 @@ spec:
           {{- if (.Values.pluginConfig.waitForObjectDeletion | default false) }}
             - "--waitforobjectdeletion"
           {{- end }}
+          {{- if .Values.pluginConfig.encryption.allowEncryptionWithoutKms}}
+            - "--allowencryptionwithoutkms"
+          {{- end}}
           ports:
             - containerPort: 9898
               name: healthz

--- a/charts/csi-wekafsplugin/values.yaml
+++ b/charts/csi-wekafsplugin/values.yaml
@@ -171,6 +171,10 @@ pluginConfig:
     - "readcache,writecache,coherent,forcedirect"
     - "sync,async"
     - "ro,rw"
+  encryption:
+    # -- Allow encryption of Weka filesystems associated with CSI volumes without using external KMS server.
+    #    Should never be run in production, only for testing purposes
+    allowEncryptionWithoutKms: false
   mountProtocol:
     # -- Use NFS transport for mounting Weka filesystems, off by default
     useNfs: false

--- a/cmd/wekafsplugin/main.go
+++ b/cmd/wekafsplugin/main.go
@@ -98,6 +98,7 @@ var (
 	nfsProtocolVersion                   = flag.String("nfsprotocolversion", "4.1", "NFS protocol version to use for mounting volumes")
 	skipGarbageCollection                = flag.Bool("skipgarbagecollection", false, "Skip garbage collection of directory volumes data, only move to trash")
 	waitForObjectDeletion                = flag.Bool("waitforobjectdeletion", false, "Wait for object deletion before returning from DeleteVolume")
+	allowEncryptionWithoutKms            = flag.Bool("allowencryptionwithoutkms", false, "Allow encryption without KMS, for testing purposes only")
 	// Set by the build process
 	version = ""
 )
@@ -232,6 +233,7 @@ func handle() {
 		version,
 		*skipGarbageCollection,
 		*waitForObjectDeletion,
+		*allowEncryptionWithoutKms,
 	)
 	driver, err := wekafs.NewWekaFsDriver(
 		*driverName, *nodeID, *endpoint, *maxVolumesPerNode, version, *debugPath, csiMode, *selinuxSupport, config)

--- a/examples/dynamic_filesystem_encrypted/README.md
+++ b/examples/dynamic_filesystem_encrypted/README.md
@@ -1,0 +1,36 @@
+# Overview
+## Example Intentions
+1. This example concentrates on Weka Filesystem-backed volume backed by Encrypted filesystem
+2. Filesystem is provisioned automatically when volume is created, and encryption is enabled for the filesystem
+
+## Configuration Requirements
+This example introduces automatic provisioning of encrypted filesystems. 
+For this functionality to work, the WEKA cluster must be configured with a valid KMS server.
+If KMS server is not configured, volume will not be created and the following error will be displayed:
+```
+Encryption is not enabled on the cluster
+```
+If WEKA cluster does not support encryption of filesystems, the following error will be displayed:
+```
+Encryption is not supported on the cluster
+```
+
+> **NOTE:** Encryption is only supported for filesystem-backed volumes
+
+## StorageClass Highlights
+- Refer to highlights described in [../dynamic_filesystem/storageclass-wekafs-api.yaml]
+- Storage class includes a parameter `parameters.encryption` that defines whether the filesystem should be encrypted or not. This is a string and not boolean
+    - `true` - filesystem is encrypted using WEKA-managed encryption keys.
+    - `false` - filesystem is not encrypted
+- Storage class includes a parameter `parameters.manageEncryptionKeys` that is currently not supported. This parameter is reserved for future use
+
+## Notes regarding object deletion:
+1. Filesystem-backed volume maps directly to Weka filesystem. 
+2. Filesystem is encrypted
+
+# Workflow
+> All commands below may be executed by `kubectl apply -f <FILE>.yaml`
+1. Create storageclass `storageclass-wekafs-fs-encrypted-api`
+2. Create CSI secret `csi-wekafs-api-secret`  (Located in [../common/csi-wekafs-api-secret.yaml](../common/csi-wekafs-api-secret.yaml)) 
+3. Provision a new filesystem volume `pvc-wekafs-fs-encrypted-api`
+4. Create a pod `csi-app-on-fs-encrypted-api` that uses the volume

--- a/examples/dynamic_filesystem_encrypted/README.md
+++ b/examples/dynamic_filesystem_encrypted/README.md
@@ -15,18 +15,19 @@ If WEKA cluster does not support encryption of filesystems, the following error 
 Encryption is not supported on the cluster
 ```
 
-> **NOTE:** Encryption is only supported for filesystem-backed volumes
+## Example Highlights
+1. Encryption is only supported for filesystem-backed volumes.
+2. Volumes created from snapshots or directories inherit the encryption setting from the underlying filesystem.
+3. However, if encryption is enabled in storageClass, the driver will validate that the underlying filesystem is encrypted.
+   If the filesystem does not have encryption enabled, an appropriate error will be returned.
+4. The configuration of the KMS server is not part of this example. Please refer to the Weka documentation for more information.
 
 ## StorageClass Highlights
 - Refer to highlights described in [../dynamic_filesystem/storageclass-wekafs-api.yaml]
-- Storage class includes a parameter `parameters.encryption` that defines whether the filesystem should be encrypted or not. This is a string and not boolean
-    - `true` - filesystem is encrypted using WEKA-managed encryption keys.
-    - `false` - filesystem is not encrypted
-- Storage class includes a parameter `parameters.manageEncryptionKeys` that is currently not supported. This parameter is reserved for future use
-
-## Notes regarding object deletion:
-1. Filesystem-backed volume maps directly to Weka filesystem. 
-2. Filesystem is encrypted
+- Storage class includes a parameter `parameters.encryptionEnabled` that defines whether the filesystem should be encrypted or not. 
+  This is a string and not boolean.
+    - `"true"` - filesystem is encrypted using WEKA-managed encryption keys.
+    - `"false"` - filesystem is not encrypted
 
 # Workflow
 > All commands below may be executed by `kubectl apply -f <FILE>.yaml`
@@ -34,3 +35,13 @@ Encryption is not supported on the cluster
 2. Create CSI secret `csi-wekafs-api-secret`  (Located in [../common/csi-wekafs-api-secret.yaml](../common/csi-wekafs-api-secret.yaml)) 
 3. Provision a new filesystem volume `pvc-wekafs-fs-encrypted-api`
 4. Create a pod `csi-app-on-fs-encrypted-api` that uses the volume
+5. Create application that writes timestamp every 10 seconds into `/data/temp.txt`: `csi-app-on-fs-encrypted-api`
+6. Create a snapshot of the PVC: `snapshot-pvc-wekafs-fs-encrypted-api`
+7. Create a new volume from snapshot: `pvc-wekafs-fs-snapshot-encrypted-api`
+8. Create application that tails content of `/data/temp.txt` from volume created from snapshot: `csi-app-on-fs-snapshot-encrypted-api`
+  - the file should exist and be accessible
+  - the latest timestamp you are expected to see is the timestamp just before creation of snapshot
+9. Create a new volume straight from original volume (e.g. clone volume): `pvc-wekafs-fs-clone-encrypted-api`
+10. Create application that tails content of `/data/temp.txt` from volume created from snapshot: `csi-app-on-fs-clone-encrypted-api`
+  - the file should exist and be accessible
+  - the latest timestamp you are expected to see is the timestamp just before volume cloning

--- a/examples/dynamic_filesystem_encrypted/csi-app-on-fs-clone-encrypted-api.yaml
+++ b/examples/dynamic_filesystem_encrypted/csi-app-on-fs-clone-encrypted-api.yaml
@@ -1,0 +1,20 @@
+kind: Pod
+apiVersion: v1
+metadata:
+  name: csi-app-on-fs-clone-encrypted-api
+spec:
+  # make sure that pod is scheduled only on node having weka CSI node running
+  nodeSelector:
+    topology.csi.weka.io/global: "true"
+  containers:
+    - name: my-frontend
+      image: busybox
+      volumeMounts:
+      - mountPath: "/data"
+        name: my-csi-volume
+      command: ["/bin/sh"]
+      args: ["-c", "tail -F /data/temp.txt"]
+  volumes:
+    - name: my-csi-volume
+      persistentVolumeClaim:
+        claimName: pvc-wekafs-fs-clone-encrypted-api

--- a/examples/dynamic_filesystem_encrypted/csi-app-on-fs-encrypted-api.yaml
+++ b/examples/dynamic_filesystem_encrypted/csi-app-on-fs-encrypted-api.yaml
@@ -1,0 +1,20 @@
+kind: Pod
+apiVersion: v1
+metadata:
+  name: csi-app-on-fs-encrypted-api
+spec:
+  # make sure that pod is scheduled only on node having weka CSI node running
+  nodeSelector:
+    topology.csi.weka.io/global: "true"
+  containers:
+    - name: my-frontend
+      image: ubuntu
+      volumeMounts:
+      - mountPath: "/data"
+        name: my-csi-volume
+      command: ["/bin/sh"]
+      args: ["-c", "while true; do echo `date` hello >> /data/temp.txt; sleep 10;done"]
+  volumes:
+    - name: my-csi-volume
+      persistentVolumeClaim:
+        claimName: pvc-wekafs-fs-encrypted-api # defined in pvc-wekafs-dir-api.yaml

--- a/examples/dynamic_filesystem_encrypted/csi-app-on-fs-snapshot-encrypted-api.yaml
+++ b/examples/dynamic_filesystem_encrypted/csi-app-on-fs-snapshot-encrypted-api.yaml
@@ -1,0 +1,20 @@
+kind: Pod
+apiVersion: v1
+metadata:
+  name: csi-app-on-fs-snapshot-encrypted-api
+spec:
+  # make sure that pod is scheduled only on node having weka CSI node running
+  nodeSelector:
+    topology.csi.weka.io/global: "true"
+  containers:
+    - name: my-frontend
+      image: busybox
+      volumeMounts:
+      - mountPath: "/data"
+        name: my-csi-volume
+      command: ["/bin/sh"]
+      args: ["-c", "tail -F /data/temp.txt"]
+  volumes:
+    - name: my-csi-volume
+      persistentVolumeClaim:
+        claimName: pvc-wekafs-fs-snapshot-encrypted-api

--- a/examples/dynamic_filesystem_encrypted/pvc-wekafs-fs-clone-encrypted-api.yaml
+++ b/examples/dynamic_filesystem_encrypted/pvc-wekafs-fs-clone-encrypted-api.yaml
@@ -1,7 +1,7 @@
 kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
-  name: pvc-wekafs-fs-snapshot-encrypted-api
+  name: pvc-wekafs-fs-clone-encrypted-api
 spec:
   accessModes:
     - ReadWriteMany
@@ -11,6 +11,6 @@ spec:
     requests:
       storage: 1Gi
   dataSource:
-    kind: VolumeSnapshot
-    name: snapshot-pvc-wekafs-fs-encrypted-api
-    apiGroup: snapshot.storage.k8s.io
+    kind: PersistentVolumeClaim
+    name: pvc-wekafs-fs-encrypted-api
+    apiGroup: ""

--- a/examples/dynamic_filesystem_encrypted/pvc-wekafs-fs-encrypted-api.yaml
+++ b/examples/dynamic_filesystem_encrypted/pvc-wekafs-fs-encrypted-api.yaml
@@ -1,0 +1,12 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: pvc-wekafs-fs-encrypted-api
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: storageclass-wekafs-fs-encrypted-api
+  volumeMode: Filesystem
+  resources:
+    requests:
+      storage: 1Gi

--- a/examples/dynamic_filesystem_encrypted/pvc-wekafs-fs-snapshot-encrypted-api.yaml
+++ b/examples/dynamic_filesystem_encrypted/pvc-wekafs-fs-snapshot-encrypted-api.yaml
@@ -1,0 +1,16 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: pvc-wekafs-fs-snapshot-encrypted-api
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: storageclass-wekafs-fs-api
+  volumeMode: Filesystem
+  resources:
+    requests:
+      storage: 1Gi
+  dataSource:
+    kind: VolumeSnapshot
+    name: snapshot-pvc-wekafs-fs-encrypted-api
+    apiGroup: snapshot.storage.k8s.io

--- a/examples/dynamic_filesystem_encrypted/snapshot-pvc-wekafs-fs-encrypted-api.yaml
+++ b/examples/dynamic_filesystem_encrypted/snapshot-pvc-wekafs-fs-encrypted-api.yaml
@@ -1,0 +1,8 @@
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshot
+metadata:
+  name: snapshot-pvc-wekafs-fs-encrypted-api
+spec:
+  volumeSnapshotClassName: snapshotclass-csi-wekafs
+  source:
+    persistentVolumeClaimName: pvc-wekafs-fs-encrypted-api

--- a/examples/dynamic_filesystem_encrypted/snapshot-pvc-wekafs-fs-encrypted-api.yaml
+++ b/examples/dynamic_filesystem_encrypted/snapshot-pvc-wekafs-fs-encrypted-api.yaml
@@ -3,6 +3,6 @@ kind: VolumeSnapshot
 metadata:
   name: snapshot-pvc-wekafs-fs-encrypted-api
 spec:
-  volumeSnapshotClassName: snapshotclass-csi-wekafs
+  volumeSnapshotClassName: snapshotclass-csi-wekafs-encrypted
   source:
     persistentVolumeClaimName: pvc-wekafs-fs-encrypted-api

--- a/examples/dynamic_filesystem_encrypted/storageclass-wekafs-fs-encrypted-api.yaml
+++ b/examples/dynamic_filesystem_encrypted/storageclass-wekafs-fs-encrypted-api.yaml
@@ -8,10 +8,8 @@ volumeBindingMode: Immediate
 allowVolumeExpansion: true
 parameters:
   volumeType: weka/v2  # this line can be ommitted completely
-
+  # encrypt the filesystems created by the CSI plugin. Requires KMS server to be configured on the WEKA cluster
   encryptionEnabled: "true"
-  manageEncryptionKeys: "false"  # this is not currently supported
-
   # name of the filesystem group to create FS in.
   filesystemGroupName: default
   # minimum size of filesystem to create (preallocate space for snapshots and derived volumes)

--- a/examples/dynamic_filesystem_encrypted/storageclass-wekafs-fs-encrypted-api.yaml
+++ b/examples/dynamic_filesystem_encrypted/storageclass-wekafs-fs-encrypted-api.yaml
@@ -16,9 +16,9 @@ parameters:
   initialFilesystemSizeGB: "100"
   # name of the secret that stores API credentials for a cluster
   # change the name of secret to match secret of a particular cluster (if you have several Weka clusters)
-  csi.storage.k8s.io/provisioner-secret-name: &secretName weka-csi-cluster-dev
+  csi.storage.k8s.io/provisioner-secret-name: &secretName csi-wekafs-api-secret
   # change the name of the namespace in which the cluster API credentials
-  csi.storage.k8s.io/provisioner-secret-namespace: &secretNamespace default
+  csi.storage.k8s.io/provisioner-secret-namespace: &secretNamespace csi-wekafs
   # do not change anything below this line, or set to same parameters as above
   csi.storage.k8s.io/controller-publish-secret-name: *secretName
   csi.storage.k8s.io/controller-publish-secret-namespace: *secretNamespace

--- a/examples/dynamic_filesystem_encrypted/storageclass-wekafs-fs-encrypted-api.yaml
+++ b/examples/dynamic_filesystem_encrypted/storageclass-wekafs-fs-encrypted-api.yaml
@@ -11,6 +11,7 @@ parameters:
 
   encryptionEnabled: "true"
   manageEncryptionKeys: "false"  # this is not currently supported
+  encryptWithoutKms: "false"  # this is not for production use, only for testing.
 
   # name of the filesystem group to create FS in.
   filesystemGroupName: default

--- a/examples/dynamic_filesystem_encrypted/storageclass-wekafs-fs-encrypted-api.yaml
+++ b/examples/dynamic_filesystem_encrypted/storageclass-wekafs-fs-encrypted-api.yaml
@@ -1,0 +1,32 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: storageclass-wekafs-fs-encrypted-api
+provisioner: csi.weka.io
+reclaimPolicy: Delete
+volumeBindingMode: Immediate
+allowVolumeExpansion: true
+parameters:
+  volumeType: weka/v2  # this line can be ommitted completely
+
+  encryptionEnabled: "true"
+  manageEncryptionKeys: "false"  # this is not currently supported
+
+  # name of the filesystem group to create FS in.
+  filesystemGroupName: default
+  # minimum size of filesystem to create (preallocate space for snapshots and derived volumes)
+  initialFilesystemSizeGB: "100"
+  # name of the secret that stores API credentials for a cluster
+  # change the name of secret to match secret of a particular cluster (if you have several Weka clusters)
+  csi.storage.k8s.io/provisioner-secret-name: &secretName csi-wekafs-api-secret
+  # change the name of the namespace in which the cluster API credentials
+  csi.storage.k8s.io/provisioner-secret-namespace: &secretNamespace csi-wekafs
+  # do not change anything below this line, or set to same parameters as above
+  csi.storage.k8s.io/controller-publish-secret-name: *secretName
+  csi.storage.k8s.io/controller-publish-secret-namespace: *secretNamespace
+  csi.storage.k8s.io/controller-expand-secret-name: *secretName
+  csi.storage.k8s.io/controller-expand-secret-namespace: *secretNamespace
+  csi.storage.k8s.io/node-stage-secret-name: *secretName
+  csi.storage.k8s.io/node-stage-secret-namespace: *secretNamespace
+  csi.storage.k8s.io/node-publish-secret-name: *secretName
+  csi.storage.k8s.io/node-publish-secret-namespace: *secretNamespace

--- a/examples/dynamic_filesystem_encrypted_nokms/README.md
+++ b/examples/dynamic_filesystem_encrypted_nokms/README.md
@@ -1,0 +1,36 @@
+# Overview
+## Example Intentions
+1. This example concentrates on Weka Filesystem-backed volume backed by Encrypted filesystem
+2. Filesystem is provisioned automatically when volume is created, and encryption is enabled for the filesystem
+
+## Configuration Requirements
+This example introduces automatic provisioning of encrypted filesystems. 
+For this functionality to work, the WEKA cluster must be configured with a valid KMS server.
+If KMS server is not configured, volume will not be created and the following error will be displayed:
+```
+Encryption is not enabled on the cluster
+```
+If WEKA cluster does not support encryption of filesystems, the following error will be displayed:
+```
+Encryption is not supported on the cluster
+```
+
+> **NOTE:** Encryption is only supported for filesystem-backed volumes
+
+## StorageClass Highlights
+- Refer to highlights described in [../dynamic_filesystem/storageclass-wekafs-api.yaml]
+- Storage class includes a parameter `parameters.encryption` that defines whether the filesystem should be encrypted or not. This is a string and not boolean
+    - `true` - filesystem is encrypted using WEKA-managed encryption keys.
+    - `false` - filesystem is not encrypted
+- Storage class includes a parameter `parameters.manageEncryptionKeys` that is currently not supported. This parameter is reserved for future use
+
+## Notes regarding object deletion:
+1. Filesystem-backed volume maps directly to Weka filesystem. 
+2. Filesystem is encrypted
+
+# Workflow
+> All commands below may be executed by `kubectl apply -f <FILE>.yaml`
+1. Create storageclass `storageclass-wekafs-fs-encrypted-nokms-api`
+2. Create CSI secret `csi-wekafs-api-secret`  (Located in [../common/csi-wekafs-api-secret.yaml](../common/csi-wekafs-api-secret.yaml)) 
+3. Provision a new filesystem volume `pvc-wekafs-fs-encrypted-nokms-api`
+4. Create a pod `csi-app-on-fs-encrypted-nokms-api` that uses the volume

--- a/examples/dynamic_filesystem_encrypted_nokms/README.md
+++ b/examples/dynamic_filesystem_encrypted_nokms/README.md
@@ -4,29 +4,36 @@
 2. Filesystem is provisioned automatically when volume is created, and encryption is enabled for the filesystem
 
 ## Configuration Requirements
-This example introduces automatic provisioning of encrypted filesystems. 
-For this functionality to work, the WEKA cluster must be configured with a valid KMS server.
-If KMS server is not configured, volume will not be created and the following error will be displayed:
+This example introduces automatic provisioning of encrypted filesystems without KMS server configuration.
+> **WARNING**: This configuration is for testing purposes only and is not supported for production environments.
+
+Since using encryption without external KMS server is not considered safe, this behavior is prohibited by default in WEKA CSI Plugin.
+For this functionality to work, the plugin needs to be installed with explicit configuration parameter
 ```
-Encryption is not enabled on the cluster
+.Values.pluginConfig.encryption.allowEncryptionWithoutKms = "true"
 ```
+
+If the plugin is not installed with this configuration, the following error will be displayed when trying to provision a PVC using encryption:
+```
+Creating encrypted filesystems without KMS server configuration is prohibited
+```
+
 If WEKA cluster does not support encryption of filesystems, the following error will be displayed:
 ```
 Encryption is not supported on the cluster
 ```
 
-> **NOTE:** Encryption is only supported for filesystem-backed volumes
+## Example Highlights
+1. Encryption is only supported for filesystem-backed volumes.
+2. Volumes created from snapshots or directories inherit the encryption setting from the underlying filesystem.
+3. However, if encryption is enabled in storageClass, the driver will validate that the underlying filesystem is encrypted.
+   If the filesystem does not have encryption enabled, an appropriate error will be returned.
 
 ## StorageClass Highlights
 - Refer to highlights described in [../dynamic_filesystem/storageclass-wekafs-api.yaml]
-- Storage class includes a parameter `parameters.encryption` that defines whether the filesystem should be encrypted or not. This is a string and not boolean
-    - `true` - filesystem is encrypted using WEKA-managed encryption keys.
-    - `false` - filesystem is not encrypted
-- Storage class includes a parameter `parameters.manageEncryptionKeys` that is currently not supported. This parameter is reserved for future use
-
-## Notes regarding object deletion:
-1. Filesystem-backed volume maps directly to Weka filesystem. 
-2. Filesystem is encrypted
+- Storage class includes a parameter `parameters.encryptionEnabled` that defines whether the filesystem should be encrypted or not. This is a string and not boolean
+    - `"true"` - filesystem is encrypted using cluster-wide encryption key defined via KMS server configuration.
+    - `"false"` - filesystem is not encrypted
 
 # Workflow
 > All commands below may be executed by `kubectl apply -f <FILE>.yaml`
@@ -34,3 +41,6 @@ Encryption is not supported on the cluster
 2. Create CSI secret `csi-wekafs-api-secret`  (Located in [../common/csi-wekafs-api-secret.yaml](../common/csi-wekafs-api-secret.yaml)) 
 3. Provision a new filesystem volume `pvc-wekafs-fs-encrypted-nokms-api`
 4. Create a pod `csi-app-on-fs-encrypted-nokms-api` that uses the volume
+
+Since no significant differences are present in the workflow compared to the [../dynamic_filesystem_encrypted/README.md](../dynamic_filesystem_encrypted/README.md), 
+the rest of the workflow is omitted here.

--- a/examples/dynamic_filesystem_encrypted_nokms/csi-app-on-fs-encrypted-nokms-api.yaml
+++ b/examples/dynamic_filesystem_encrypted_nokms/csi-app-on-fs-encrypted-nokms-api.yaml
@@ -1,0 +1,20 @@
+kind: Pod
+apiVersion: v1
+metadata:
+  name: csi-app-on-fs-encrypted-nokms-api
+spec:
+  # make sure that pod is scheduled only on node having weka CSI node running
+  nodeSelector:
+    topology.csi.weka.io/global: "true"
+  containers:
+    - name: my-frontend
+      image: ubuntu
+      volumeMounts:
+      - mountPath: "/data"
+        name: my-csi-volume
+      command: ["/bin/sh"]
+      args: ["-c", "while true; do echo `date` hello >> /data/temp.txt; sleep 10;done"]
+  volumes:
+    - name: my-csi-volume
+      persistentVolumeClaim:
+        claimName: pvc-wekafs-fs-encrypted-nokms-api # defined in pvc-wekafs-dir-api.yaml

--- a/examples/dynamic_filesystem_encrypted_nokms/pvc-wekafs-fs-encrypted-nokms-api.yaml
+++ b/examples/dynamic_filesystem_encrypted_nokms/pvc-wekafs-fs-encrypted-nokms-api.yaml
@@ -1,0 +1,12 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: pvc-wekafs-fs-encrypted-nokms-api
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: storageclass-wekafs-fs-encrypted-nokms-api
+  volumeMode: Filesystem
+  resources:
+    requests:
+      storage: 1Gi

--- a/examples/dynamic_filesystem_encrypted_nokms/storageclass-wekafs-fs-encrypted-nokms-api.yaml
+++ b/examples/dynamic_filesystem_encrypted_nokms/storageclass-wekafs-fs-encrypted-nokms-api.yaml
@@ -1,7 +1,7 @@
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: storageclass-wekafs-fs-encrypted-api
+  name: storageclass-wekafs-fs-encrypted-nokms-api
 provisioner: csi.weka.io
 reclaimPolicy: Delete
 volumeBindingMode: Immediate
@@ -11,6 +11,7 @@ parameters:
 
   encryptionEnabled: "true"
   manageEncryptionKeys: "false"  # this is not currently supported
+  encryptWithoutKms: "true"  # this is not for production use, only for testing.
 
   # name of the filesystem group to create FS in.
   filesystemGroupName: default

--- a/examples/dynamic_filesystem_encrypted_nokms/storageclass-wekafs-fs-encrypted-nokms-api.yaml
+++ b/examples/dynamic_filesystem_encrypted_nokms/storageclass-wekafs-fs-encrypted-nokms-api.yaml
@@ -8,11 +8,11 @@ volumeBindingMode: Immediate
 allowVolumeExpansion: true
 parameters:
   volumeType: weka/v2  # this line can be ommitted completely
-
+  # encrypt the filesystems created by the CSI plugin. Requires KMS server to be configured on the WEKA cluster
   encryptionEnabled: "true"
-  manageEncryptionKeys: "false"  # this is not currently supported
-  encryptWithoutKms: "true"  # this is not for production use, only for testing.
-
+  # ALLOW creation of encrypted volumes without KMS server configured. NOT SUPPORTED FOR PRODUCTION USE.
+  # The flag does not imply not using KMS, just allows to proceed without it. If KMS is defined, it will still be used.
+  encryptWithoutKms: "true"
   # name of the filesystem group to create FS in.
   filesystemGroupName: default
   # minimum size of filesystem to create (preallocate space for snapshots and derived volumes)

--- a/pkg/wekafs/apiclient/cluster.go
+++ b/pkg/wekafs/apiclient/cluster.go
@@ -49,7 +49,6 @@ func (a *ApiClient) fetchClusterInfo(ctx context.Context) error {
 		Str("cluster_version", clusterVersion).Msg("Successfully connected to cluster")
 	logger.Info().Msg(fmt.Sprintf("Cluster compatibility for filesystem as CSI volume: %t", a.SupportsFilesystemAsVolume()))
 	logger.Info().Msg(fmt.Sprintf("Cluster compatibility for quota directory as CSI volume: %t", a.SupportsQuotaDirectoryAsVolume()))
-	logger.Info().Msg(fmt.Sprintf("Cluster compatibility for quota on non-empty CSI volume: %t", a.SupportsQuotaOnNonEmptyDirs()))
 	logger.Info().Msg(fmt.Sprintf("Cluster compatibility for regular directory as CSI volume: %t", a.SupportsDirectoryAsVolume()))
 	logger.Info().Msg(fmt.Sprintf("Cluster compatibility for authenticated filesystem mounts: %t", a.SupportsAuthenticatedMounts()))
 	logger.Info().Msg(fmt.Sprintf("Cluster compatibility for new filesystem from snapshot: %t", a.SupportsNewFileSystemFromSnapshot()))
@@ -60,8 +59,8 @@ func (a *ApiClient) fetchClusterInfo(ctx context.Context) error {
 	logger.Info().Msg(fmt.Sprintf("Cluster supports URL query parameters: %t", a.SupportsUrlQueryParams()))
 	logger.Info().Msg(fmt.Sprintf("Cluster supports quotas on snapshots: %t", a.SupportsQuotaOnSnapshots()))
 	logger.Info().Msg(fmt.Sprintf("Cluster supports encryption without KMS: %t", a.SupportsEncryptionWithNoKms()))
-	logger.Info().Msg(fmt.Sprintf("Cluster supports encryption of filesystems with commomn key: %t", a.SupportsEncryptionWithCommonKey()))
-	logger.Info().Msg(fmt.Sprintf("Cluster supports encryption of filesystems with key per filesystem: %t", a.SupportsEncryptionWithKeyPerFilesystem()))
+	logger.Info().Msg(fmt.Sprintf("Cluster supports encryption of filesystems with a cluster-wide key: %t", a.SupportsEncryptionWithCommonKey()))
+	logger.Info().Msg(fmt.Sprintf("Cluster supports encryption of filesystems with custom keys: %t", a.SupportsCustomEncryptionSettings()))
 	return nil
 }
 

--- a/pkg/wekafs/apiclient/cluster.go
+++ b/pkg/wekafs/apiclient/cluster.go
@@ -57,6 +57,11 @@ func (a *ApiClient) fetchClusterInfo(ctx context.Context) error {
 	logger.Info().Msg(fmt.Sprintf("Cluster compatibility for sync_on_close mount option: %t", a.SupportsSyncOnCloseMountOption()))
 	logger.Info().Msg(fmt.Sprintf("Cluster compatibility for supporting multiple connections: %t", a.SupportsMultipleClusters()))
 	logger.Info().Msg(fmt.Sprintf("Cluster requires using new API path for nodes (nodes->processes): %t", a.RequiresNewNodePath()))
+	logger.Info().Msg(fmt.Sprintf("Cluster supports URL query parameters: %t", a.SupportsUrlQueryParams()))
+	logger.Info().Msg(fmt.Sprintf("Cluster supports quotas on snapshots: %t", a.SupportsQuotaOnSnapshots()))
+	logger.Info().Msg(fmt.Sprintf("Cluster supports encryption without KMS: %t", a.SupportsEncryptionWithNoKms()))
+	logger.Info().Msg(fmt.Sprintf("Cluster supports encryption of filesystems with commomn key: %t", a.SupportsEncryptionWithCommonKey()))
+	logger.Info().Msg(fmt.Sprintf("Cluster supports encryption of filesystems with key per filesystem: %t", a.SupportsEncryptionWithKeyPerFilesystem()))
 	return nil
 }
 

--- a/pkg/wekafs/apiclient/compatibility.go
+++ b/pkg/wekafs/apiclient/compatibility.go
@@ -37,7 +37,7 @@ var MinimumSupportedWekaVersions = &WekaCompatibilityRequiredVersions{
 	NewNodeApiObjectPath:           "v4.2",   // new API object paths (processes, containers, etc.)
 	EncryptionWithNoKms:            "v4.0",   // can create encrypted filesystems without KMS
 	EncryptionWithClusterKey:       "v4.0",   // can create encrypted filesystems with common cluster-wide key
-	EncryptionWithCustomSettings:   "v4.4.0", // can create encrypted filesystems with custom settings (key per filesystem(s))
+	EncryptionWithCustomSettings:   "v4.4.1", // can create encrypted filesystems with custom settings (key per filesystem(s))
 }
 
 type WekaCompatibilityMap struct {

--- a/pkg/wekafs/apiclient/compatibility.go
+++ b/pkg/wekafs/apiclient/compatibility.go
@@ -18,28 +18,32 @@ type WekaCompatibilityRequiredVersions struct {
 	SyncOnCloseMountOption         string
 	SingleClientMultipleClusters   string
 	NewNodeApiObjectPath           string
+	EncryptionWithNoKms            string
+	EncryptionWithCommonKey        string
+	EncryptionWithManagedKeys      string
 }
 
 var MinimumSupportedWekaVersions = &WekaCompatibilityRequiredVersions{
-	DirectoryAsCSIVolume:           "v3.0",  // can create CSI volume from directory, without quota support
-	FilesystemAsVolume:             "v3.13", // can create CSI volume from filesystem
-	QuotaDirectoryAsVolume:         "v3.13", // can create CSI volume from directory with quota support
-	QuotaOnNonEmptyDirs:            "v9.99", // can enable quota on legacy CSI volume (directory) without quota support
-	QuotaOnSnapshot:                "v4.2",  // can create a valid quota on snapshot
-	MountFilesystemsUsingAuthToken: "v3.14", // can mount filesystems that require authentication (and non-root orgID)
-	NewFilesystemFromSnapshot:      "v9.99", // can create new filesystem from snapshot on storage side
-	CloneFilesystem:                "v9.99", // can clone a volume directly on storage side
-	UrlQueryParams:                 "v4.0",  // can perform URL query by fields
-	SyncOnCloseMountOption:         "v4.2",  // can perform sync_on_close mount option
-	SingleClientMultipleClusters:   "v4.2",  // single client can have multiple Weka cluster connections
-	NewNodeApiObjectPath:           "v4.2",  // new API object paths (processes, containers, etc.)
+	DirectoryAsCSIVolume:           "v3.0",   // can create CSI volume from directory, without quota support
+	FilesystemAsVolume:             "v3.13",  // can create CSI volume from filesystem
+	QuotaDirectoryAsVolume:         "v3.13",  // can create CSI volume from directory with quota support
+	QuotaOnSnapshot:                "v4.2",   // can create a valid quota on snapshot
+	MountFilesystemsUsingAuthToken: "v3.14",  // can mount filesystems that require authentication (and non-root orgID)
+	NewFilesystemFromSnapshot:      "v9.99",  // can create new filesystem from snapshot on storage side
+	CloneFilesystem:                "v9.99",  // can clone a volume directly on storage side
+	UrlQueryParams:                 "v4.0",   // can perform URL query by fields
+	SyncOnCloseMountOption:         "v4.2",   // can perform sync_on_close mount option
+	SingleClientMultipleClusters:   "v4.2",   // single client can have multiple Weka cluster connections
+	NewNodeApiObjectPath:           "v4.2",   // new API object paths (processes, containers, etc.)
+	EncryptionWithNoKms:            "v4.0",   // can create encrypted filesystems without KMS
+	EncryptionWithCommonKey:        "v4.0",   // can create encrypted filesystems with common key (no specific key per filesystem)
+	EncryptionWithManagedKeys:      "v4.4.0", // can create encrypted filesystems with key per filesystem
 }
 
 type WekaCompatibilityMap struct {
 	FilesystemAsCSIVolume           bool
 	DirectoryAsCSIVolume            bool
 	QuotaOnDirectoryVolume          bool
-	QuotaSetOnNonEmptyVolume        bool
 	QuotaOnSnapshot                 bool
 	MountFilesystemsUsingAuthToken  bool
 	CreateNewFilesystemFromSnapshot bool
@@ -48,6 +52,9 @@ type WekaCompatibilityMap struct {
 	SyncOnCloseMountOption          bool
 	SingleClientMultipleClusters    bool
 	NewNodeApiObjectPath            bool
+	EncryptionWithNoKms             bool
+	EncryptionWithCommonKey         bool
+	EncryptionWithKeyPerFilesystem  bool
 }
 
 func (cm *WekaCompatibilityMap) fillIn(versionStr string) {
@@ -57,7 +64,6 @@ func (cm *WekaCompatibilityMap) fillIn(versionStr string) {
 		cm.DirectoryAsCSIVolume = true
 		cm.FilesystemAsCSIVolume = false
 		cm.QuotaOnDirectoryVolume = false
-		cm.QuotaSetOnNonEmptyVolume = false
 		cm.MountFilesystemsUsingAuthToken = false
 		cm.CreateNewFilesystemFromSnapshot = false
 		cm.CloneFilesystem = false
@@ -66,12 +72,15 @@ func (cm *WekaCompatibilityMap) fillIn(versionStr string) {
 		cm.SyncOnCloseMountOption = false
 		cm.SingleClientMultipleClusters = false
 		cm.NewNodeApiObjectPath = false
+		cm.EncryptionWithNoKms = false
+		cm.EncryptionWithCommonKey = false
+		cm.EncryptionWithKeyPerFilesystem = false
+
 		return
 	}
 	d, _ := version.NewVersion(MinimumSupportedWekaVersions.DirectoryAsCSIVolume)
 	f, _ := version.NewVersion(MinimumSupportedWekaVersions.FilesystemAsVolume)
 	q, _ := version.NewVersion(MinimumSupportedWekaVersions.QuotaDirectoryAsVolume)
-	n, _ := version.NewVersion(MinimumSupportedWekaVersions.QuotaOnNonEmptyDirs)
 	a, _ := version.NewVersion(MinimumSupportedWekaVersions.MountFilesystemsUsingAuthToken)
 	s, _ := version.NewVersion(MinimumSupportedWekaVersions.NewFilesystemFromSnapshot)
 	c, _ := version.NewVersion(MinimumSupportedWekaVersions.CloneFilesystem)
@@ -80,11 +89,13 @@ func (cm *WekaCompatibilityMap) fillIn(versionStr string) {
 	sc, _ := version.NewVersion(MinimumSupportedWekaVersions.SyncOnCloseMountOption)
 	mc, _ := version.NewVersion(MinimumSupportedWekaVersions.SingleClientMultipleClusters)
 	nn, _ := version.NewVersion(MinimumSupportedWekaVersions.NewNodeApiObjectPath)
+	en, _ := version.NewVersion(MinimumSupportedWekaVersions.EncryptionWithNoKms)
+	ec, _ := version.NewVersion(MinimumSupportedWekaVersions.EncryptionWithCommonKey)
+	epf, _ := version.NewVersion(MinimumSupportedWekaVersions.EncryptionWithManagedKeys)
 
 	cm.DirectoryAsCSIVolume = v.GreaterThanOrEqual(d)
 	cm.FilesystemAsCSIVolume = v.GreaterThanOrEqual(f)
 	cm.QuotaOnDirectoryVolume = v.GreaterThanOrEqual(q)
-	cm.QuotaSetOnNonEmptyVolume = v.GreaterThanOrEqual(n)
 	cm.MountFilesystemsUsingAuthToken = v.GreaterThanOrEqual(a)
 	cm.CreateNewFilesystemFromSnapshot = v.GreaterThanOrEqual(s)
 	cm.CloneFilesystem = v.GreaterThanOrEqual(c)
@@ -93,14 +104,13 @@ func (cm *WekaCompatibilityMap) fillIn(versionStr string) {
 	cm.SyncOnCloseMountOption = v.GreaterThanOrEqual(sc)
 	cm.SingleClientMultipleClusters = v.GreaterThanOrEqual(mc)
 	cm.NewNodeApiObjectPath = v.GreaterThanOrEqual(nn)
+	cm.EncryptionWithNoKms = v.GreaterThanOrEqual(en)
+	cm.EncryptionWithCommonKey = v.GreaterThanOrEqual(ec)
+	cm.EncryptionWithKeyPerFilesystem = v.GreaterThanOrEqual(epf)
 }
 
 func (a *ApiClient) SupportsQuotaDirectoryAsVolume() bool {
 	return a.CompatibilityMap.QuotaOnDirectoryVolume
-}
-
-func (a *ApiClient) SupportsQuotaOnNonEmptyDirs() bool {
-	return a.CompatibilityMap.QuotaSetOnNonEmptyVolume
 }
 
 func (a *ApiClient) SupportsQuotaOnSnapshots() bool {
@@ -137,6 +147,18 @@ func (a *ApiClient) SupportsSyncOnCloseMountOption() bool {
 
 func (a *ApiClient) SupportsMultipleClusters() bool {
 	return a.CompatibilityMap.SingleClientMultipleClusters
+}
+
+func (a *ApiClient) SupportsEncryptionWithNoKms() bool {
+	return a.CompatibilityMap.EncryptionWithNoKms
+}
+
+func (a *ApiClient) SupportsEncryptionWithCommonKey() bool {
+	return a.CompatibilityMap.EncryptionWithCommonKey
+}
+
+func (a *ApiClient) SupportsEncryptionWithKeyPerFilesystem() bool {
+	return a.CompatibilityMap.EncryptionWithKeyPerFilesystem
 }
 
 func (a *ApiClient) RequiresNewNodePath() bool {

--- a/pkg/wekafs/apiclient/compatibility.go
+++ b/pkg/wekafs/apiclient/compatibility.go
@@ -19,8 +19,8 @@ type WekaCompatibilityRequiredVersions struct {
 	SingleClientMultipleClusters   string
 	NewNodeApiObjectPath           string
 	EncryptionWithNoKms            string
-	EncryptionWithCommonKey        string
-	EncryptionWithManagedKeys      string
+	EncryptionWithClusterKey       string
+	EncryptionWithCustomSettings   string
 }
 
 var MinimumSupportedWekaVersions = &WekaCompatibilityRequiredVersions{
@@ -36,8 +36,8 @@ var MinimumSupportedWekaVersions = &WekaCompatibilityRequiredVersions{
 	SingleClientMultipleClusters:   "v4.2",   // single client can have multiple Weka cluster connections
 	NewNodeApiObjectPath:           "v4.2",   // new API object paths (processes, containers, etc.)
 	EncryptionWithNoKms:            "v4.0",   // can create encrypted filesystems without KMS
-	EncryptionWithCommonKey:        "v4.0",   // can create encrypted filesystems with common key (no specific key per filesystem)
-	EncryptionWithManagedKeys:      "v4.4.0", // can create encrypted filesystems with key per filesystem
+	EncryptionWithClusterKey:       "v4.0",   // can create encrypted filesystems with common cluster-wide key
+	EncryptionWithCustomSettings:   "v4.4.0", // can create encrypted filesystems with custom settings (key per filesystem(s))
 }
 
 type WekaCompatibilityMap struct {
@@ -53,8 +53,8 @@ type WekaCompatibilityMap struct {
 	SingleClientMultipleClusters    bool
 	NewNodeApiObjectPath            bool
 	EncryptionWithNoKms             bool
-	EncryptionWithCommonKey         bool
-	EncryptionWithKeyPerFilesystem  bool
+	EncryptionWithClusterKey        bool
+	EncryptionWithCustomSettings    bool
 }
 
 func (cm *WekaCompatibilityMap) fillIn(versionStr string) {
@@ -73,8 +73,8 @@ func (cm *WekaCompatibilityMap) fillIn(versionStr string) {
 		cm.SingleClientMultipleClusters = false
 		cm.NewNodeApiObjectPath = false
 		cm.EncryptionWithNoKms = false
-		cm.EncryptionWithCommonKey = false
-		cm.EncryptionWithKeyPerFilesystem = false
+		cm.EncryptionWithClusterKey = false
+		cm.EncryptionWithCustomSettings = false
 
 		return
 	}
@@ -90,8 +90,8 @@ func (cm *WekaCompatibilityMap) fillIn(versionStr string) {
 	mc, _ := version.NewVersion(MinimumSupportedWekaVersions.SingleClientMultipleClusters)
 	nn, _ := version.NewVersion(MinimumSupportedWekaVersions.NewNodeApiObjectPath)
 	en, _ := version.NewVersion(MinimumSupportedWekaVersions.EncryptionWithNoKms)
-	ec, _ := version.NewVersion(MinimumSupportedWekaVersions.EncryptionWithCommonKey)
-	epf, _ := version.NewVersion(MinimumSupportedWekaVersions.EncryptionWithManagedKeys)
+	ec, _ := version.NewVersion(MinimumSupportedWekaVersions.EncryptionWithClusterKey)
+	ecc, _ := version.NewVersion(MinimumSupportedWekaVersions.EncryptionWithCustomSettings)
 
 	cm.DirectoryAsCSIVolume = v.GreaterThanOrEqual(d)
 	cm.FilesystemAsCSIVolume = v.GreaterThanOrEqual(f)
@@ -105,8 +105,8 @@ func (cm *WekaCompatibilityMap) fillIn(versionStr string) {
 	cm.SingleClientMultipleClusters = v.GreaterThanOrEqual(mc)
 	cm.NewNodeApiObjectPath = v.GreaterThanOrEqual(nn)
 	cm.EncryptionWithNoKms = v.GreaterThanOrEqual(en)
-	cm.EncryptionWithCommonKey = v.GreaterThanOrEqual(ec)
-	cm.EncryptionWithKeyPerFilesystem = v.GreaterThanOrEqual(epf)
+	cm.EncryptionWithClusterKey = v.GreaterThanOrEqual(ec)
+	cm.EncryptionWithCustomSettings = v.GreaterThanOrEqual(ecc)
 }
 
 func (a *ApiClient) SupportsQuotaDirectoryAsVolume() bool {
@@ -154,11 +154,11 @@ func (a *ApiClient) SupportsEncryptionWithNoKms() bool {
 }
 
 func (a *ApiClient) SupportsEncryptionWithCommonKey() bool {
-	return a.CompatibilityMap.EncryptionWithCommonKey
+	return a.CompatibilityMap.EncryptionWithClusterKey
 }
 
-func (a *ApiClient) SupportsEncryptionWithKeyPerFilesystem() bool {
-	return a.CompatibilityMap.EncryptionWithKeyPerFilesystem
+func (a *ApiClient) SupportsCustomEncryptionSettings() bool {
+	return a.CompatibilityMap.EncryptionWithCustomSettings
 }
 
 func (a *ApiClient) RequiresNewNodePath() bool {

--- a/pkg/wekafs/apiclient/compatibility_test.go
+++ b/pkg/wekafs/apiclient/compatibility_test.go
@@ -69,7 +69,6 @@ func TestWekaCompatibilityMap_fillIn(t *testing.T) {
 				DirectoryAsCSIVolume:            true,
 				FilesystemAsCSIVolume:           true,
 				QuotaOnDirectoryVolume:          true,
-				QuotaSetOnNonEmptyVolume:        true,
 				QuotaOnSnapshot:                 true,
 				MountFilesystemsUsingAuthToken:  true,
 				CreateNewFilesystemFromSnapshot: true,

--- a/pkg/wekafs/apiclient/encryption.go
+++ b/pkg/wekafs/apiclient/encryption.go
@@ -1,10 +1,24 @@
 package apiclient
 
-func (a *ApiClient) IsEncryptionEnabled() bool {
-	if !a.SupportsEncryptionWithNoKms() {
+import "context"
+
+func (a *ApiClient) IsEncryptionEnabled(ctx context.Context) bool {
+	if !a.SupportsEncryptionWithCommonKey() {
 		return false
 	}
-	return true // TODO: implement the rest of the function to actually fetch the data
+
+	kms, err := a.GetKmsConfiguration(ctx)
+	if err != nil {
+		return false
+	}
+	if kms == nil {
+		return false
+	}
+	if !kms.IsSupported() {
+		return false
+	}
+
+	return true
 }
 
 type EncryptionParams struct {

--- a/pkg/wekafs/apiclient/encryption.go
+++ b/pkg/wekafs/apiclient/encryption.go
@@ -14,10 +14,30 @@ func (a *ApiClient) IsEncryptionEnabled(ctx context.Context) bool {
 	if kms == nil {
 		return false
 	}
-	if !kms.IsSupported() {
+	if !kms.IsSupportedForCommonEncryptionKey() {
 		return false
 	}
 
+	return true
+}
+
+func (a *ApiClient) IsEncryptionEnabledWithKeyPerFilesystem(ctx context.Context) bool {
+	if !a.SupportsEncryptionWithKeyPerFilesystem() {
+		return false
+	}
+	kms, err := a.GetKmsConfiguration(ctx)
+	if err != nil {
+		return false
+	}
+	if kms == nil {
+		return false
+	}
+	if !kms.IsSupportedForCommonEncryptionKey() {
+		return false
+	}
+	if !kms.IsSupportedForEncryptionKeyPerFilesystem() {
+		return false
+	}
 	return true
 }
 

--- a/pkg/wekafs/apiclient/encryption.go
+++ b/pkg/wekafs/apiclient/encryption.go
@@ -1,0 +1,8 @@
+package apiclient
+
+func (a *ApiClient) IsEncryptionEnabled() bool {
+	if !a.SupportsEncryptionWithNoKms() {
+		return false
+	}
+	return true // TODO: implement the rest of the function to actually fetch the data
+}

--- a/pkg/wekafs/apiclient/encryption.go
+++ b/pkg/wekafs/apiclient/encryption.go
@@ -21,8 +21,8 @@ func (a *ApiClient) IsEncryptionEnabled(ctx context.Context) bool {
 	return true
 }
 
-func (a *ApiClient) IsEncryptionEnabledWithKeyPerFilesystem(ctx context.Context) bool {
-	if !a.SupportsEncryptionWithKeyPerFilesystem() {
+func (a *ApiClient) AllowsCustomEncryptionSettings(ctx context.Context) bool {
+	if !a.SupportsCustomEncryptionSettings() {
 		return false
 	}
 	kms, err := a.GetKmsConfiguration(ctx)

--- a/pkg/wekafs/apiclient/encryption.go
+++ b/pkg/wekafs/apiclient/encryption.go
@@ -6,3 +6,12 @@ func (a *ApiClient) IsEncryptionEnabled() bool {
 	}
 	return true // TODO: implement the rest of the function to actually fetch the data
 }
+
+type EncryptionParams struct {
+	Encrypted             bool
+	AllowNoKms            bool
+	KmsVaultKeyIdentifier string
+	KmsVaultNamespace     string
+	KmsVaultRoleId        string
+	KmsVaultSecretId      string
+}

--- a/pkg/wekafs/apiclient/filesystem.go
+++ b/pkg/wekafs/apiclient/filesystem.go
@@ -39,7 +39,7 @@ type FileSystem struct {
 	AvailableSsd         int64     `json:"available_ssd" url:"-"`
 	FreeSsd              int64     `json:"free_ssd" url:"-"`
 
-	ObsBuckets     []interface{} `json:"obs_buckets" url"-"`
+	ObsBuckets     []interface{} `json:"obs_buckets" url:"-"`
 	ObjectStorages []interface{} `json:"object_storages" url:"-"`
 
 	KmsKeyIdentifier string `json:"kms_key_identifier,omitempty" url:"-"`

--- a/pkg/wekafs/apiclient/filesystem.go
+++ b/pkg/wekafs/apiclient/filesystem.go
@@ -39,8 +39,12 @@ type FileSystem struct {
 	AvailableSsd         int64     `json:"available_ssd" url:"-"`
 	FreeSsd              int64     `json:"free_ssd" url:"-"`
 
-	ObsBuckets     []interface{} `json:"obs_buckets"`
-	ObjectStorages []interface{} `json:"object_storages"`
+	ObsBuckets     []interface{} `json:"obs_buckets" url"-"`
+	ObjectStorages []interface{} `json:"object_storages" url:"-"`
+
+	KmsKeyIdentifier string `json:"kms_key_identifier,omitempty" url:"-"`
+	KmsNamespace     string `json:"kms_namespace,omitempty" url:"-"`
+	KmsRole          string `json:"kms_role,omitempty" url:"-"`
 }
 
 type FileSystemMountToken struct {
@@ -321,6 +325,11 @@ type FileSystemCreateRequest struct {
 	Encrypted     bool   `json:"encrypted,omitempty"`
 	AuthRequired  bool   `json:"auth_required,omitempty"`
 	AllowNoKms    bool   `json:"allow_no_kms,omitempty"`
+
+	KmsVaultKeyIdentifier string `json:"kms_vault_key_identifier,omitempty"`
+	KmsVaultNamespace     string `json:"kms_vault_namespace,omitempty"`
+	KmsVaultRoleId        string `json:"kms_vault_role_id,omitempty"`
+	KmsVaultSecretId      string `json:"kms_vault_secret_id,omitempty"`
 }
 
 func (fsc *FileSystemCreateRequest) getApiUrl(a *ApiClient) string {
@@ -341,11 +350,12 @@ func (fsc *FileSystemCreateRequest) String() string {
 	return fmt.Sprintln("FileSystemCreateRequest(name:", fsc.Name, "groupName:", fsc.GroupName, "capacity:", fsc.TotalCapacity, ")")
 }
 
-func NewFilesystemCreateRequest(name, groupName string, totalCapacity int64) (*FileSystemCreateRequest, error) {
+func NewFilesystemCreateRequest(name, groupName string, totalCapacity int64, isEncrypted bool) (*FileSystemCreateRequest, error) {
 	ret := &FileSystemCreateRequest{
 		Name:          name,
 		GroupName:     groupName,
 		TotalCapacity: totalCapacity,
+		Encrypted:     isEncrypted,
 	}
 	return ret, nil
 }

--- a/pkg/wekafs/apiclient/filesystem.go
+++ b/pkg/wekafs/apiclient/filesystem.go
@@ -350,12 +350,18 @@ func (fsc *FileSystemCreateRequest) String() string {
 	return fmt.Sprintln("FileSystemCreateRequest(name:", fsc.Name, "groupName:", fsc.GroupName, "capacity:", fsc.TotalCapacity, ")")
 }
 
-func NewFilesystemCreateRequest(name, groupName string, totalCapacity int64, isEncrypted bool) (*FileSystemCreateRequest, error) {
+func NewFilesystemCreateRequest(name, groupName string, totalCapacity int64, encrytionParams EncryptionParams) (*FileSystemCreateRequest, error) {
+
 	ret := &FileSystemCreateRequest{
-		Name:          name,
-		GroupName:     groupName,
-		TotalCapacity: totalCapacity,
-		Encrypted:     isEncrypted,
+		Name:                  name,
+		GroupName:             groupName,
+		TotalCapacity:         totalCapacity,
+		Encrypted:             encrytionParams.Encrypted,
+		AllowNoKms:            encrytionParams.AllowNoKms,
+		KmsVaultKeyIdentifier: encrytionParams.KmsVaultKeyIdentifier,
+		KmsVaultNamespace:     encrytionParams.KmsVaultNamespace,
+		KmsVaultRoleId:        encrytionParams.KmsVaultRoleId,
+		KmsVaultSecretId:      encrytionParams.KmsVaultSecretId,
 	}
 	return ret, nil
 }

--- a/pkg/wekafs/apiclient/kms.go
+++ b/pkg/wekafs/apiclient/kms.go
@@ -6,10 +6,13 @@ import (
 )
 
 type KmsType string
+type KmsAuthMethod string
 
 const (
-	KmsTypeLocal          KmsType = "Local"
-	KmsTypeHashicorpVault KmsType = "HashiCorpVault"
+	KmsTypeLocal          KmsType       = "Local"
+	KmsTypeHashicorpVault KmsType       = "HashiCorpVault"
+	KmsAuthMethodToken    KmsAuthMethod = "token"
+	KmsAuthMethodAppRole  KmsAuthMethod = "RoleId/SecretId"
 )
 
 type Kms struct {
@@ -18,9 +21,9 @@ type Kms struct {
 }
 
 type KmsParams struct {
-	MasterKeyName string `json:"master_key_name"`
-	BaseUrl       string `json:"base_url"`
-	AuthMethod    string `json:"auth_method"`
+	MasterKeyName string        `json:"master_key_name"`
+	BaseUrl       string        `json:"base_url"`
+	AuthMethod    KmsAuthMethod `json:"auth_method"`
 }
 
 func (k *Kms) GetType() string {
@@ -55,6 +58,10 @@ func (k *Kms) IsLocal() bool {
 
 func (k *Kms) IsHashicorpVault() bool {
 	return k.KmsType == KmsTypeHashicorpVault
+}
+
+func (k *Kms) SupportsPerFilesystemEncryptionKey() bool {
+	return k.Params.AuthMethod == KmsAuthMethodAppRole
 }
 
 func (k *Kms) IsSupported() bool {

--- a/pkg/wekafs/apiclient/kms.go
+++ b/pkg/wekafs/apiclient/kms.go
@@ -1,0 +1,93 @@
+package apiclient
+
+import (
+	"fmt"
+	"golang.org/x/net/context"
+)
+
+type KmsType string
+
+const (
+	KmsTypeLocal          KmsType = "Local"
+	KmsTypeHashicorpVault KmsType = "HashiCorpVault"
+)
+
+type Kms struct {
+	KmsType KmsType   `json:"kms_type"`
+	Params  KmsParams `json:"params"`
+}
+
+type KmsParams struct {
+	MasterKeyName string `json:"master_key_name"`
+	BaseUrl       string `json:"base_url"`
+	AuthMethod    string `json:"auth_method"`
+}
+
+func (k *Kms) GetType() string {
+	return "kms"
+}
+
+func (k *Kms) GetBasePath(a *ApiClient) string {
+	return "/kms"
+}
+
+func (k *Kms) GetApiUrl(a *ApiClient) string {
+	return k.GetBasePath(a)
+}
+
+func (k *Kms) EQ(other ApiObject) bool {
+	return true
+}
+
+func (k *Kms) getImmutableFields() []string {
+	return []string{
+		"KmsType", "Params",
+	}
+}
+
+func (k *Kms) String() string {
+	return fmt.Sprintln("Kms(type:", k.KmsType, "URL:", k.Params.BaseUrl, "AuthMetod:", k.Params.AuthMethod, ")")
+}
+
+func (k *Kms) IsLocal() bool {
+	return k.KmsType == KmsTypeLocal
+}
+
+func (k *Kms) IsHashicorpVault() bool {
+	return k.KmsType == KmsTypeHashicorpVault
+}
+
+func (k *Kms) IsSupported() bool {
+	return k.IsHashicorpVault()
+}
+
+func (a *ApiClient) getKms(ctx context.Context) (*Kms, error) {
+	responseData := &Kms{}
+	err := a.Get(ctx, responseData.GetBasePath(a), nil, responseData)
+	if err != nil {
+		return nil, err
+	}
+	return responseData, nil
+}
+
+func (a *ApiClient) GetKmsConfiguration(ctx context.Context) (*Kms, error) {
+	kms, err := a.getKms(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if kms.IsSupported() {
+		return kms, nil
+	}
+	return nil, fmt.Errorf("KMS configuration is not supported")
+}
+
+func (a *ApiClient) HasKmsConfiguration(ctx context.Context) bool {
+	kms, err := a.GetKmsConfiguration(ctx)
+	if err != nil {
+		return false
+	}
+	if kms.IsSupported() {
+		return true
+	}
+	return false
+}

--- a/pkg/wekafs/apiclient/kms_test.go
+++ b/pkg/wekafs/apiclient/kms_test.go
@@ -24,6 +24,7 @@ func TestHasKmsConfigurationWhenNotPresent(t *testing.T) {
 
 func TestIsEncryptionEnabledWhenNotPresent(t *testing.T) {
 	apiClient := GetApiClientForTest(t)
-	isEnabled := apiClient.IsEncryptionEnabled()
+	ctx := context.Background()
+	isEnabled := apiClient.IsEncryptionEnabled(ctx)
 	assert.False(t, isEnabled, "Expected encryption to be disabled")
 }

--- a/pkg/wekafs/apiclient/kms_test.go
+++ b/pkg/wekafs/apiclient/kms_test.go
@@ -1,0 +1,29 @@
+package apiclient
+
+import (
+	"context"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestGetKmsWhenNotDefined(t *testing.T) {
+	apiClient := GetApiClientForTest(t)
+	ctx := context.Background()
+	kms, err := apiClient.GetKmsConfiguration(ctx)
+	assert.Error(t, err, "Expected error when getting KMS since it is not defined")
+	assert.Equal(t, "KMS configuration is not supported", err.Error(), "Expected error message to indicate KMS is not supported")
+	assert.Equal(t, (*Kms)(nil), kms, "Expected nil KMS")
+}
+
+func TestHasKmsConfigurationWhenNotPresent(t *testing.T) {
+	apiClient := GetApiClientForTest(t)
+	ctx := context.Background()
+	hasKms := apiClient.HasKmsConfiguration(ctx)
+	assert.False(t, hasKms, "Expected KMS configuration to not be present")
+}
+
+func TestIsEncryptionEnabledWhenNotPresent(t *testing.T) {
+	apiClient := GetApiClientForTest(t)
+	isEnabled := apiClient.IsEncryptionEnabled()
+	assert.False(t, isEnabled, "Expected encryption to be disabled")
+}

--- a/pkg/wekafs/apiclient/quota.go
+++ b/pkg/wekafs/apiclient/quota.go
@@ -259,7 +259,7 @@ func (a *ApiClient) WaitForQuotaActive(ctx context.Context, q *Quota) error {
 	f := wait.ConditionFunc(func() (bool, error) {
 		return a.IsQuotaActive(ctx, q)
 	})
-	err := wait.Poll(5*time.Second, time.Hour*24, f)
+	err := wait.Poll(1*time.Second, time.Hour*24, f)
 	if err != nil {
 		log.Ctx(ctx).Error().Err(err).Msg("")
 		return err

--- a/pkg/wekafs/driverconfig.go
+++ b/pkg/wekafs/driverconfig.go
@@ -41,6 +41,7 @@ type DriverConfig struct {
 	csiVersion                       string
 	skipGarbageCollection            bool
 	waitForObjectDeletion            bool
+	allowEncryptionWithoutKms        bool
 }
 
 func (dc *DriverConfig) Log() {
@@ -79,6 +80,7 @@ func NewDriverConfig(dynamicVolPath, VolumePrefix, SnapshotPrefix, SeedSnapshotP
 	interfaceGroupName, clientGroupName, nfsProtocolVersion string,
 	version string,
 	skipGarbageCollection, waitForObjectDeletion bool,
+	allowEncryptionWithoutKms bool,
 ) *DriverConfig {
 
 	var MutuallyExclusiveMountOptions []mutuallyExclusiveMountOptionSet
@@ -126,6 +128,7 @@ func NewDriverConfig(dynamicVolPath, VolumePrefix, SnapshotPrefix, SeedSnapshotP
 		csiVersion:                       version,
 		skipGarbageCollection:            skipGarbageCollection,
 		waitForObjectDeletion:            waitForObjectDeletion,
+		allowEncryptionWithoutKms:        allowEncryptionWithoutKms,
 	}
 }
 

--- a/pkg/wekafs/volume.go
+++ b/pkg/wekafs/volume.go
@@ -168,10 +168,6 @@ func (v *Volume) isFilesystem() bool {
 	return !v.isOnSnapshot() && !v.hasInnerPath()
 }
 
-func (v *Volume) canBeEncrypted() bool {
-	return v.isFilesystem()
-}
-
 // isEncrypted returns true if the volume is encrypted
 func (v *Volume) isEncrypted() bool {
 	return v.encrypted
@@ -1620,9 +1616,7 @@ func (v *Volume) ObtainRequestParams(ctx context.Context, params map[string]stri
 		if err != nil {
 			return errors.Join(err, errors.New("failed to parse 'encrypted' parameter"))
 		}
-		if v.canBeEncrypted() {
-			v.encrypted = encrypted
-		}
+		v.encrypted = encrypted
 	}
 	if val, ok := params["manageEncryptionKeys"]; ok {
 		if v.encrypted {

--- a/pkg/wekafs/volume.go
+++ b/pkg/wekafs/volume.go
@@ -54,6 +54,7 @@ type Volume struct {
 	mountOptions          MountOptions
 	encrypted             bool
 	manageEncryptionKeys  bool
+	encryptWithoutKms     bool
 
 	srcVolume   *Volume
 	srcSnapshot *Snapshot
@@ -1626,7 +1627,15 @@ func (v *Volume) ObtainRequestParams(ctx context.Context, params map[string]stri
 			return errors.New("manageEncryptionKeys is not supported at this moment")
 		}
 	}
-
+	if val, ok := params["encryptWithoutKms"]; ok {
+		if v.encrypted {
+			encryptWithoutKms, err := strconv.ParseBool(val)
+			if err != nil {
+				return errors.Join(err, errors.New("failed to parse 'encryptWithoutKms' parameter"))
+			}
+			v.encryptWithoutKms = encryptWithoutKms
+		}
+	}
 	return nil
 }
 

--- a/pkg/wekafs/volume.go
+++ b/pkg/wekafs/volume.go
@@ -1654,7 +1654,7 @@ func (v *Volume) ObtainRequestParams(ctx context.Context, params map[string]stri
 	}
 	if val, ok := params["encryptWithoutKms"]; ok {
 		if !v.encrypted {
-			return errors.New("manageEncryptionKeys is only supported for encrypted volumes")
+			return errors.New("encryptWithoutKms is only supported for encrypted volumes")
 		}
 
 		encryptWithoutKms, err := strconv.ParseBool(val)

--- a/pkg/wekafs/volume.go
+++ b/pkg/wekafs/volume.go
@@ -1300,10 +1300,10 @@ func (v *Volume) ensureEncryptionParams(ctx context.Context) (apiclient.Encrypti
 			return apiclient.EncryptionParams{}, status.Errorf(codes.FailedPrecondition, "Encryption with key per filesystem is not supported yet")
 
 			// flow for encryption keys per filesystem
-			if !v.apiClient.SupportsEncryptionWithKeyPerFilesystem() {
+			if !v.apiClient.SupportsCustomEncryptionSettings() {
 				return apiclient.EncryptionParams{}, status.Errorf(codes.FailedPrecondition, "Encryption with key per filesystem is not supported on the cluster")
 			}
-			if !v.apiClient.IsEncryptionEnabledWithKeyPerFilesystem(ctx) {
+			if !v.apiClient.AllowsCustomEncryptionSettings(ctx) {
 				return apiclient.EncryptionParams{}, status.Errorf(codes.FailedPrecondition, "WEKA cluster KMS server configuration does not support encryption keys per filesystem")
 			}
 		} else {


### PR DESCRIPTION
### TL;DR
Added support for encrypted filesystems in CSI volumes with and without KMS server configuration.

### What changed?
- Added encryption parameters to filesystem creation API
- Introduced new storage class parameters for encryption configuration:
  - `encryptionEnabled`: Enable/disable encryption
  - `encryptWithoutKms`: Allow encryption without KMS (testing only)
- Added compatibility checks for encryption features based on WEKA cluster version
- Added example configurations for encrypted filesystem volumes

### How to test?
1. Deploy CSI driver with encryption support enabled
2. Apply the example configurations from either:
   - `examples/dynamic_filesystem_encrypted/` for KMS-based encryption
   - `examples/dynamic_filesystem_encrypted_nokms/` for testing without KMS
3. Create PVC using the encrypted storage class
4. Verify filesystem encryption status on the WEKA cluster

### Why make this change?
To support data encryption at rest and in transit for CSI volumes, allowing users to secure their data using WEKA's filesystem encryption capabilities. This provides both production-ready KMS-based encryption and a testing mode without KMS for development environments.