### PR TITLE
fix(CSI-330): label cleanup should be done only on node server

### DIFF
--- a/pkg/wekafs/wekafs.go
+++ b/pkg/wekafs/wekafs.go
@@ -330,9 +330,13 @@ func (driver *WekaFsDriver) Run(ctx context.Context) {
 	defer stop()
 	go func() {
 		<-termContext.Done()
-		log.Info().Msg("Received SIGTERM/SIGINT, running cleanup of node labels...")
-		driver.CleanupNodeLabels(ctx)
-		log.Info().Msg("Cleanup completed, stopping server")
+		if driver.csiMode == CsiModeNode || driver.csiMode == CsiModeAll {
+			log.Info().Msg("Received SIGTERM/SIGINT, running cleanup of node labels...")
+			driver.CleanupNodeLabels(ctx)
+			log.Info().Msg("Cleanup completed, stopping server")
+		} else {
+			log.Info().Msg("Received SIGTERM/SIGINT, stopping server")
+		}
 		s.Stop()
 		log.Info().Msg("Server stopped")
 		os.Exit(1)


### PR DESCRIPTION
### TL;DR
Added conditional node label cleanup during CSI driver shutdown based on CSI mode.

### What changed?
Modified the termination handler to only perform node label cleanup when the CSI driver is running in Node or All mode. For other modes, the driver now proceeds directly to shutdown without attempting label cleanup.

### How to test?
1. Deploy the CSI driver in different modes (Node, Controller, All)
2. Trigger a shutdown of the driver (e.g., using SIGTERM)
3. Verify that node label cleanup only occurs in Node and All modes
4. Check logs to confirm appropriate shutdown messages

### Why make this change?
To prevent node label cleanup on controller node, which does not have the necessary permissions and should not set labels.