### PR TITLE
fix(CSI-343): panic on apiclient when endpoint list is empty

### DIFF
--- a/.github/workflows/lint_pr.yaml
+++ b/.github/workflows/lint_pr.yaml
@@ -49,7 +49,7 @@ jobs:
             CSI-\d+
             WEKAPP-\d+
           # Configure that a scope must always be provided.
-          requireScope: true
+          requireScope: false
           # Configure which scopes are disallowed in PR titles (newline-delimited).
           # For instance by setting the value below, `chore(release): ...` (lowercase)
           # and `ci(e2e,release): ...` (unknown scope) will be rejected.

--- a/pkg/wekafs/apiclient/apiclient.go
+++ b/pkg/wekafs/apiclient/apiclient.go
@@ -88,6 +88,9 @@ func NewApiClient(ctx context.Context, credentials Credentials, allowInsecureHtt
 		NfsInterfaceGroups: make(map[string]*InterfaceGroup),
 	}
 	a.resetDefaultEndpoints(ctx)
+	if len(a.Credentials.Endpoints) < 1 {
+		return nil, errors.New("no endpoints could be found for API client")
+	}
 
 	logger.Trace().Bool("insecure_skip_verify", allowInsecureHttps).Bool("custom_ca_cert", useCustomCACert).Msg("Creating new API client")
 	a.clientHash = a.generateHash()

--- a/pkg/wekafs/apiclient/apiclient.go
+++ b/pkg/wekafs/apiclient/apiclient.go
@@ -89,7 +89,9 @@ func NewApiClient(ctx context.Context, credentials Credentials, allowInsecureHtt
 	}
 	a.resetDefaultEndpoints(ctx)
 	if len(a.Credentials.Endpoints) < 1 {
-		return nil, errors.New("no endpoints could be found for API client")
+		return nil, &ApiNoEndpointsError{
+			Err: errors.New("no endpoints could be found for API client"),
+		}
 	}
 
 	logger.Trace().Bool("insecure_skip_verify", allowInsecureHttps).Bool("custom_ca_cert", useCustomCACert).Msg("Creating new API client")

--- a/pkg/wekafs/apiclient/apiclient_test.go
+++ b/pkg/wekafs/apiclient/apiclient_test.go
@@ -1,6 +1,8 @@
 package apiclient
 
 import (
+	"context"
+	"flag"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
@@ -144,4 +146,39 @@ func TestIsValidHostname(t *testing.T) {
 			assert.Equal(t, tt.expected, isValidHostname(tt.hostname))
 		})
 	}
+}
+
+var creds Credentials
+var endpoint string
+var fsName string
+
+var client *ApiClient
+
+func TestMain(m *testing.M) {
+	flag.StringVar(&endpoint, "api-endpoint", "localhost:14000", "API endpoint for tests")
+	flag.StringVar(&creds.Username, "api-username", "admin", "API username for tests")
+	flag.StringVar(&creds.Password, "api-password", "", "API password for tests")
+	flag.StringVar(&creds.Organization, "api-org", "Root", "API org for tests")
+	flag.StringVar(&creds.HttpScheme, "api-scheme", "https", "API scheme for tests")
+	flag.StringVar(&fsName, "fs-name", "default", "Filesystem name for tests")
+	flag.Parse()
+	m.Run()
+}
+
+func GetApiClientForTest(t *testing.T) *ApiClient {
+	creds.Endpoints = []string{endpoint}
+	if client == nil {
+		apiClient, err := NewApiClient(context.Background(), creds, true, endpoint)
+		if err != nil {
+			t.Fatalf("Failed to create API client: %v", err)
+		}
+		if apiClient == nil {
+			t.Fatalf("Failed to create API client")
+		}
+		if err := apiClient.Login(context.Background()); err != nil {
+			t.Fatalf("Failed to login: %v", err)
+		}
+		client = apiClient
+	}
+	return client
 }

--- a/pkg/wekafs/apiclient/compatibility_test.go
+++ b/pkg/wekafs/apiclient/compatibility_test.go
@@ -47,6 +47,8 @@ func TestWekaCompatibilityMap_fillIn(t *testing.T) {
 				SingleClientMultipleClusters:   true,
 				NewNodeApiObjectPath:           true,
 				MountFilesystemsUsingAuthToken: true,
+				EncryptionWithNoKms:            true,
+				EncryptionWithClusterKey:       true,
 			},
 		},
 		{
@@ -61,6 +63,8 @@ func TestWekaCompatibilityMap_fillIn(t *testing.T) {
 				SingleClientMultipleClusters:   true,
 				NewNodeApiObjectPath:           true,
 				MountFilesystemsUsingAuthToken: true,
+				EncryptionWithNoKms:            true,
+				EncryptionWithClusterKey:       true,
 			},
 		},
 		{
@@ -77,6 +81,9 @@ func TestWekaCompatibilityMap_fillIn(t *testing.T) {
 				SyncOnCloseMountOption:          true,
 				SingleClientMultipleClusters:    true,
 				NewNodeApiObjectPath:            true,
+				EncryptionWithNoKms:             true,
+				EncryptionWithClusterKey:        true,
+				EncryptionWithCustomSettings:    true,
 			},
 		},
 	}

