### PR TITLE
fix(CSI-331): add terminationGracePeriodSeconds to controller and pod workloads

### DIFF
--- a/charts/csi-wekafsplugin/templates/controllerserver-deployment.yaml
+++ b/charts/csi-wekafsplugin/templates/controllerserver-deployment.yaml
@@ -344,6 +344,7 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.controller.terminationGracePeriodSeconds | default 30 }}
       volumes:
         - hostPath:
             path: {{ .Values.kubeletPath | default "/var/lib/kubelet" }}/plugins/{{ .Release.Name }}-controller

--- a/charts/csi-wekafsplugin/templates/nodeserver-daemonset.yaml
+++ b/charts/csi-wekafsplugin/templates/nodeserver-daemonset.yaml
@@ -220,6 +220,7 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.node.terminationGracePeriodSeconds | default 30 }}
       volumes:
         - hostPath:
             path: {{ .Values.kubeletPath | default "/var/lib/kubelet" }}/pods

--- a/charts/csi-wekafsplugin/values.yaml
+++ b/charts/csi-wekafsplugin/values.yaml
@@ -79,6 +79,8 @@ controller:
   labels: {}
   # -- optional labels to add to controller pods
   podLabels: {}
+  # -- termination grace period for controller pods
+  terminationGracePeriodSeconds: 10
 # Node-specific parameters, please do not change unless explicitly guided
 node:
   # -- Maximum concurrent requests from sidecars (global)
@@ -97,6 +99,8 @@ node:
   labels: {}
   # -- optional labels to add to node pods
   podLabels: {}
+  # -- termination grace period for node pods
+  terminationGracePeriodSeconds: 10
 # -- Log level of CSI plugin
 logLevel: 5
 # -- Use JSON structured logging instead of human-readable logging format (for exporting logs to structured log parser)


### PR DESCRIPTION
### TL;DR
Added configurable termination grace periods for controller and node pods in the WekaFS CSI plugin.

### What changed?
- Added `terminationGracePeriodSeconds` configuration option for both controller and node components
- Set default value to 10 seconds for both components
- Made the value configurable through Helm values

### How to test?
1. Deploy the CSI plugin with custom termination grace periods:
```yaml
controller:
  terminationGracePeriodSeconds: 15
node:
  terminationGracePeriodSeconds: 20
```
2. Delete a pod and verify it terminates within the configured grace period
3. Verify the default value (10 seconds) is applied when no custom value is specified

### Why make this change?
To provide more control over pod termination behavior, allowing users to fine-tune how long pods have to gracefully shut down before being forcefully terminated. This helps in scenarios where faster pod termination is desired or when longer grace periods are needed for clean shutdown.