### PR TITLE
feat(CSI-342): get filesystem free space via API without requiring fs mount

### DIFF
--- a/pkg/wekafs/apiclient/filesystem.go
+++ b/pkg/wekafs/apiclient/filesystem.go
@@ -45,6 +45,9 @@ type FileSystem struct {
 	KmsKeyIdentifier string `json:"kms_key_identifier,omitempty" url:"-"`
 	KmsNamespace     string `json:"kms_namespace,omitempty" url:"-"`
 	KmsRole          string `json:"kms_role,omitempty" url:"-"`
+
+	// used for internal purposes
+	ForceFresh *bool `json:"-" url:"force_fresh,omitempty"`
 }
 
 type FileSystemMountToken struct {
@@ -59,11 +62,14 @@ func (fs *FileSystem) String() string {
 	return fmt.Sprintln("FileSystem(fsUid:", fs.Uid, "name:", fs.Name, "capacity:", strconv.FormatInt(fs.TotalCapacity, 10), ")")
 }
 
-func (a *ApiClient) GetFileSystemByUid(ctx context.Context, uid uuid.UUID, fs *FileSystem) error {
+func (a *ApiClient) GetFileSystemByUid(ctx context.Context, uid uuid.UUID, fs *FileSystem, forceFresh bool) error {
 	ret := &FileSystem{
-		Uid: uid,
+		Uid:        uid,
+		ForceFresh: &forceFresh,
 	}
-	err := a.Get(ctx, ret.GetApiUrl(a), nil, fs)
+
+	q, _ := qs.Values(ret)
+	err := a.Get(ctx, ret.GetApiUrl(a), q, fs)
 	if err != nil {
 		switch t := err.(type) {
 		case *ApiNotFoundError:

--- a/pkg/wekafs/volume.go
+++ b/pkg/wekafs/volume.go
@@ -871,7 +871,7 @@ func (v *Volume) getSizeFromXattr(ctx context.Context) (uint64, error) {
 
 // getFilesystemObj returns the Weka filesystem object
 func (v *Volume) getFilesystemObj(ctx context.Context, fromCache bool) (*apiclient.FileSystem, error) {
-	if v.fileSystemObject != nil && fromCache {
+	if v.fileSystemObject != nil && fromCache && !v.fileSystemObject.IsRemoving {
 		return v.fileSystemObject, nil
 	}
 	if v.apiClient == nil {
@@ -1575,7 +1575,7 @@ func (v *Volume) waitForFilesystemDeletion(ctx context.Context, logger zerolog.L
 	logger.Trace().Msg("Waiting for filesystem deletion to complete")
 	for start := time.Now(); time.Since(start) < MaxSnapshotDeletionDuration; {
 		fsObj := &apiclient.FileSystem{}
-		err := v.apiClient.GetFileSystemByUid(ctx, fsUid, fsObj)
+		err := v.apiClient.GetFileSystemByUid(ctx, fsUid, fsObj, false)
 		if err != nil {
 			if err == apiclient.ObjectNotFoundError {
 				logger.Trace().Str("filesystem", v.FilesystemName).Msg("Filesystem was removed successfully")

--- a/pkg/wekafs/volume_test.go
+++ b/pkg/wekafs/volume_test.go
@@ -1,0 +1,88 @@
+package wekafs
+
+import (
+	"context"
+	"flag"
+	"github.com/stretchr/testify/assert"
+	"github.com/wekafs/csi-wekafs/pkg/wekafs/apiclient"
+	"testing"
+)
+
+func GetDriverForTest(t *testing.T) *WekaFsDriver {
+	ctx := context.Background()
+	nodeId := "localhost"
+	mutuallyExclusive := MutuallyExclusiveMountOptsStrings{"readcache,writecache,coherent,forcedirect", "sync,async", "ro,rw"}
+	driverConfig := NewDriverConfig("csi-volumes", "csi-vol-", "csi-snap-", "csi-seed-snap-",
+		"", true, true, true, true, true,
+		true, true, mutuallyExclusive,
+		1, 1, 1, 1, 1, 1, 1, 10,
+		true, true, true, "", "", "4.1", "v1", false, false, true)
+	driver, err := NewWekaFsDriver("csi.weka.io", nodeId, "unix://tmp/csi.sock", 10, "v1.0", "", CsiModeAll, false, driverConfig)
+	if err != nil {
+		t.Fatalf("Failed to create new driver: %v", err)
+	}
+	go driver.Run(ctx)
+	return driver
+}
+
+var creds apiclient.Credentials
+var endpoint string
+var fsName string
+
+var client *apiclient.ApiClient
+
+func TestMain(m *testing.M) {
+	flag.StringVar(&endpoint, "api-endpoint", "localhost:14000", "API endpoint for tests")
+	flag.StringVar(&creds.Username, "api-username", "admin", "API username for tests")
+	flag.StringVar(&creds.Password, "api-password", "", "API password for tests")
+	flag.StringVar(&creds.Organization, "api-org", "Root", "API org for tests")
+	flag.StringVar(&creds.HttpScheme, "api-scheme", "https", "API scheme for tests")
+	flag.StringVar(&fsName, "fs-name", "default", "Filesystem name for tests")
+	flag.Parse()
+	m.Run()
+}
+
+func GetApiClientForTest(t *testing.T) *apiclient.ApiClient {
+	creds.Endpoints = []string{endpoint}
+	if client == nil {
+		apiClient, err := apiclient.NewApiClient(context.Background(), creds, true, endpoint)
+		if err != nil {
+			t.Fatalf("Failed to create API client: %v", err)
+		}
+		if apiClient == nil {
+			t.Fatalf("Failed to create API client")
+		}
+		if err := apiClient.Login(context.Background()); err != nil {
+			t.Fatalf("Failed to login: %v", err)
+		}
+		client = apiClient
+	}
+	return client
+}
+
+func TestVolume_getFilesystemFreeSpaceByApi(t *testing.T) {
+	driver := GetDriverForTest(t)
+	apiClient := GetApiClientForTest(t)
+	ctx := context.Background()
+	volume, err := NewVolumeFromId(ctx, "weka/v2/default", apiClient, driver.cs)
+	if err != nil {
+		t.Fatalf("Failed to create volume: %v", err)
+	}
+	free, err := volume.getFilesystemFreeSpaceByApi(ctx)
+	assert.NoError(t, err)
+	assert.NotZero(t, free)
+
+}
+
+func TestVolume_getFilesystemFreeSpace(t *testing.T) {
+	driver := GetDriverForTest(t)
+	apiClient := GetApiClientForTest(t)
+	ctx := context.Background()
+	volume, err := NewVolumeFromId(ctx, "weka/v2/default", apiClient, driver.cs)
+	if err != nil {
+		t.Fatalf("Failed to create volume: %v", err)
+	}
+	free, err := volume.getFilesystemFreeSpace(ctx)
+	assert.NoError(t, err)
+	assert.NotZero(t, free)
+}


### PR DESCRIPTION
### TL;DR
Added support for force-fresh filesystem capacity queries through the API

### What changed?
- Added `ForceFresh` parameter to filesystem API calls to ensure accurate capacity reporting
- Implemented new `getFilesystemFreeSpaceByApi` method to query filesystem capacity directly through API
- Modified `getFilesystemFreeSpace` to prioritize API-based capacity queries when possible
- Added unit tests to verify both capacity query methods

### How to test?
1. Run the new unit tests using:
```bash
go test -v ./pkg/wekafs -args \
  -api-endpoint=<your-endpoint> \
  -api-username=<username> \
  -api-password=<password> \
  -api-org=<org> \
  -fs-name=<filesystem-name>
```
2. Verify that both `TestVolume_getFilesystemFreeSpaceByApi` and `TestVolume_getFilesystemFreeSpace` pass
3. Confirm that filesystem capacity queries return accurate, non-zero values

### Why make this change?
To improve the accuracy and efficiency of filesystem capacity reporting by leveraging direct API queries instead of requiring filesystem mounts. This provides more reliable capacity information and reduces operational overhead.