### PR TITLE
feat(CSI-340): use API for inode resolution on path for setting quota

### DIFF
--- a/pkg/wekafs/apiclient/cluster.go
+++ b/pkg/wekafs/apiclient/cluster.go
@@ -61,6 +61,7 @@ func (a *ApiClient) fetchClusterInfo(ctx context.Context) error {
 	logger.Info().Msg(fmt.Sprintf("Cluster supports encryption without KMS: %t", a.SupportsEncryptionWithNoKms()))
 	logger.Info().Msg(fmt.Sprintf("Cluster supports encryption of filesystems with a cluster-wide key: %t", a.SupportsEncryptionWithCommonKey()))
 	logger.Info().Msg(fmt.Sprintf("Cluster supports encryption of filesystems with custom keys: %t", a.SupportsCustomEncryptionSettings()))
+	logger.Info().Msg(fmt.Sprintf("Cluster supports resolving paths to inodes: %t", a.SupportsResolvePathToInode()))
 	return nil
 }
 

--- a/pkg/wekafs/apiclient/compatibility.go
+++ b/pkg/wekafs/apiclient/compatibility.go
@@ -21,6 +21,7 @@ type WekaCompatibilityRequiredVersions struct {
 	EncryptionWithNoKms            string
 	EncryptionWithClusterKey       string
 	EncryptionWithCustomSettings   string
+	ResolvePathToInode             string
 }
 
 var MinimumSupportedWekaVersions = &WekaCompatibilityRequiredVersions{
@@ -38,6 +39,7 @@ var MinimumSupportedWekaVersions = &WekaCompatibilityRequiredVersions{
 	EncryptionWithNoKms:            "v4.0",   // can create encrypted filesystems without KMS
 	EncryptionWithClusterKey:       "v4.0",   // can create encrypted filesystems with common cluster-wide key
 	EncryptionWithCustomSettings:   "v4.4.1", // can create encrypted filesystems with custom settings (key per filesystem(s))
+	ResolvePathToInode:             "v4.3",   // can resolve a path to an inode instead of doing it via mount
 }
 
 type WekaCompatibilityMap struct {
@@ -55,6 +57,7 @@ type WekaCompatibilityMap struct {
 	EncryptionWithNoKms             bool
 	EncryptionWithClusterKey        bool
 	EncryptionWithCustomSettings    bool
+	ResolvePathToInode              bool
 }
 
 func (cm *WekaCompatibilityMap) fillIn(versionStr string) {
@@ -75,6 +78,7 @@ func (cm *WekaCompatibilityMap) fillIn(versionStr string) {
 		cm.EncryptionWithNoKms = false
 		cm.EncryptionWithClusterKey = false
 		cm.EncryptionWithCustomSettings = false
+		cm.ResolvePathToInode = false
 
 		return
 	}
@@ -92,6 +96,7 @@ func (cm *WekaCompatibilityMap) fillIn(versionStr string) {
 	en, _ := version.NewVersion(MinimumSupportedWekaVersions.EncryptionWithNoKms)
 	ec, _ := version.NewVersion(MinimumSupportedWekaVersions.EncryptionWithClusterKey)
 	ecc, _ := version.NewVersion(MinimumSupportedWekaVersions.EncryptionWithCustomSettings)
+	rp, _ := version.NewVersion(MinimumSupportedWekaVersions.ResolvePathToInode)
 
 	cm.DirectoryAsCSIVolume = v.GreaterThanOrEqual(d)
 	cm.FilesystemAsCSIVolume = v.GreaterThanOrEqual(f)
@@ -107,6 +112,7 @@ func (cm *WekaCompatibilityMap) fillIn(versionStr string) {
 	cm.EncryptionWithNoKms = v.GreaterThanOrEqual(en)
 	cm.EncryptionWithClusterKey = v.GreaterThanOrEqual(ec)
 	cm.EncryptionWithCustomSettings = v.GreaterThanOrEqual(ecc)
+	cm.ResolvePathToInode = v.GreaterThanOrEqual(rp)
 }
 
 func (a *ApiClient) SupportsQuotaDirectoryAsVolume() bool {
@@ -163,4 +169,8 @@ func (a *ApiClient) SupportsCustomEncryptionSettings() bool {
 
 func (a *ApiClient) RequiresNewNodePath() bool {
 	return a.CompatibilityMap.NewNodeApiObjectPath
+}
+
+func (a *ApiClient) SupportsResolvePathToInode() bool {
+	return a.CompatibilityMap.ResolvePathToInode
 }

--- a/pkg/wekafs/apiclient/resolvepath.go
+++ b/pkg/wekafs/apiclient/resolvepath.go
@@ -1,0 +1,83 @@
+package apiclient
+
+import (
+	"context"
+	"fmt"
+	"github.com/google/go-querystring/query"
+	"github.com/google/uuid"
+	"github.com/rs/zerolog/log"
+	"go.opentelemetry.io/otel"
+	"k8s.io/helm/pkg/urlutil"
+	"strconv"
+	"strings"
+)
+
+type FilesystemResolvePath struct {
+	Uid     uuid.UUID `json:"-" url:"-"`
+	InodeId string    `json:"inode_id,omitempty" url:"-"`
+	Path    string    `json:"-" url:"path,omitempty"`
+}
+
+func (fsr *FilesystemResolvePath) GetType() string {
+	return "resolvePath"
+}
+
+func (fsr *FilesystemResolvePath) GetBasePath(a *ApiClient) string {
+	fsUrl := (&FileSystem{Uid: fsr.Uid}).GetApiUrl(a)
+	url, err := urlutil.URLJoin(fsUrl, fsr.GetType())
+	if err != nil {
+		return ""
+	}
+	return url
+}
+
+func (fsr *FilesystemResolvePath) GetApiUrl(a *ApiClient) string {
+	return fsr.GetBasePath(a)
+}
+
+func (fsr *FilesystemResolvePath) EQ(q ApiObject) bool {
+	return ObjectsAreEqual(q, fsr)
+}
+
+func (fsr *FilesystemResolvePath) getImmutableFields() []string {
+	return []string{"InodeId"}
+}
+
+func (fsr *FilesystemResolvePath) String() string {
+	return fmt.Sprintln("FilesystemResolvePath(inodeId:", fsr.InodeId, ")")
+}
+
+func (a *ApiClient) ResolvePathToInode(ctx context.Context, fs *FileSystem, path string) (uint64, error) {
+	op := "ResolvePathToInode"
+	ctx, span := otel.Tracer(TracerName).Start(ctx, op)
+	defer span.End()
+	ctx = log.With().Str("trace_id", span.SpanContext().TraceID().String()).Str("span_id", span.SpanContext().SpanID().String()).Str("op", op).Logger().WithContext(ctx)
+	if fs == nil || path == "" {
+		return 0, RequestMissingParams
+	}
+	p := &FilesystemResolvePath{
+		Uid:  fs.Uid,
+		Path: path,
+	}
+	q, _ := query.Values(p)
+
+	err := a.Get(ctx, p.GetApiUrl(a), q, p)
+	if err != nil {
+		switch t := err.(type) {
+		case *ApiNotFoundError:
+			return 0, ObjectNotFoundError
+		case *ApiBadRequestError:
+			if strings.Contains(t.ApiResponse.Message, "PATH_NOT_FOUND") {
+				return 0, ObjectNotFoundError
+			}
+
+		default:
+			return 0, err
+		}
+	}
+
+	if p.InodeId == "" {
+		return 0, ObjectNotFoundError
+	}
+	return strconv.ParseUint(p.InodeId, 10, 64)
+}

--- a/pkg/wekafs/apiclient/resolvepath_test.go
+++ b/pkg/wekafs/apiclient/resolvepath_test.go
@@ -1,0 +1,35 @@
+package apiclient
+
+import (
+	"context"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestApiClient_ResolvePathToInode(t *testing.T) {
+	apiClient := GetApiClientForTest(t)
+
+	ctx := context.Background()
+	fs, err := apiClient.GetFileSystemByName(ctx, "default")
+	assert.NoError(t, err)
+	assert.NotEmpty(t, fs)
+
+	inode, err := apiClient.ResolvePathToInode(ctx, fs, "/")
+	assert.NoError(t, err)
+	assert.Positive(t, inode)
+
+	// test non-existing path
+	inode, err = apiClient.ResolvePathToInode(ctx, fs, "/test-not-existing")
+	assert.Error(t, err)
+	assert.IsType(t, ObjectNotFoundError, err)
+	assert.Zero(t, inode)
+
+	// test non-existing filesystem
+	fs = &FileSystem{Uid: uuid.New()}
+	inode, err = apiClient.ResolvePathToInode(ctx, fs, "/")
+	assert.Error(t, err)
+	assert.IsType(t, ObjectNotFoundError, err)
+	assert.Zero(t, inode)
+
+}


### PR DESCRIPTION
feat(CSI-340): add resolvePathToInode to compatibility map

feat(CSI-340): implement ApiClient.ResolvePathToInode()

feat(CSI-340): attempt to resolve InodeId from API if supported rather than mount

Adds support for resolving filesystem paths to inodes via API calls for Weka v4.3+ clusters, reducing the need for filesystem mounts. This improves efficiency by eliminating unnecessary mount operations when determining inode IDs.