### PR TITLE
feat(CSI-341): cache filesystem and snapshot objects to avoid multiple similar API calls

### DIFF
--- a/pkg/wekafs/snapshotconstructors.go
+++ b/pkg/wekafs/snapshotconstructors.go
@@ -23,7 +23,7 @@ func NewSnapshotFromVolumeCreate(ctx context.Context, name string, sourceVolume 
 	snapshotId := generateSnapshotIdFromComponents(SnapshotTypeUnifiedSnap, filesystemName, snapNameHash, snapIntegrityId, innerPath)
 	var sourceSnapUid *uuid.UUID
 	if sourceVolume != nil && sourceVolume.isOnSnapshot() {
-		obj, err := sourceVolume.getSnapshotObj(ctx)
+		obj, err := sourceVolume.getSnapshotObj(ctx, false)
 		if err != nil {
 			logger.Error().Err(err).Msg("Failed to fetch content object of source volume")
 			return nil, err


### PR DESCRIPTION
### TL;DR
Added caching mechanism for filesystem and snapshot objects to reduce API calls

### What changed?
- Added `fileSystemObject` and `snapshotObject` fields to the Volume struct to cache API responses
- Modified `getFilesystemObj` and `getSnapshotObj` methods to accept a `fromCache` parameter
- Added cache invalidation when deleting filesystems and snapshots
- Updated all method calls to specify whether to use cached objects

### How to test?
1. Create a volume and perform multiple operations on it
2. Monitor API calls to verify reduced number of filesystem/snapshot fetches
3. Verify that cache invalidation works correctly after deletion operations
4. Ensure all volume operations continue to work as expected with caching

### Why make this change?
The previous implementation made redundant API calls to fetch filesystem and snapshot objects, even when the same object was needed multiple times in quick succession. This caching mechanism reduces the number of API calls, improving performance and reducing load on the storage system.