### PR TITLE
ci: add tracing-configuration-for-sanity

### DIFF
--- a/.github/workflows/sanity.yaml
+++ b/.github/workflows/sanity.yaml
@@ -16,6 +16,7 @@ env:
   # - '-ginkgo.v'
   # - '-ginkgo.vv'
   SANITY_VERBOSITY: ${{ vars.SANITY_VERBOSITY }}
+  TRACING_SETTING: ${{ vars.TRACING_SETTING }}
   COMPOSE_DEFAULTS: '--exit-code-from=sanity --always-recreate-deps --force-recreate'
 
 jobs:

--- a/cmd/wekafsplugin/main.go
+++ b/cmd/wekafsplugin/main.go
@@ -167,6 +167,7 @@ func main() {
 		log.Error().Err(err).Msg("Failed to set up OpenTelemetry tracerProvider")
 	} else {
 		otel.SetTracerProvider(tp)
+		log.Info().Str("tracing_url", url).Msg("OpenTelemetry tracing initialized")
 		ctx, cancel := context.WithCancel(ctx)
 		c := make(chan os.Signal, 1)
 		signal.Notify(c, os.Interrupt)
@@ -234,6 +235,7 @@ func handle(ctx context.Context) {
 		*skipGarbageCollection,
 		*waitForObjectDeletion,
 		*allowEncryptionWithoutKms,
+		*tracingUrl,
 	)
 	driver, err := wekafs.NewWekaFsDriver(*driverName, *nodeID, *endpoint, *maxVolumesPerNode, version, *debugPath, csiMode, *selinuxSupport, config)
 	if err != nil {

--- a/pkg/wekafs/driverconfig.go
+++ b/pkg/wekafs/driverconfig.go
@@ -43,6 +43,7 @@ type DriverConfig struct {
 	waitForObjectDeletion            bool
 	allowEncryptionWithoutKms        bool
 	driverRef                        *WekaFsDriver
+	tracingUrl                       string
 }
 
 func (dc *DriverConfig) Log() {
@@ -67,6 +68,7 @@ func (dc *DriverConfig) Log() {
 		Str("client_group_name", dc.clientGroupName).
 		Bool("skip_garbage_collection", dc.skipGarbageCollection).
 		Bool("wait_for_object_deletion", dc.waitForObjectDeletion).
+		Str("tracing_url", dc.tracingUrl).
 		Msg("Starting driver with the following configuration")
 
 }
@@ -82,6 +84,7 @@ func NewDriverConfig(dynamicVolPath, VolumePrefix, SnapshotPrefix, SeedSnapshotP
 	version string,
 	skipGarbageCollection, waitForObjectDeletion bool,
 	allowEncryptionWithoutKms bool,
+	tracingUrl string,
 ) *DriverConfig {
 
 	var MutuallyExclusiveMountOptions []mutuallyExclusiveMountOptionSet
@@ -130,6 +133,7 @@ func NewDriverConfig(dynamicVolPath, VolumePrefix, SnapshotPrefix, SeedSnapshotP
 		skipGarbageCollection:            skipGarbageCollection,
 		waitForObjectDeletion:            waitForObjectDeletion,
 		allowEncryptionWithoutKms:        allowEncryptionWithoutKms,
+		tracingUrl:                       tracingUrl,
 	}
 }
 

--- a/pkg/wekafs/volume.go
+++ b/pkg/wekafs/volume.go
@@ -188,6 +188,7 @@ func (v *Volume) hasUnderlyingSnapshots(ctx context.Context) (bool, error) {
 	if !v.isFilesystem() {
 		return false, nil
 	}
+	logger.Debug().Str("volume_id", v.GetId()).Msg("Checking if filesystem has underlying snapshots that prevent deletion")
 
 	snapshots, err := v.getUnderlyingSnapshots(ctx)
 	if err != nil {

--- a/pkg/wekafs/volumeconstructors.go
+++ b/pkg/wekafs/volumeconstructors.go
@@ -57,6 +57,7 @@ func NewVolumeFromControllerCreateRequest(ctx context.Context, req *csi.CreateVo
 	logger := log.Ctx(ctx)
 	cSource := req.GetVolumeContentSource()
 	origin := "blank_volume"
+	srcId := ""
 	if cSource != nil {
 		cSourceVolume = cSource.GetVolume()
 		cSourceSnapshot = cSource.GetSnapshot()
@@ -75,6 +76,7 @@ func NewVolumeFromControllerCreateRequest(ctx context.Context, req *csi.CreateVo
 			if err != nil {
 				return nil, err
 			}
+			srcId = volume.srcVolume.GetId()
 		} else {
 			logger.Warn().Msg("Received a request with content source but without definition")
 			// this is blank volume
@@ -82,6 +84,7 @@ func NewVolumeFromControllerCreateRequest(ctx context.Context, req *csi.CreateVo
 			if err != nil {
 				return nil, err
 			}
+			srcId = volume.srcSnapshot.GetId()
 		}
 
 	} else {
@@ -100,7 +103,7 @@ func NewVolumeFromControllerCreateRequest(ctx context.Context, req *csi.CreateVo
 
 	volume.pruneUnsupportedMountOptions(ctx)
 
-	logger.Trace().Object("volume_info", volume).Str("origin", origin).Msg("Successfully initialized object")
+	logger.Debug().Object("volume_info", volume).Str("origin", origin).Str("src_id", srcId).Msg("Successfully initialized object")
 	return volume, nil
 }
 

--- a/tests/csi-sanity/docker-compose-nfs-snapshotcaps.yaml
+++ b/tests/csi-sanity/docker-compose-nfs-snapshotcaps.yaml
@@ -3,7 +3,7 @@ version: '3.8'
 services:
   plugin_controller:
     image: sanity
-    command: wekafsplugin -nodeid 1 -v 6 --allowinsecurehttps --endpoint=unix://tmp/weka-csi-test/controller.sock -metricsport=9091  --csimode=controller -enablemetrics -allowautofscreation -allowautofsexpansion -allowsnapshotsoflegacyvolumes -alwaysallowsnapshotvolumes -usenfs -interfacegroupname=NFS
+    command: wekafsplugin -nodeid 1 -v ${PLUGIN_VERBOSITY} --allowinsecurehttps --endpoint=unix://tmp/weka-csi-test/controller.sock -metricsport=9091  --csimode=controller -enablemetrics -allowautofscreation -allowautofsexpansion -allowsnapshotsoflegacyvolumes -alwaysallowsnapshotvolumes -usenfs -interfacegroupname=NFS
     volumes:
       - test-volume:/tmp/weka-csi-test
     privileged: true
@@ -16,7 +16,7 @@ services:
       interval: 3s
   plugin_node:
     image: sanity
-    command: wekafsplugin -nodeid 1 -v 6 --allowinsecurehttps --endpoint=unix://tmp/weka-csi-test/node.sock -metricsport=9092 --csimode=node -enablemetrics -allowautofscreation -allowautofsexpansion -allowsnapshotsoflegacyvolumes -alwaysallowsnapshotvolumes -usenfs -interfacegroupname=NFS
+    command: wekafsplugin -nodeid 1 -v ${PLUGIN_VERBOSITY} --allowinsecurehttps --endpoint=unix://tmp/weka-csi-test/node.sock -metricsport=9092 --csimode=node -enablemetrics -allowautofscreation -allowautofsexpansion -allowsnapshotsoflegacyvolumes -alwaysallowsnapshotvolumes -usenfs -interfacegroupname=NFS
     volumes:
       - test-volume:/tmp/weka-csi-test
     privileged: true

--- a/tests/csi-sanity/docker-compose-nfs-snapshotcaps.yaml
+++ b/tests/csi-sanity/docker-compose-nfs-snapshotcaps.yaml
@@ -3,7 +3,7 @@ version: '3.8'
 services:
   plugin_controller:
     image: sanity
-    command: wekafsplugin -nodeid 1 -v ${PLUGIN_VERBOSITY} --allowinsecurehttps --endpoint=unix://tmp/weka-csi-test/controller.sock -metricsport=9091  --csimode=controller -enablemetrics -allowautofscreation -allowautofsexpansion -allowsnapshotsoflegacyvolumes -alwaysallowsnapshotvolumes -usenfs -interfacegroupname=NFS
+    command: wekafsplugin -nodeid 1 -v ${PLUGIN_VERBOSITY} --allowinsecurehttps --endpoint=unix://tmp/weka-csi-test/controller.sock -metricsport=9091  --csimode=controller -enablemetrics -allowautofscreation -allowautofsexpansion -allowsnapshotsoflegacyvolumes -alwaysallowsnapshotvolumes -usenfs -interfacegroupname=NFS ${TRACING_SETTING}
     volumes:
       - test-volume:/tmp/weka-csi-test
     privileged: true
@@ -16,7 +16,7 @@ services:
       interval: 3s
   plugin_node:
     image: sanity
-    command: wekafsplugin -nodeid 1 -v ${PLUGIN_VERBOSITY} --allowinsecurehttps --endpoint=unix://tmp/weka-csi-test/node.sock -metricsport=9092 --csimode=node -enablemetrics -allowautofscreation -allowautofsexpansion -allowsnapshotsoflegacyvolumes -alwaysallowsnapshotvolumes -usenfs -interfacegroupname=NFS
+    command: wekafsplugin -nodeid 1 -v ${PLUGIN_VERBOSITY} --allowinsecurehttps --endpoint=unix://tmp/weka-csi-test/node.sock -metricsport=9092 --csimode=node -enablemetrics -allowautofscreation -allowautofsexpansion -allowsnapshotsoflegacyvolumes -alwaysallowsnapshotvolumes -usenfs -interfacegroupname=NFS ${TRACING_SETTING}
     volumes:
       - test-volume:/tmp/weka-csi-test
     privileged: true

--- a/tests/csi-sanity/docker-compose-snapshotcaps.yaml
+++ b/tests/csi-sanity/docker-compose-snapshotcaps.yaml
@@ -3,7 +3,7 @@ version: '3.8'
 services:
   plugin_controller:
     image: sanity
-    command: wekafsplugin -nodeid 1 -v ${PLUGIN_VERBOSITY} --allowinsecurehttps --endpoint=unix://tmp/weka-csi-test/controller.sock --debugpath=/tmp/weka-csi-test/filesystems  -metricsport=9091  --csimode=controller -enablemetrics -allowautofscreation -allowautofsexpansion -allowsnapshotsoflegacyvolumes -alwaysallowsnapshotvolumes
+    command: wekafsplugin -nodeid 1 -v ${PLUGIN_VERBOSITY} --allowinsecurehttps --endpoint=unix://tmp/weka-csi-test/controller.sock --debugpath=/tmp/weka-csi-test/filesystems  -metricsport=9091  --csimode=controller -enablemetrics -allowautofscreation -allowautofsexpansion -allowsnapshotsoflegacyvolumes -alwaysallowsnapshotvolumes ${TRACING_SETTING}
     volumes:
       - test-volume:/tmp/weka-csi-test
     privileged: true
@@ -16,7 +16,7 @@ services:
       interval: 3s
   plugin_node:
     image: sanity
-    command: wekafsplugin -nodeid 1 -v ${PLUGIN_VERBOSITY} --allowinsecurehttps --endpoint=unix://tmp/weka-csi-test/node.sock --debugpath=/tmp/weka-csi-test/filesystems  -metricsport=9092 --csimode=node -enablemetrics -allowautofscreation -allowautofsexpansion -allowsnapshotsoflegacyvolumes -alwaysallowsnapshotvolumes
+    command: wekafsplugin -nodeid 1 -v ${PLUGIN_VERBOSITY} --allowinsecurehttps --endpoint=unix://tmp/weka-csi-test/node.sock --debugpath=/tmp/weka-csi-test/filesystems  -metricsport=9092 --csimode=node -enablemetrics -allowautofscreation -allowautofsexpansion -allowsnapshotsoflegacyvolumes -alwaysallowsnapshotvolumes ${TRACING_SETTING}
     volumes:
       - test-volume:/tmp/weka-csi-test
     privileged: true


### PR DESCRIPTION
# Enhanced Tracing and Logging for CSI Driver

- Added `TRACING_SETTING` environment variable to GitHub workflows for configuring tracing in sanity tests
- Added tracing URL to driver configuration and improved logging of tracing initialization
- Enhanced volume creation logs by adding source ID information to debug messages
- Added debug logging when checking for underlying snapshots during volume operations
- Improved volume initialization logging with better context about volume origins

The changes improve observability by propagating tracing configuration from GitHub variables to test environments and adding more detailed logging around critical operations.