### PR TITLE
fix(CSI-322): revert CSI-309 migrate from Alpine to RedHat UBI9 base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
 ARG KUBECTL_VERSION=1.31.2
-ARG UBI_HASH=9.5-1736404036
 FROM golang:1.23-alpine AS go-builder
 ARG TARGETARCH
 ARG TARGETOS
@@ -30,11 +29,15 @@ RUN echo Building package
 RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -a -ldflags "-X main.version=$VERSION -extldflags '-static'" -o "/bin/wekafsplugin" /src/cmd/*
 FROM registry.k8s.io/kubernetes/kubectl:v${KUBECTL_VERSION} AS kubectl
 
-FROM registry.access.redhat.com/ubi9/ubi:${UBI_HASH}
+FROM alpine:3.18
 LABEL maintainers="WekaIO, LTD"
 LABEL description="Weka CSI Driver"
 
-RUN dnf install -y util-linux libselinux-utils pciutils binutils jq procps less
+RUN apk add --no-cache util-linux libselinux libselinux-utils util-linux  \
+    pciutils usbutils coreutils binutils findutils  \
+    grep bash nfs-utils rpcbind ca-certificates jq
+# Update CA certificates
+RUN update-ca-certificates
 RUN mkdir -p /licenses
 COPY LICENSE /licenses
 LABEL maintainer="csi@weka.io"


### PR DESCRIPTION
### TL;DR
Switch base image from Red Hat UBI to Alpine Linux for the CSI driver container

### What changed?
- Removed UBI_HASH build argument
- Changed base image from `registry.access.redhat.com/ubi9/ubi` to `alpine:3.18`
- Replaced `dnf install` with `apk add` for system packages
- Added additional Alpine-specific packages and CA certificate update step

### How to test?
1. Build the container image using the updated Dockerfile
2. Deploy the CSI driver in a test environment
3. Verify all CSI operations function correctly
4. Confirm system utilities are accessible and working as expected

### Why make this change?
This is an interim solution to resolve SELinux permissions issues when running on top of SELinux-enabled nodes and using a UBI9 base image.