### PR TITLE
ci(chore): update workflows to use larger server group

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -6,7 +6,8 @@ on:
 
 jobs:
   pr-test:
-    runs-on: ubuntu-latest
+    runs-on:
+      group: large-runners-public
     steps:
       - name: Checkout Code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4

--- a/.github/workflows/push-dev.yaml
+++ b/.github/workflows/push-dev.yaml
@@ -8,7 +8,8 @@ on:
 
 jobs:
   push-dev:
-    runs-on: ubuntu-latest
+    runs-on:
+      group: large-runners-public
     permissions:
       contents: write
       pages: write

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,7 +28,8 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    runs-on:
+      group: large-runners-public
     steps:
 
       - name: log inputs


### PR DESCRIPTION
### TL;DR
Updated GitHub Actions workflows to use large-runners-public runner group instead of ubuntu-latest

### What changed?
Modified the `runs-on` configuration in pull-request, push-dev, and release workflows to utilize the `large-runners-public` runner group

### How to test?
1. Create a new pull request
2. Verify that workflows are triggered and execute on the large-runners-public group
3. Confirm that all jobs complete successfully

### Why make this change?
To improve workflow execution performance and resource availability by utilizing larger runner instances instead of the default ubuntu-latest runners