### PR TITLE
feat(CSI-334): allow using multiple mounters in parallel on same server

### DIFF
--- a/pkg/wekafs/controllerserver.go
+++ b/pkg/wekafs/controllerserver.go
@@ -18,6 +18,7 @@ package wekafs
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/rs/zerolog"
@@ -43,7 +44,7 @@ type ControllerServer struct {
 	csi.UnimplementedControllerServer
 	caps            []*csi.ControllerServiceCapability
 	nodeID          string
-	mounters   *MounterGroup
+	mounters        *MounterGroup
 	api             *ApiStore
 	config          *DriverConfig
 	semaphores      map[string]*semaphore.Weighted
@@ -113,16 +114,20 @@ func (cs *ControllerServer) ControllerModifyVolume(context.Context, *csi.Control
 	panic("implement me")
 }
 
-func NewControllerServer(nodeID string, api *ApiStore, mounters *MounterGroup, config *DriverConfig) *ControllerServer {
+func NewControllerServer(driver *WekaFsDriver) *ControllerServer {
+	if driver == nil {
+		panic("driver is nil")
+	}
+
 	exposedCapabilities := []csi.ControllerServiceCapability_RPC_Type{
 		csi.ControllerServiceCapability_RPC_CREATE_DELETE_VOLUME,
 		csi.ControllerServiceCapability_RPC_EXPAND_VOLUME,
-		csi.ControllerServiceCapability_RPC_SINGLE_NODE_MULTI_WRITER, // add ReadWriteOncePod supoort
+		csi.ControllerServiceCapability_RPC_SINGLE_NODE_MULTI_WRITER, // add ReadWriteOncePod support
 	}
-	if config.advertiseSnapshotSupport {
+	if driver.config.advertiseSnapshotSupport {
 		exposedCapabilities = append(exposedCapabilities, csi.ControllerServiceCapability_RPC_CREATE_DELETE_SNAPSHOT)
 	}
-	if config.advertiseVolumeCloneSupport {
+	if driver.config.advertiseVolumeCloneSupport {
 		exposedCapabilities = append(exposedCapabilities, csi.ControllerServiceCapability_RPC_CLONE_VOLUME)
 	}
 
@@ -130,10 +135,10 @@ func NewControllerServer(nodeID string, api *ApiStore, mounters *MounterGroup, c
 
 	return &ControllerServer{
 		caps:            capabilities,
-		nodeID:          nodeID,
-		mounters:        mounters,
-		api:             api,
-		config:          config,
+		nodeID:          driver.nodeID,
+		mounters:        driver.mounters,
+		api:             driver.api,
+		config:          driver.config,
 		semaphores:      make(map[string]*semaphore.Weighted),
 		backgroundTasks: new(sync.WaitGroup),
 	}
@@ -177,9 +182,9 @@ func (cs *ControllerServer) CheckCreateVolumeRequestSanity(ctx context.Context, 
 	return nil
 }
 
-type releaseSempahore func()
+type releaseSemaphore func()
 
-func (cs *ControllerServer) acquireSemaphore(ctx context.Context, op string) (error, releaseSempahore) {
+func (cs *ControllerServer) acquireSemaphore(ctx context.Context, op string) (error, releaseSemaphore) {
 	logger := log.Ctx(ctx)
 	cs.initializeSemaphore(ctx, op)
 	sem := cs.semaphores[op]
@@ -210,10 +215,10 @@ func (cs *ControllerServer) initializeSemaphore(ctx context.Context, op string) 
 	if _, ok := cs.semaphores[op]; ok {
 		return
 	}
-	max := cs.getConfig().maxConcurrencyPerOp[op]
+	m := cs.getConfig().maxConcurrencyPerOp[op]
 	logger := log.Ctx(ctx)
-	logger.Info().Str("op", op).Int64("max_concurrency", max).Msg("Initializing semaphore")
-	sem := semaphore.NewWeighted(max)
+	logger.Info().Str("op", op).Int64("max_concurrency", m).Msg("Initializing semaphore")
+	sem := semaphore.NewWeighted(m)
 	cs.semaphores[op] = sem
 }
 
@@ -300,7 +305,7 @@ func (cs *ControllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 	} else if volExists && err == nil {
 		// current capacity explicitly differs from requested, this is another volume request
 		return CreateVolumeError(ctx, codes.AlreadyExists, "Volume with same name and different capacity already exists")
-	} else if volExists && err != nil {
+	} else if volExists {
 		// can happen if volume is half-made (object was created but capacity was not set on it on previous run)
 		if err := volume.UpdateCapacity(ctx, &volume.enforceCapacity, capacity); err == nil {
 			result = "SUCCESS"
@@ -411,7 +416,7 @@ func (cs *ControllerServer) DeleteVolume(ctx context.Context, req *csi.DeleteVol
 	}
 	// cleanup
 	if err != nil {
-		if err == ErrFilesystemHasUnderlyingSnapshots {
+		if errors.Is(err, ErrFilesystemHasUnderlyingSnapshots) {
 			return &csi.DeleteVolumeResponse{}, err
 		}
 		return DeleteVolumeError(ctx, codes.Internal, err.Error())

--- a/pkg/wekafs/identityserver.go
+++ b/pkg/wekafs/identityserver.go
@@ -61,11 +61,14 @@ func (ids *identityServer) getBackgroundTasksWg() *sync.WaitGroup {
 }
 
 //goland:noinspection GoExportedFuncWithUnexportedType
-func NewIdentityServer(name, version string, config *DriverConfig) *identityServer {
+func NewIdentityServer(driver *WekaFsDriver) *identityServer {
+	if driver == nil {
+		panic("Driver is nil")
+	}
 	return &identityServer{
-		name:    name,
-		version: version,
-		config:  config,
+		name:    driver.name,
+		version: driver.version,
+		config:  driver.config,
 	}
 }
 

--- a/pkg/wekafs/identityserver.go
+++ b/pkg/wekafs/identityserver.go
@@ -110,15 +110,31 @@ func (ids *identityServer) getConfig() *DriverConfig {
 //goland:noinspection GoUnusedParameter
 func (ids *identityServer) Probe(ctx context.Context, req *csi.ProbeRequest) (*csi.ProbeResponse, error) {
 	logger := log.Ctx(ctx)
-	isReady := ids.getConfig().isInDevMode() || isWekaRunning()
-	if !isReady {
-		if ids.getConfig().useNfs || ids.getConfig().allowNfsFailback {
-			isReady = true
-		}
+	config := ids.getConfig()
+	driver := config.GetDriver()
+	mounters := driver.mounters
+
+	nfsReady := config.useNfs || config.allowNfsFailback
+	// weka is ready if we are in dev mode or weka is running AND NFS is not forced
+	wekafsReady := config.isInDevMode() || isWekaRunning() && !config.useNfs
+
+	if nfsReady {
+		mounters.nfs.Enable()
+	} else {
+		mounters.nfs.Disable()
 	}
+
+	if wekafsReady {
+		mounters.wekafs.Enable()
+	} else {
+		mounters.wekafs.Disable()
+	}
+
+	serverReady := nfsReady || wekafsReady
+
 	// manage node topology labels only if set by configuration
 	if ids.config.manageNodeTopologyLabels {
-		if !isReady {
+		if !serverReady {
 			logger.Error().Msg("Weka driver not running on host and NFS transport is not configured, not ready to perform operations")
 			if ids.config.driverRef.csiMode == CsiModeNode || ids.config.driverRef.csiMode == CsiModeAll {
 				ids.getConfig().GetDriver().CleanupNodeLabels(ctx)
@@ -127,9 +143,10 @@ func (ids *identityServer) Probe(ctx context.Context, req *csi.ProbeRequest) (*c
 			ids.getConfig().GetDriver().SetNodeLabels(ctx)
 		}
 	}
+
 	return &csi.ProbeResponse{
 		Ready: &wrapperspb.BoolValue{
-			Value: isReady,
+			Value: serverReady,
 		},
 	}, nil
 }

--- a/pkg/wekafs/interfaces.go
+++ b/pkg/wekafs/interfaces.go
@@ -13,7 +13,8 @@ const (
 )
 
 type AnyServer interface {
-	getMounter() AnyMounter
+	getMounter(ctx context.Context) AnyMounter
+	getMounterByTransport(ctx context.Context, transport DataTransport) AnyMounter
 	getApiStore() *ApiStore
 	getConfig() *DriverConfig
 	isInDevMode() bool
@@ -32,6 +33,9 @@ type AnyMounter interface {
 	schedulePeriodicMountGc()
 	getGarbageCollector() *innerPathVolGc
 	getTransport() DataTransport
+	isEnabled() bool
+	Enable()
+	Disable()
 }
 
 type nfsMountsMap map[string]int // we only follow the mountPath and number of references

--- a/pkg/wekafs/mountergroup.go
+++ b/pkg/wekafs/mountergroup.go
@@ -1,0 +1,63 @@
+package wekafs
+
+import (
+	"context"
+	"github.com/rs/zerolog/log"
+)
+
+type MounterGroup struct {
+	nfs    AnyMounter
+	wekafs AnyMounter
+}
+
+var TransportPreference []DataTransport = []DataTransport{dataTransportWekafs, dataTransportNfs}
+
+func NewMounterGroup(driver *WekaFsDriver) *MounterGroup {
+	ret := &MounterGroup{}
+	log.Info().Msg("Configuring Mounter Group")
+	ret.nfs = newNfsMounter(driver)
+	ret.wekafs = newWekafsMounter(driver)
+
+	if driver.config.useNfs {
+		log.Warn().Msg("Enforcing NFS transport due to configuration")
+		ret.nfs.Enable()
+		ret.wekafs.Disable()
+
+	} else if driver.config.allowNfsFailback {
+		ret.nfs.Enable()
+		if driver.config.isInDevMode() {
+			log.Info().Msg("Not Enforcing NFS transport due to dev mode")
+		} else {
+			if !isWekaRunning() {
+				ret.nfs.Enable()
+				ret.wekafs.Disable()
+				log.Warn().Msg("Weka Driver not found. Failing back to NFS transport")
+			}
+		}
+	}
+	log.Info().Msg("Enforcing WekaFS transport")
+	return ret
+}
+
+func (mg *MounterGroup) GetMounterByTransport(ctx context.Context, transport DataTransport) AnyMounter {
+	logger := log.Ctx(ctx)
+	if transport == dataTransportNfs {
+		return mg.nfs
+	} else if transport == dataTransportWekafs {
+		return mg.wekafs
+	} else {
+		logger.Error().Msgf("Unknown transport type: %s", transport)
+		return nil
+	}
+}
+
+func (mg *MounterGroup) GetPreferredMounter(ctx context.Context) AnyMounter {
+	for _, t := range TransportPreference {
+		m := mg.GetMounterByTransport(ctx, t)
+		if m.isEnabled() {
+			return m
+		}
+	}
+	log.Ctx(ctx).Error().Msg("No enabled mounter found")
+	return nil
+}

--- a/pkg/wekafs/nfsmounter.go
+++ b/pkg/wekafs/nfsmounter.go
@@ -34,10 +34,16 @@ func (n *nfsMounter) isEnabled() bool {
 }
 
 func (n *nfsMounter) Enable() {
+	if !n.enabled {
+		log.Ctx(context.Background()).Info().Msg("Enabling NFS mounter")
+	}
 	n.enabled = true
 }
 
 func (n *nfsMounter) Disable() {
+	if n.enabled {
+		log.Ctx(context.Background()).Info().Msg("Disabling NFS mounter")
+	}
 	n.enabled = false
 }
 

--- a/pkg/wekafs/nodeserver.go
+++ b/pkg/wekafs/nodeserver.go
@@ -198,7 +198,10 @@ func getVolumeStats(volumePath string) (volumeStats *VolumeStats, err error) {
 	return &VolumeStats{capacityBytes, usedBytes, availableBytes, inodes, inodesUsed, inodesFree}, nil
 }
 
-func NewNodeServer(nodeId string, maxVolumesPerNode int64, api *ApiStore, mounters *MounterGroup, config *DriverConfig) *NodeServer {
+func NewNodeServer(driver *WekaFsDriver) *NodeServer {
+	if driver == nil {
+		panic("Driver is nil")
+	}
 	//goland:noinspection GoBoolExpressions
 	return &NodeServer{
 		caps: getNodeServiceCapabilities(
@@ -208,17 +211,17 @@ func NewNodeServer(nodeId string, maxVolumesPerNode int64, api *ApiStore, mounte
 				csi.NodeServiceCapability_RPC_VOLUME_CONDITION,
 			},
 		),
-		nodeID:            nodeId,
-		maxVolumesPerNode: maxVolumesPerNode,
-		mounters:          mounters,
-		api:               api,
-		config:            config,
+		nodeID:            driver.nodeID,
+		maxVolumesPerNode: driver.maxVolumesPerNode,
+		mounters:          driver.mounters,
+		api:               driver.api,
+		config:            driver.config,
 		semaphores:        make(map[string]*semaphore.Weighted),
 		backgroundTasksWg: new(sync.WaitGroup),
 	}
 }
 
-func (ns *NodeServer) acquireSemaphore(ctx context.Context, op string) (error, releaseSempahore) {
+func (ns *NodeServer) acquireSemaphore(ctx context.Context, op string) (error, releaseSemaphore) {
 	logger := log.Ctx(ctx)
 	ns.initializeSemaphore(ctx, op)
 	sem := ns.semaphores[op]

--- a/pkg/wekafs/utilities.go
+++ b/pkg/wekafs/utilities.go
@@ -17,6 +17,7 @@ import (
 	"google.golang.org/grpc/status"
 	timestamp "google.golang.org/protobuf/types/known/timestamppb"
 	"os"
+	"path"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -322,7 +323,7 @@ func GetMountIpFromActualMountPoint(mountPointBase string) (string, error) {
 		fields := strings.Fields(scanner.Text())
 		if len(fields) >= 3 && strings.HasPrefix(fields[1], fmt.Sprintf("%s-", mountPointBase)) {
 			actualMountPoint = fields[1]
-			return strings.TrimLeft(actualMountPoint, mountPointBase+"-"), nil
+			return strings.TrimLeft(actualMountPoint, string(mountPointBase+"-")), nil
 		}
 	}
 	return "", errors.New("mount point not found")
@@ -604,4 +605,15 @@ func getSelinuxStatus(ctx context.Context) bool {
 		logger.Error().Err(err).Str("filename", selinuxConf).Msg("Failed to read SELinux config file")
 	}
 	return false
+}
+
+func getDataTransportFromMountPath(mountPoint string) DataTransport {
+	if strings.HasPrefix(mountPoint, path.Join(MountBasePath, string(dataTransportNfs))) {
+		return dataTransportWekafs
+	}
+	if strings.HasPrefix(mountPoint, path.Join(MountBasePath, string(dataTransportWekafs))) {
+		return dataTransportWekafs
+	}
+	// just default
+	return dataTransportWekafs
 }

--- a/pkg/wekafs/volume.go
+++ b/pkg/wekafs/volume.go
@@ -258,10 +258,10 @@ func (v *Volume) getUnderlyingSnapshots(ctx context.Context) (*[]apiclient.Snaps
 		return snapshots, nil
 	}
 
-	if fsObj.IsRemoving {
-		// assume snapshots are not relevant in such case
-		return snapshots, nil
-	}
+	//if fsObj.IsRemoving {
+	//	// assume snapshots are not relevant in such case
+	//	return snapshots, nil
+	//}
 
 	err = v.apiClient.FindSnapshotsByFilesystem(ctx, fsObj, snapshots)
 	if err != nil {
@@ -1521,7 +1521,7 @@ func (v *Volume) deleteFilesystem(ctx context.Context) error {
 
 	logger := log.Ctx(ctx).With().Str("volume_id", v.GetId()).Logger()
 	logger.Debug().Str("filesystem", v.FilesystemName).Msg("Deleting filesystem")
-	fsObj, err := v.getFilesystemObj(ctx, true)
+	fsObj, err := v.getFilesystemObj(ctx, false)
 	if err != nil {
 		logger.Error().Err(err).Str("filesystem", v.FilesystemName).Msg("Failed to fetch filesystem for deletion")
 		return status.Errorf(codes.Internal, "Failed to fetch filesystem for deletion: %s, %e", v.FilesystemName, err)

--- a/pkg/wekafs/volume.go
+++ b/pkg/wekafs/volume.go
@@ -684,7 +684,7 @@ func (v *Volume) updateCapacityXattr(ctx context.Context, enforceCapacity *bool,
 
 func (v *Volume) Trash(ctx context.Context) error {
 	if v.requiresGc() {
-		return v.server.getMounter().getGarbageCollector().triggerGcVolume(ctx, v)
+		return v.server.getMounter(ctx).getGarbageCollector().triggerGcVolume(ctx, v)
 	}
 	return v.Delete(ctx)
 }
@@ -914,13 +914,13 @@ func (v *Volume) MountUnderlyingFS(ctx context.Context) (error, UnmountFunc) {
 	defer span.End()
 	ctx = log.With().Str("trace_id", span.SpanContext().TraceID().String()).Str("span_id", span.SpanContext().SpanID().String()).Str("op", op).Logger().WithContext(ctx)
 	logger := log.Ctx(ctx)
-	if v.server.getMounter() == nil {
+	if v.server.getMounter(ctx) == nil {
 		return errors.New("could not mount volume, mounter not in context"), func() {}
 	}
 
 	mountOpts := v.server.getDefaultMountOptions().MergedWith(v.getMountOptions(ctx), v.server.getConfig().mutuallyExclusiveOptions)
 
-	mount, err, unmountFunc := v.server.getMounter().mountWithOptions(ctx, v.FilesystemName, mountOpts, v.apiClient)
+	mount, err, unmountFunc := v.server.getMounter(ctx).mountWithOptions(ctx, v.FilesystemName, mountOpts, v.apiClient)
 	retUmountFunc := func() {}
 	if err == nil {
 		v.mountPath = mount
@@ -942,12 +942,12 @@ func (v *Volume) UnmountUnderlyingFS(ctx context.Context) error {
 	ctx = log.With().Str("trace_id", span.SpanContext().TraceID().String()).Str("span_id", span.SpanContext().SpanID().String()).Str("op", op).Logger().WithContext(ctx)
 	logger := log.Ctx(ctx)
 
-	if v.server.getMounter() == nil {
+	if v.server.getMounter(ctx) == nil {
 		Die("Volume unmount could not be done since mounter not defined on it")
 	}
 
 	mountOpts := v.getMountOptions(ctx)
-	err := v.server.getMounter().unmountWithOptions(ctx, v.FilesystemName, mountOpts)
+	err := v.server.getMounter(ctx).unmountWithOptions(ctx, v.FilesystemName, mountOpts)
 
 	if err == nil {
 		v.mountPath = ""
@@ -1533,7 +1533,7 @@ func (v *Volume) deleteFilesystem(ctx context.Context) error {
 	}
 
 	deleteFunc := func(fsObj *apiclient.FileSystem) error {
-		if v.server.getMounter().getTransport() == dataTransportNfs {
+		if v.server.getMounter(ctx).getTransport() == dataTransportNfs {
 			logger.Trace().Str("filesystem", v.FilesystemName).Msg("Ensuring no NFS permissions exist that could block filesystem deletion")
 			err := v.apiClient.EnsureNoNfsPermissionsForFilesystem(ctx, fsObj.Name)
 			if err != nil {

--- a/pkg/wekafs/volume.go
+++ b/pkg/wekafs/volume.go
@@ -919,7 +919,6 @@ func (v *Volume) MountUnderlyingFS(ctx context.Context) (error, UnmountFunc) {
 	}
 
 	mountOpts := v.server.getDefaultMountOptions().MergedWith(v.getMountOptions(ctx), v.server.getConfig().mutuallyExclusiveOptions)
-
 	mount, err, unmountFunc := v.server.getMounter(ctx).mountWithOptions(ctx, v.FilesystemName, mountOpts, v.apiClient)
 	retUmountFunc := func() {}
 	if err == nil {
@@ -942,12 +941,20 @@ func (v *Volume) UnmountUnderlyingFS(ctx context.Context) error {
 	ctx = log.With().Str("trace_id", span.SpanContext().TraceID().String()).Str("span_id", span.SpanContext().SpanID().String()).Str("op", op).Logger().WithContext(ctx)
 	logger := log.Ctx(ctx)
 
-	if v.server.getMounter(ctx) == nil {
-		Die("Volume unmount could not be done since mounter not defined on it")
+	mountTransport := getDataTransportFromMountPath(v.mountPath)
+
+	mounter := v.server.getMounter(ctx)
+	if mountTransport == "" {
+		logger.Debug().Msg("Could not identify transport from mount path, assuming default")
+	} else {
+		mounter = v.server.getMounterByTransport(ctx, mountTransport)
+	}
+	if mounter == nil {
+		return errors.New(string("could not find mounter for transport " + mountTransport))
 	}
 
 	mountOpts := v.getMountOptions(ctx)
-	err := v.server.getMounter(ctx).unmountWithOptions(ctx, v.FilesystemName, mountOpts)
+	err := mounter.unmountWithOptions(ctx, v.FilesystemName, mountOpts)
 
 	if err == nil {
 		v.mountPath = ""

--- a/pkg/wekafs/wekafsmounter.go
+++ b/pkg/wekafs/wekafsmounter.go
@@ -31,10 +31,16 @@ func (m *wekafsMounter) isEnabled() bool {
 }
 
 func (m *wekafsMounter) Enable() {
+	if !m.enabled {
+		log.Ctx(context.Background()).Info().Msg("Enabling WekaFS mounter")
+	}
 	m.enabled = true
 }
 
 func (m *wekafsMounter) Disable() {
+	if m.enabled {
+		log.Ctx(context.Background()).Info().Msg("Disabling WekaFS mounter")
+	}
 	m.enabled = false
 }
 


### PR DESCRIPTION
# Multiple Transport Protocol Support with Automatic Failover

Adds support for multiple transport protocols (NFS/WekaFS) with automatic failover and protocol preference configuration. Enables dynamic selection of the optimal transport method based on system capabilities and configuration settings.

Key changes:
- Introduces MounterGroup to manage multiple transport protocols
- Implements transport protocol preference ordering
- Adds automatic failover between WekaFS and NFS based on system availability
- Supports configuration-driven transport selection
- Maintains backward compatibility with existing mount paths
- Adds enable/disable functionality for transport protocols