### PR TITLE
feat(CSI-344): delete filesystems out-of-band if not waiting for object deletion

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -6,8 +6,7 @@ on:
 
 jobs:
   pr-test:
-    runs-on:
-      group: large-runners-public
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4

--- a/.github/workflows/sanity.yaml
+++ b/.github/workflows/sanity.yaml
@@ -46,8 +46,11 @@ jobs:
     needs: build
     runs-on: self-hosted
     steps:
+      - name: Set up Docker Compose
+        uses: docker/setup-compose-action@v1
+
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-      - run: docker-compose -f tests/csi-sanity/docker-compose-nosnapshotcaps.yaml up $COMPOSE_DEFAULTS
+      - run: docker compose -f tests/csi-sanity/docker-compose-nosnapshotcaps.yaml up $COMPOSE_DEFAULTS
         env:
           SANITY_FUNCTION: legacy_sanity
 
@@ -55,8 +58,11 @@ jobs:
     needs: legacy_sanity
     runs-on: self-hosted
     steps:
+      - name: Set up Docker Compose
+        uses: docker/setup-compose-action@v1
+
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-      - run: docker-compose -f tests/csi-sanity/docker-compose-snapshotcaps.yaml up $COMPOSE_DEFAULTS
+      - run: docker compose -f tests/csi-sanity/docker-compose-snapshotcaps.yaml up $COMPOSE_DEFAULTS
         env:
           SANITY_FUNCTION: directory_volume_and_snapshots
 
@@ -64,8 +70,11 @@ jobs:
     needs: directory_volume_and_snapshots
     runs-on: self-hosted
     steps:
+      - name: Set up Docker Compose
+        uses: docker/setup-compose-action@v1
+
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-      - run: docker-compose -f tests/csi-sanity/docker-compose-nfs-snapshotcaps.yaml up $COMPOSE_DEFAULTS
+      - run: docker compose -f tests/csi-sanity/docker-compose-nfs-snapshotcaps.yaml up $COMPOSE_DEFAULTS
         env:
           SANITY_FUNCTION: directory_volume_and_snapshots_nfs
 
@@ -73,8 +82,11 @@ jobs:
     needs: directory_volume_and_snapshots_nfs
     runs-on: self-hosted
     steps:
+      - name: Set up Docker Compose
+        uses: docker/setup-compose-action@v1
+
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-      - run: docker-compose -f tests/csi-sanity/docker-compose-snapshotcaps.yaml up $COMPOSE_DEFAULTS
+      - run: docker compose -f tests/csi-sanity/docker-compose-snapshotcaps.yaml up $COMPOSE_DEFAULTS
         env:
           SANITY_FUNCTION: snaphot_volumes_with_2nd_level_shapshots
 
@@ -82,8 +94,11 @@ jobs:
     needs: snaphot_volumes_with_2nd_level_shapshots
     runs-on: self-hosted
     steps:
+      - name: Set up Docker Compose
+        uses: docker/setup-compose-action@v1
+
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-      - run: docker-compose -f tests/csi-sanity/docker-compose-nfs-snapshotcaps.yaml up $COMPOSE_DEFAULTS
+      - run: docker compose -f tests/csi-sanity/docker-compose-nfs-snapshotcaps.yaml up $COMPOSE_DEFAULTS
         env:
           SANITY_FUNCTION: snaphot_volumes_with_2nd_level_shapshots_nfs
 
@@ -91,8 +106,11 @@ jobs:
     needs: snaphot_volumes_with_2nd_level_shapshots_nfs
     runs-on: self-hosted
     steps:
+      - name: Set up Docker Compose
+        uses: docker/setup-compose-action@v1
+
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-      - run: docker-compose -f tests/csi-sanity/docker-compose-snapshotcaps.yaml up $COMPOSE_DEFAULTS
+      - run: docker compose -f tests/csi-sanity/docker-compose-snapshotcaps.yaml up $COMPOSE_DEFAULTS
         env:
           SANITY_FUNCTION: filesystem_volumes
 
