### PR TITLE
fix(CSI-326): invalid socket dir path causing 2 instances of CSI plugin to interfere with each other

### DIFF
--- a/charts/csi-wekafsplugin/templates/controllerserver-deployment.yaml
+++ b/charts/csi-wekafsplugin/templates/controllerserver-deployment.yaml
@@ -343,7 +343,7 @@ spec:
       {{- end }}
       volumes:
         - hostPath:
-            path: {{ .Values.kubeletPath | default "/var/lib/kubelet" }}/plugins/csi-wekafs-controller
+            path: {{ .Values.kubeletPath | default "/var/lib/kubelet" }}/plugins/{{ .Release.Name }}-controller
             type: DirectoryOrCreate
           name: socket-dir
         - hostPath:

--- a/charts/csi-wekafsplugin/templates/nodeserver-daemonset.yaml
+++ b/charts/csi-wekafsplugin/templates/nodeserver-daemonset.yaml
@@ -228,7 +228,7 @@ spec:
             - name: ADDRESS
               value: unix:///csi/csi.sock
             - name: KUBELET_REGISTRATION_PATH
-              value: "{{ (.Values.kubeletPath | default "/var/lib/kubelet") | toString }}/plugins/csi-wekafs-node/csi.sock"
+              value: "{{ (.Values.kubeletPath | default "/var/lib/kubelet") | toString }}/plugins/{{ .Release.Name }}-node/csi.sock"
 
           volumeMounts:
             - mountPath: /csi
@@ -255,7 +255,7 @@ spec:
             type: Directory
           name: plugins-dir
         - hostPath:
-            path: {{ .Values.kubeletPath | default "/var/lib/kubelet" }}/plugins/csi-wekafs-node
+            path: {{ .Values.kubeletPath | default "/var/lib/kubelet" }}/plugins/{{ .Release.Name }}-node
             type: DirectoryOrCreate
           name: socket-dir
         - hostPath:


### PR DESCRIPTION
### TL;DR
Updated plugin socket paths to use dynamic release names instead of hardcoded values

### What changed?
- Modified socket directory paths in both controller and node components to use `{{ .Release.Name }}` instead of hardcoded `csi-wekafs`
- Controller path changed from `csi-wekafs-controller` to `{{ .Release.Name }}-controller`
- Node path changed from `csi-wekafs-node` to `{{ .Release.Name }}-node`

### How to test?
1. Deploy the helm chart with a custom release name
2. Verify that the socket directories are created with the correct release name prefix
3. Confirm that the CSI driver can still communicate through the updated socket paths
4. Test volume operations to ensure functionality remains intact

### Why make this change?
This change enables multiple installations of the CSI driver in the same cluster by using unique socket paths based on the helm release name, preventing conflicts between different instances of the driver.