### PR TITLE
fix(CSI-352): topology.csi.weka.io/transport=wekafs & topology.wekafs.csi/node labels missing on weka client restart

### DIFF
--- a/pkg/wekafs/wekafs.go
+++ b/pkg/wekafs/wekafs.go
@@ -376,10 +376,22 @@ func (d *WekaFsDriver) SetNodeLabels(ctx context.Context) {
 		return
 	}
 
+	transport := func() string {
+		if d.config.useNfs {
+			return "nfs"
+		}
+		wekaRunning := isWekaRunning()
+		if d.config.allowNfsFailback && !wekaRunning {
+			return "nfs"
+		}
+		return "wekafs"
+	}()
+
 	labelsToSet := make(map[string]string)
+	labelsToSet[TopologyKeyNode] = d.nodeID
 	labelsToSet[fmt.Sprintf(TopologyLabelNodePattern, d.name)] = d.nodeID
 	labelsToSet[fmt.Sprintf(TopologyLabelWekaLocalPattern, d.name)] = "true"
-
+	labelsToSet[fmt.Sprintf(TopologyLabelTransportPattern, d.name)] = transport
 	updateNeeded := false
 
 	for label, value := range labelsToSet {


### PR DESCRIPTION
### TL;DR

Added transport type labeling to nodes for WekaFS driver.

### What changed?

- Added a new function to determine the appropriate transport type ("nfs" or "wekafs") based on configuration and system state
- Added a new label to track the transport type using the `TopologyLabelTransportPattern` format
- Added the `TopologyKeyNode` label to the node

### How to test?

1. Deploy the CSI driver with different configurations:
   - With `useNfs: true`
   - With `allowNfsFailback: true` and Weka not running
   - With standard WekaFS configuration
2. Verify that nodes are correctly labeled with the appropriate transport type
3. Check that the `TopologyKeyNode` label is properly set with the node ID

### Why make this change?

This change enables better scheduling decisions by exposing the transport mechanism (NFS or WekaFS) as a node label. This information can be used by the scheduler to place pods on nodes with the appropriate transport capabilities, improving reliability and performance of storage operations.