### PR TITLE
feat(CSI-337): no readiness check and labels removal when weka client not running

### DIFF
--- a/pkg/wekafs/identityserver.go
+++ b/pkg/wekafs/identityserver.go
@@ -90,6 +90,11 @@ func (ids *identityServer) Probe(ctx context.Context, req *csi.ProbeRequest) (*c
 	}
 	if !isReady {
 		logger.Error().Msg("Weka driver not running on host and NFS transport is not configured, not ready to perform operations")
+		if ids.config.driverRef.csiMode == CsiModeNode || ids.config.driverRef.csiMode == CsiModeAll {
+			ids.getConfig().GetDriver().CleanupNodeLabels(ctx)
+		}
+	} else if !ids.getConfig().isInDevMode() {
+		ids.getConfig().GetDriver().SetNodeLabels(ctx)
 	}
 	return &csi.ProbeResponse{
 		Ready: &wrapperspb.BoolValue{


### PR DESCRIPTION
### TL;DR
Enhanced node readiness checks and label management in the Weka CSI driver

### What changed?
- Added verification of Weka client software connectivity through `/proc/wekafs/interface`
- Implemented automatic node label management based on driver readiness state
- Added new constants for proc paths (`ProcModulesPath` and `ProcWekafsInterface`)
- Enhanced `isWekaInstalled()` to verify both kernel module presence and client software connectivity
- Added `SetNodeLabels()` method to manage node topology labels

### How to test?
1. Deploy the CSI driver in a Kubernetes cluster
2. Verify node labels are automatically set when Weka client is running
3. Verify node labels are removed when Weka client becomes unavailable
4. Check `/proc/wekafs/interface` for "Connected frontend pid" message
5. Monitor node labels for proper topology label management

### Why make this change?
To improve cluster awareness of Weka CSI driver status and ensure proper node selection for volume operations. This change provides better visibility into the actual state of Weka client connectivity and maintains accurate topology information in the cluster.