### PR TITLE
fix(CSI-332): collision on OCP machineConfigs when installing multiple instances due to same name

### DIFF
--- a/charts/csi-wekafsplugin/templates/selinux-policy-machineconfig.yaml
+++ b/charts/csi-wekafsplugin/templates/selinux-policy-machineconfig.yaml
@@ -3,7 +3,7 @@
 kind: MachineConfig
 apiVersion: machineconfiguration.openshift.io/v1
 metadata:
-  name: 50-csi-wekafs-selinux-policy-{{ . }}
+  name: 50-{{ $.Release.Name }}-selinux-policy-{{ . }}
   labels:
     machineconfiguration.openshift.io/role: {{ . }}
 spec:


### PR DESCRIPTION
### TL;DR
Updated the MachineConfig name to include the Helm release name in the SELinux policy template.

### What changed?
Modified the `name` field in the MachineConfig template to include `$.Release.Name` as part of the resource identifier, changing from `50-csi-wekafs-selinux-policy-{{ . }}` to `50-{{ $.Release.Name }}-selinux-policy-{{ . }}`.

### How to test?
1. Install the chart with a custom release name
2. Verify that the MachineConfig resources are created with the release name in their names
3. Confirm that SELinux policies are still properly applied to the nodes

### Why make this change?
This change allows for better resource identification and isolation when multiple instances of the chart are deployed in the same cluster with different release names, preventing potential naming conflicts.