--- a/pkg/wekafs/apiclient/nfs_test.go
+++ b/pkg/wekafs/apiclient/nfs_test.go
@@ -2,85 +2,11 @@ package apiclient
 
 import (
 	"context"
-	"flag"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/apimachinery/pkg/util/rand"
 	"testing"
 )
-
-var creds Credentials
-var endpoint string
-var fsName string
-
-var client *ApiClient
-
-func TestMain(m *testing.M) {
-	flag.StringVar(&endpoint, "api-endpoint", "localhost:14000", "API endpoint for tests")
-	flag.StringVar(&creds.Username, "api-username", "admin", "API username for tests")
-	flag.StringVar(&creds.Password, "api-password", "Qwerty1@", "API password for tests")
-	flag.StringVar(&creds.Organization, "api-org", "Root", "API org for tests")
-	flag.StringVar(&creds.HttpScheme, "api-scheme", "https", "API scheme for tests")
-	flag.StringVar(&fsName, "fs-name", "default", "Filesystem name for tests")
-	flag.Parse()
-	m.Run()
-}
-
-func GetApiClientForTest(t *testing.T) *ApiClient {
-	creds.Endpoints = []string{endpoint}
-	if client == nil {
-		apiClient, err := NewApiClient(context.Background(), creds, true, "test")
-		if err != nil {
-			t.Fatalf("Failed to create API client: %v", err)
-		}
-		if apiClient == nil {
-			t.Fatalf("Failed to create API client")
-		}
-		if err := apiClient.Login(context.Background()); err != nil {
-			t.Fatalf("Failed to login: %v", err)
-		}
-		client = apiClient
-	}
-	return client
-}
-
-//
-//func TestGetNfsPermissions(t *testing.T) {
-//	apiClient := GetApiClientForTest(t)
-//
-//	var permissions []NfsPermission
-//
-//	req := &NfsPermissionCreateRequest{
-//		Filesystem: fsName,
-//		Group:      "group1",
-//	}
-//	p := &NfsPermission{}
-//	err := apiClient.CreateNfsPermission(context.Background(), &NfsPermissionCreateRequest{}, p)
-//	assert.NoError(t, err)
-//	assert.NotZero(t, p.Uid)
-//
-//	err := apiClient.GetNfsPermissions(context.Background(), &permissions)
-//	assert.NoError(t, err)
-//	assert.NotEmpty(t, permissions)
-//}
-//
-//func TestFindNfsPermissionsByFilter(t *testing.T) {
-//	apiClient := GetApiClientForTest(t)
-//	query := &NfsPermission{Filesystem: "fs1"}
-//	var resultSet []NfsPermission
-//	err := apiClient.FindNfsPermissionsByFilter(context.Background(), query, &resultSet)
-//	assert.NoError(t, err)
-//	assert.NotEmpty(t, resultSet)
-//}
-//
-//func TestGetNfsPermissionByFilter(t *testing.T) {
-//	apiClient := GetApiClientForTest(t)
-//
-//	query := &NfsPermission{Filesystem: "fs1"}
-//	result, err := apiClient.GetNfsPermissionByFilter(context.Background(), query)
-//	assert.NoError(t, err)
-//	assert.NotNil(t, result)
-//}
 
 func TestFindNfsPermissionsByFilesystemName(t *testing.T) {
 	apiClient := GetApiClientForTest(t)
@@ -101,52 +27,6 @@ func TestFindNfsPermissionsByFilesystemName(t *testing.T) {
 	assert.Empty(t, permissions)
 
 }
-
-//
-//func TestGetNfsPermissionByUid(t *testing.T) {
-//	apiClient := GetApiClientForTest(t)
-//	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-//		w.WriteHeader(http.StatusOK)
-//		w.Write([]byte(`{"filesystem": "fs1", "group": "group1"}`))
-//	}))
-//	defer server.Close()
-//
-//
-//	uid := uuid.New()
-//	result, err := apiClient.GetNfsPermissionByUid(context.Background(), uid)
-//	assert.NoError(t, err)
-//	assert.NotNil(t, result)
-//}
-//
-//func TestCreateNfsPermission(t *testing.T) {
-//	apiClient := GetApiClientForTest(t)
-//
-//	req := &NfsPermissionCreateRequest{
-//		Filesystem:      "fs1",
-//		Group:           "group1",
-//		SquashMode:      NfsPermissionSquashModeNone,
-//		AnonUid:         1000,
-//		AnonGid:         1000,
-//		EnableAuthTypes: []NfsAuthType{NfsAuthTypeSys},
-//	}
-//	var perm NfsPermission
-//	err := apiClient.CreateNfsPermission(context.Background(), req, &perm)
-//	assert.NoError(t, err)
-//	assert.NotNil(t, perm)
-//}
-//
-//func TestEnsureNfsPermission(t *testing.T) {
-//	apiClient := GetApiClientForTest(t)
-//	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-//		w.WriteHeader(http.StatusOK)
-//		w.Write([]byte(`{"filesystem": "fs1", "group": "group1"}`))
-//	}))
-//	defer server.Close()
-//
-//
-//	err := EnsureNfsPermission(context.Background(), "fs1", "group1", apiClient)
-//	assert.NoError(t, err)
-//}
 
 func TestNfsClientGroup(t *testing.T) {
 	apiClient := GetApiClientForTest(t)
@@ -298,33 +178,9 @@ func TestInterfaceGroup(t *testing.T) {
 	err := apiClient.GetInterfaceGroups(context.Background(), &igs)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, igs)
-	assert.NotEmpty(t, igs[0].Ips)
-	//
-	//// Test GetGroupByUid
-	//uid := ig.Uid
-	//err = apiClient.GetInterfaceGroupByUid(context.Background(), uid, ig)
-	//assert.NoError(t, err)
-	//assert.Equal(t, igName, ig.Name)
-	//assert.NotEmpty(t, ig.Uid)
-	//
-	//// Test GetGroupByName
-	//name := ig.Name
-	//ig, err = apiClient.GetInterfaceGroupByName(context.Background(), name)
-	//assert.NoError(t, err)
-	//assert.Equal(t, igName, ig.Name)
-	//assert.NotEmpty(t, ig.Uid)
-	//
-	//// Test Delete
-	//r := &InterfaceGroupDeleteRequest{Uid: ig.Uid}
-	//err = apiClient.DeleteInterfaceGroup(context.Background(), r)
-	//assert.NoError(t, err)
-	//err = apiClient.GetInterfaceGroups(context.Background(), &igs)
-	//assert.NoError(t, err)
-	//for _, r := range igs {
-	//	if r.Uid == ig.Uid {
-	//		t.Errorf("Failed to delete group")
-	//	}
-	//}
+	if len(igs) > 0 {
+		assert.NotEmpty(t, igs[0].Ips)
+	}
 }
 
 func TestIsSupersetOf(t *testing.T) {

--- a/pkg/wekafs/nfsmounter.go
+++ b/pkg/wekafs/nfsmounter.go
@@ -155,7 +155,7 @@ func (m *nfsMounter) gcInactiveMounts() {
 
 func (m *nfsMounter) schedulePeriodicMountGc() {
 	go func() {
-		log.Debug().Msg("Initializing periodic mount GC")
+		log.Debug().Msg("Initializing periodic mount GC for nfs transport")
 		for true {
 			m.LogActiveMounts()
 			m.gcInactiveMounts()

--- a/pkg/wekafs/wekafsmounter.go
+++ b/pkg/wekafs/wekafsmounter.go
@@ -149,7 +149,7 @@ func (m *wekafsMounter) gcInactiveMounts() {
 
 func (m *wekafsMounter) schedulePeriodicMountGc() {
 	go func() {
-		log.Debug().Msg("Initializing periodic mount GC")
+		log.Debug().Msg("Initializing periodic mount GC for wekafs transport")
 		for true {
 			m.LogActiveMounts()
 			m.gcInactiveMounts()


### PR DESCRIPTION
### TL;DR
Added validation for empty API endpoints and enhanced encryption compatibility checks.

### What changed?
- Added validation to prevent API client creation when no endpoints are provided
- Added encryption-related compatibility flags for different Weka versions
- Moved API client test setup code to a central location
- Updated mount GC logging to differentiate between transport types
- Made PR scope requirement optional in GitHub workflow

### How to test?
1. Attempt to create an API client with no endpoints - should return error
2. Verify encryption compatibility checks for different Weka versions
3. Run API client tests with provided test credentials
4. Check mount GC logs for both NFS and WekaFS transports

### Why make this change?
- Prevents potential issues from API clients being created without valid endpoints
- Improves encryption feature compatibility detection across different Weka versions
- Centralizes test setup code for better maintainability
- Makes logs clearer by distinguishing between transport types
- Allows more flexibility in PR titles while maintaining quality standards