### PR TITLE
fix(CSI-351): incorrect error message when creating PVC with CSI secret missing endpoints

### DIFF
--- a/pkg/wekafs/wekafs.go
+++ b/pkg/wekafs/wekafs.go
@@ -98,6 +98,9 @@ func (api *ApiStore) getByClusterGuid(guid uuid.UUID) (*apiclient.ApiClient, err
 // fromSecrets returns a pointer to API by secret contents
 func (api *ApiStore) fromSecrets(ctx context.Context, secrets map[string]string, hostname string) (*apiclient.ApiClient, error) {
 	endpointsRaw := strings.TrimSpace(strings.ReplaceAll(strings.TrimSuffix(secrets["endpoints"], "\n"), "\n", ","))
+	if endpointsRaw == "" {
+		return nil, errors.New("no valid endpoints defined in secret, cannot create API client")
+	}
 	endpoints := func() []string {
 		var ret []string
 		for _, s := range strings.Split(endpointsRaw, ",") {


### PR DESCRIPTION
### TL;DR

Added validation for empty endpoints in the API client creation process.

### What changed?

Added a check in the `fromSecrets` method to verify that the `endpoints` value from the provided secrets is not empty. If empty, the function now returns an error with a clear message indicating that no valid endpoints are defined in the secret.

### How to test?

1. Try to create an API client with an empty endpoints value in the secrets
2. Verify that the function returns the expected error: "no valid endpoints defined in secret, cannot create API client"
3. Test with valid endpoints to ensure normal functionality is preserved

### Why make this change?

This change improves error handling by providing an early, explicit check for missing endpoints configuration. Without this validation, the code would likely fail later with a less descriptive error message, making troubleshooting more difficult. This enhancement helps users identify configuration issues more quickly.