### PR TITLE
feat(CSI-321): provide ability to add custom labels to CSI components

### DIFF
--- a/charts/csi-wekafsplugin/templates/controllerserver-deployment.yaml
+++ b/charts/csi-wekafsplugin/templates/controllerserver-deployment.yaml
@@ -7,10 +7,15 @@ metadata:
     app: {{ .Release.Name }}-controller
     component: {{ .Release.Name }}-controller
     release: {{ .Release.Name }}
+    {{- if .Values.controller.labels }}
+    {{- toYaml .Values.controller.labels | nindent 4 }}
+    {{- end }}
 spec:
   selector:
     matchLabels:
       app: {{ .Release.Name }}-controller
+      component: {{ .Release.Name }}-controller
+      release: {{ .Release.Name }}
   replicas: {{ .Values.controller.replicas | default 1 }}
   template:
     metadata:
@@ -18,6 +23,9 @@ spec:
         app: {{ .Release.Name }}-controller
         component: {{ .Release.Name }}-controller
         release: {{ .Release.Name }}
+        {{- if .Values.controller.podLabels }}
+        {{- toYaml .Values.controller.podLabels | nindent 8 }}
+        {{- end }}
     {{- if .Values.metrics.enabled }}
       annotations:
         prometheus.io/scrape: 'true'

--- a/charts/csi-wekafsplugin/templates/nodeserver-daemonset.yaml
+++ b/charts/csi-wekafsplugin/templates/nodeserver-daemonset.yaml
@@ -3,16 +3,28 @@ apiVersion: apps/v1
 metadata:
   name: {{ .Release.Name }}-node
   namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Release.Name }}-node
+    component: {{ .Release.Name }}-node
+    release: {{ .Release.Name }}
+    {{- if .Values.node.labels }}
+    {{- toYaml .Values.node.labels | nindent 4 }}
+    {{- end }}
 spec:
   selector:
     matchLabels:
       app: {{ .Release.Name }}-node
+      component: {{ .Release.Name }}-node
+      release: {{ .Release.Name }}
   template:
     metadata:
       labels:
         app: {{ .Release.Name }}-node
         component: {{ .Release.Name }}-node
         release: {{ .Release.Name }}
+        {{- if .Values.node.podLabels }}
+        {{- toYaml .Values.node.podLabels | nindent 8 }}
+        {{- end }}
     {{- if .Values.metrics.enabled }}
       annotations:
         prometheus.io/scrape: 'true'

--- a/charts/csi-wekafsplugin/values.yaml
+++ b/charts/csi-wekafsplugin/values.yaml
@@ -75,6 +75,10 @@ controller:
   nodeSelector: {}
   # -- optional affinity for controller components only
   affinity: {}
+  # -- optional labels to add to controller deployment
+  labels: {}
+  # -- optional labels to add to controller pods
+  podLabels: {}
 # Node-specific parameters, please do not change unless explicitly guided
 node:
   # -- Maximum concurrent requests from sidecars (global)
@@ -89,6 +93,10 @@ node:
   nodeSelector: {}
   # -- optional affinity for node components only
   affinity: {}
+  # -- optional labels to add to node daemonset
+  labels: {}
+  # -- optional labels to add to node pods
+  podLabels: {}
 # -- Log level of CSI plugin
 logLevel: 5
 # -- Use JSON structured logging instead of human-readable logging format (for exporting logs to structured log parser)


### PR DESCRIPTION
### TL;DR
Added support for custom labels on controller and node components in the WekaFS CSI plugin Helm chart.

### What changed?
- Added ability to specify custom labels for the controller deployment and its pods through `controller.labels` and `controller.podLabels`
- Added ability to specify custom labels for the node daemonset and its pods through `node.labels` and `node.podLabels`
- Enhanced selector labels consistency by adding component and release labels

### How to test?
1. Deploy the chart with custom labels:
```yaml
controller:
  labels:
    custom-label: value1
  podLabels:
    pod-label: value2
node:
  labels:
    custom-label: value3
  podLabels:
    pod-label: value4
```
2. Verify the labels are applied:
```bash
kubectl get deployment -l custom-label=value1
kubectl get pods -l pod-label=value2
kubectl get daemonset -l custom-label=value3
kubectl get pods -l pod-label=value4
```

### Why make this change?
To provide users with more flexibility in labeling their CSI plugin resources, enabling better integration with monitoring, security policies, and resource management tools that rely on Kubernetes labels.