@@ -100,7 +118,10 @@ jobs:
     needs: filesystem_volumes
     runs-on: self-hosted
     steps:
+      - name: Set up Docker Compose
+        uses: docker/setup-compose-action@v1
+
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-      - run: docker-compose -f tests/csi-sanity/docker-compose-nfs-snapshotcaps.yaml up $COMPOSE_DEFAULTS
+      - run: docker compose -f tests/csi-sanity/docker-compose-nfs-snapshotcaps.yaml up $COMPOSE_DEFAULTS
         env:
           SANITY_FUNCTION: filesystem_volumes_nfs

--- a/charts/csi-wekafsplugin/templates/controllerserver-deployment.yaml
+++ b/charts/csi-wekafsplugin/templates/controllerserver-deployment.yaml
@@ -123,8 +123,8 @@ spec:
           {{- if (.Values.pluginConfig.skipGarbageCollection | default false) }}
             - "--skipgarbagecollection"
           {{- end }}
-          {{- if (.Values.pluginConfig.waitForObjectDeletion | default false) }}
-            - "--waitforobjectdeletion"
+          {{- if (.Values.pluginConfig.allowedOperations.allowAsyncObjectDeletion | default false) }}
+            - "--allowasyncobjectdeletion"
           {{- end }}
           {{- if .Values.pluginConfig.encryption.allowEncryptionWithoutKms}}
             - "--allowencryptionwithoutkms"

--- a/charts/csi-wekafsplugin/values.yaml
+++ b/charts/csi-wekafsplugin/values.yaml
@@ -174,6 +174,12 @@ pluginConfig:
     # -- Allow creation of snapshot-backed volumes even on unsupported Weka cluster versions, off by default
     #    Note: On versions of Weka < v4.2 snapshot-backed volume capacity cannot be enforced
     snapshotVolumesWithoutQuotaEnforcement: false
+    # -- Should the CSI plugin wait for object deletion before reporting completion.
+    #    If true, the plugin will report success on deletion of volumes while the actual deletion of objects will be done in the background.
+    #    If false, the plugin will report success only after the objects are deleted on WEKA cluster.
+    #    Usually, async deletion would drastically increase speed of volume deletions, since deletion is performed serially.
+    #    However, it may cause objects on Weka cluster to remain if the plugin crashes or is restarted before the deletion is completed.
+    allowAsyncObjectDeletion: true
   mutuallyExclusiveMountOptions:
     - "readcache,writecache,coherent,forcedirect"
     - "sync,async"
@@ -195,7 +201,5 @@ pluginConfig:
     nfsProtocolVersion: "4.1"
   # -- Skip garbage collection of deleted directory-backed volume contents and only move them to trash. Default false
   skipGarbageCollection: false
-  # -- Wait for WEKA filesystem / snapshot deletion before acknowledging the corresponding CSI volume deletion. Default false
-  waitForObjectDeletion: false
   # -- Allow CSI plugin to manage node topology labels. For Operator-managed clusters, this should be set to false.
   manageNodeTopologyLabels: true

