### PR TITLE
fix(CSI-350): avoid wekafs mounter from mounting if weka is not running

### DIFF
--- a/pkg/wekafs/identityserver.go
+++ b/pkg/wekafs/identityserver.go
@@ -82,7 +82,7 @@ func (ids *identityServer) getConfig() *DriverConfig {
 //goland:noinspection GoUnusedParameter
 func (ids *identityServer) Probe(ctx context.Context, req *csi.ProbeRequest) (*csi.ProbeResponse, error) {
 	logger := log.Ctx(ctx)
-	isReady := ids.getConfig().isInDevMode() || isWekaInstalled()
+	isReady := ids.getConfig().isInDevMode() || isWekaRunning()
 	if !isReady {
 		if ids.getConfig().useNfs || ids.getConfig().allowNfsFailback {
 			isReady = true

--- a/pkg/wekafs/utilities.go
+++ b/pkg/wekafs/utilities.go
@@ -539,7 +539,7 @@ func volumeExistsAndMatchesCapacity(ctx context.Context, v *Volume, capacity int
 	return exists, matches, err
 }
 
-func isWekaInstalled() bool {
+func isWekaRunning() bool {
 	file, err := os.Open(ProcModulesPath)
 	if err != nil {
 		log.Err(err).Msg("Failed to open procfs and check for existence of Weka kernel module")
@@ -567,6 +567,7 @@ func isWekaInstalled() bool {
 		scanner = bufio.NewScanner(driverInfo)
 		for scanner.Scan() {
 			line := scanner.Text()
+			// TODO: improve it by checking for the explicit client container name rather than just ANY container
 			if strings.Contains(line, "Connected frontend pid") {
 				return true
 			}

--- a/pkg/wekafs/wekafs.go
+++ b/pkg/wekafs/wekafs.go
@@ -485,7 +485,7 @@ func (driver *WekaFsDriver) NewMounter() AnyMounter {
 		log.Warn().Msg("Enforcing NFS transport due to configuration")
 		return newNfsMounter(driver)
 	}
-	if driver.config.allowNfsFailback && !isWekaInstalled() {
+	if driver.config.allowNfsFailback && !isWekaRunning() {
 		if driver.config.isInDevMode() {
 			log.Info().Msg("Not Enforcing NFS transport due to dev mode")
 		} else {

--- a/pkg/wekafs/wekafsmount.go
+++ b/pkg/wekafs/wekafsmount.go
@@ -184,6 +184,10 @@ func (m *wekafsMount) doMount(ctx context.Context, apiClient *apiclient.ApiClien
 		return err
 	}
 	if !m.isInDevMode() {
+		if !isWekaRunning() {
+			logger.Error().Msg("WEKA is not running, cannot mount. Make sure WEKA client software is running on the host")
+			return errors.New("weka is not running, cannot mount")
+		}
 		if apiClient == nil {
 			// this flow is relevant only for legacy volumes, will not work with SCMC / authenticated mounts / non-root org
 			logger.Trace().Msg("No API client for mount, not requesting mount token")


### PR DESCRIPTION
### TL;DR

Changed the check for Weka client from installation to running state and added better error handling for mounts.

### What changed?

- Renamed `isWekaInstalled()` function to `isWekaRunning()` to better reflect its actual purpose
- Added an explicit error check in `doMount()` to verify Weka is running before attempting to mount
- Added a TODO comment to improve the container detection logic
- Updated all references to the renamed function throughout the codebase

### How to test?

1. Test mounting volumes when Weka client is:
   - Running normally
   - Driver is installed but client is not running (e.g. no container exists)
   - Client is stopped via `weka local stop`
   - Weka not installed at all on that host
2. Verify appropriate error messages appear when Weka client is not running
3. Confirm NFS failback works correctly when configured and Weka is not running

### Why make this change?
Mount is a non-interruptible syscall. 
In case of weka client software not running properly, any mount attempt is remaining stuck forever and cannot be cancelled. As a result, upon failure in the WEKA client, the CSI plugin still attempted to do retries on mount, causing the thread pool to be exhausted. As a result, after a short period of time new request retries start failing on `Too many concurrent requests, please retry` instead.

This change adds a WEKA client connectivity check before actually doing the mount, and returns a clear error otherwise.