### PR TITLE
fix(CSI-323): when snapshot of directory backed volumes is prohibited, incorrect error message is shown stating volume is legacy

### DIFF
--- a/pkg/wekafs/volumeconstructors.go
+++ b/pkg/wekafs/volumeconstructors.go
@@ -279,7 +279,7 @@ func NewVolumeForCloneVolumeRequest(ctx context.Context, req *csi.CreateVolumeRe
 	}
 	if sourceVol.hasInnerPath() && !server.getConfig().allowSnapshotsOfDirectoryVolumes {
 		// block cloning of snapshots from legacy volumes, as it wastes space
-		return nil, status.Errorf(codes.FailedPrecondition, "Cloning is not supported for Legacy CSI volumes")
+		return nil, status.Errorf(codes.FailedPrecondition, "Cloning is prohibited for directory-backed volumes, refer to WEKA CSI Plugin documentation for additional information")
 	}
 
 	// we assume the following when cloning a volume from existing volume:


### PR DESCRIPTION
### TL;DR
Updated error message when attempting to clone directory-backed volumes without explicitly allowing it in CSI plugin configuration.

### What changed?
Modified the error message when users attempt to clone directory-backed volumes to be more descriptive and helpful, pointing users to documentation for more information.

### How to test?
1. Attempt to clone a directory-backed volume
2. Verify the new error message appears: "Cloning is prohibited for directory-backed volumes, refer to WEKA CSI Plugin documentation for additional information"

### Why make this change?
The previous error message was unclear and didn't provide users with enough context about why the operation failed or where to find more information. The new message clearly states that directory-backed volumes cannot be cloned and directs users to documentation for further details.