--- a/cmd/wekafsplugin/main.go
+++ b/cmd/wekafsplugin/main.go
@@ -97,7 +97,7 @@ var (
 	clientGroupName                      = flag.String("clientgroupname", "", "Name of the NFS client group to use for managing NFS permissions")
 	nfsProtocolVersion                   = flag.String("nfsprotocolversion", "4.1", "NFS protocol version to use for mounting volumes")
 	skipGarbageCollection                = flag.Bool("skipgarbagecollection", false, "Skip garbage collection of directory volumes data, only move to trash")
-	waitForObjectDeletion                = flag.Bool("waitforobjectdeletion", false, "Wait for object deletion before returning from DeleteVolume")
+	allowAsyncObjectDeletion             = flag.Bool("allowasyncobjectdeletion", false, "Allow deletion of volumes in asynchronous manner. Improves speed of multiple volume deletions but might leave some objects in Weka cluster. Use with caution.")
 	allowEncryptionWithoutKms            = flag.Bool("allowencryptionwithoutkms", false, "Allow encryption without KMS, for testing purposes only")
 	manageNodeTopologyLabels             = flag.Bool("managenodetopologylabels", false, "Manage node topology labels for CSI driver")
 	// Set by the build process
@@ -234,7 +234,7 @@ func handle(ctx context.Context) {
 		*nfsProtocolVersion,
 		version,
 		*skipGarbageCollection,
-		*waitForObjectDeletion,
+		*allowAsyncObjectDeletion,
 		*allowEncryptionWithoutKms,
 		*tracingUrl,
 		*manageNodeTopologyLabels,

--- a/pkg/wekafs/apiclient/filesystem.go
+++ b/pkg/wekafs/apiclient/filesystem.go
@@ -157,7 +157,7 @@ func (a *ApiClient) CreateFileSystem(ctx context.Context, r *FileSystemCreateReq
 }
 
 func (a *ApiClient) WaitFilesystemReady(ctx context.Context, fsName string, waitPeriodMax time.Duration) (*FileSystem, error) {
-	logger := log.Ctx(ctx).With().Str("filesysem", fsName).Logger()
+	logger := log.Ctx(ctx).With().Str("filesystem", fsName).Logger()
 	for start := time.Now(); time.Since(start) < waitPeriodMax; {
 		fs, err := a.GetFileSystemByName(ctx, fsName)
 		if err != nil || fs == nil {

--- a/pkg/wekafs/driverconfig.go
+++ b/pkg/wekafs/driverconfig.go
@@ -40,7 +40,7 @@ type DriverConfig struct {
 	nfsProtocolVersion               string
 	csiVersion                       string
 	skipGarbageCollection            bool
-	waitForObjectDeletion            bool
+	allowAsyncObjectDeletion         bool
 	allowEncryptionWithoutKms        bool
 	driverRef                        *WekaFsDriver
 	tracingUrl                       string
@@ -68,7 +68,7 @@ func (dc *DriverConfig) Log() {
 		Str("interface_group_name", dc.interfaceGroupName).
 		Str("client_group_name", dc.clientGroupName).
 		Bool("skip_garbage_collection", dc.skipGarbageCollection).
-		Bool("wait_for_object_deletion", dc.waitForObjectDeletion).
+		Bool("allow_async_object_deletion", dc.allowAsyncObjectDeletion).
 		Str("tracing_url", dc.tracingUrl).
 		Bool("manage_node_topology_labels", dc.manageNodeTopologyLabels).
 		Msg("Starting driver with the following configuration")
@@ -134,7 +134,7 @@ func NewDriverConfig(dynamicVolPath, VolumePrefix, SnapshotPrefix, SeedSnapshotP
 		nfsProtocolVersion:               nfsProtocolVersion,
 		csiVersion:                       version,
 		skipGarbageCollection:            skipGarbageCollection,
-		waitForObjectDeletion:            waitForObjectDeletion,
+		allowAsyncObjectDeletion:         waitForObjectDeletion,
 		allowEncryptionWithoutKms:        allowEncryptionWithoutKms,
 		tracingUrl:                       tracingUrl,
 		manageNodeTopologyLabels:         manageNodeTopologyLabels,

--- a/pkg/wekafs/identityserver.go
+++ b/pkg/wekafs/identityserver.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"google.golang.org/protobuf/types/known/wrapperspb"
+	"sync"
 
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
@@ -33,6 +34,30 @@ type identityServer struct {
 	name    string
 	version string
 	config  *DriverConfig
+}
+
+func (ids *identityServer) getMounter() AnyMounter {
+	panic("not implemented")
+}
+
+func (ids *identityServer) getApiStore() *ApiStore {
+	panic("not implemented")
+}
+
+func (ids *identityServer) isInDevMode() bool {
+	panic("not implemented")
+}
+
+func (ids *identityServer) getDefaultMountOptions() MountOptions {
+	panic("not implemented")
+}
+
+func (ids *identityServer) getNodeId() string {
+	panic("not implemented")
+}
+
+func (ids *identityServer) getBackgroundTasksWg() *sync.WaitGroup {
+	panic("not implemented")
 }
 
 //goland:noinspection GoExportedFuncWithUnexportedType

--- a/pkg/wekafs/interfaces.go
+++ b/pkg/wekafs/interfaces.go
@@ -3,6 +3,7 @@ package wekafs
 import (
 	"context"
 	"github.com/wekafs/csi-wekafs/pkg/wekafs/apiclient"
+	"sync"
 	"time"
 )
 
@@ -18,6 +19,7 @@ type AnyServer interface {
 	isInDevMode() bool
 	getDefaultMountOptions() MountOptions
 	getNodeId() string
+	getBackgroundTasksWg() *sync.WaitGroup
 }
 
 type AnyMounter interface {

--- a/pkg/wekafs/nodeserver.go
+++ b/pkg/wekafs/nodeserver.go
@@ -59,7 +59,12 @@ type NodeServer struct {
 	api               *ApiStore
 	config            *DriverConfig
 	semaphores        map[string]*semaphore.Weighted
+	backgroundTasksWg *sync.WaitGroup // used to wait for background tasks to finish before shutting down the server
 	sync.Mutex
+}
+
+func (ns *NodeServer) getBackgroundTasksWg() *sync.WaitGroup {
+	return ns.backgroundTasksWg
 }
 
 func (ns *NodeServer) getNodeId() string {
@@ -205,6 +210,7 @@ func NewNodeServer(nodeId string, maxVolumesPerNode int64, api *ApiStore, mounte
 		api:               api,
 		config:            config,
 		semaphores:        make(map[string]*semaphore.Weighted),
+		backgroundTasksWg: new(sync.WaitGroup),
 	}
 }
 

--- a/pkg/wekafs/volume.go
+++ b/pkg/wekafs/volume.go
@@ -1570,7 +1570,9 @@ func (v *Volume) deleteFilesystem(ctx context.Context) error {
 	}
 
 	go func() {
+		v.server.getBackgroundTasksWg().Add(1)
 		_ = deleteFunc(fsObj)
+		v.server.getBackgroundTasksWg().Done()
 	}()
 	return nil
 }
@@ -1643,7 +1645,11 @@ func (v *Volume) deleteSnapshot(ctx context.Context) error {
 	if !v.server.getConfig().allowAsyncObjectDeletion {
 		return v.waitForSnapshotDeletion(ctx, logger, snapUid)
 	}
-	go func() { _ = v.waitForSnapshotDeletion(ctx, logger, snapUid) }()
+	go func() {
+		v.server.getBackgroundTasksWg().Add(1)
+		_ = v.waitForSnapshotDeletion(ctx, logger, snapUid)
+	}()
+	v.server.getBackgroundTasksWg().Done()
 	return nil
 }
 


### PR DESCRIPTION
### TL;DR

Improved CSI plugin latency on DeleteVolume by moving the deletion of actual filesystem and NFS permissions to asynchronous flow. This behavior is configurable via `allowAsyncObjectDeletion` flag.

### What changed?

- Changed GitHub workflow to use standard runners instead of large runners
- Added Docker Compose setup action to all sanity test jobs
- Renamed `waitForObjectDeletion` flag to `allowAsyncObjectDeletion` with inverted logic
- Added background task tracking with WaitGroup to ensure clean shutdown
- Added retry logic (up to 5 attempts with 1-second intervals) when deleting NFS permissions
- Fixed filesystem name typo in logs
- Improved error messages for NFS permission deletion failures
- Updated Helm chart values to reflect the parameter name change

### How to test?

1. Create a volume with NFS transport
2. Delete the volume and verify that NFS permissions are properly cleaned up
3. Verify that the plugin can handle multiple concurrent volume deletions efficiently

### Why make this change?

These changes address latency of DeleteVolume requests by moving the deletion into out-of-band threads. The retry logic for NFS permission deletion helps overcome transient API failures that could possibly block filesystem deletion, for example in case of multiple deletions at once that require massive changes to NFS server configuration. The WaitGroup ensures all background tasks complete before the plugin shuts down.

### Note:
The new behavior is DISABLED by default in the binary, but ENABLED by default in Helm chart.