### PR TITLE
feat(CSI-356): avoid failback to xattr upon quota set error

### DIFF
--- a/pkg/wekafs/volume.go
+++ b/pkg/wekafs/volume.go
@@ -541,40 +541,33 @@ func (v *Volume) UpdateCapacity(ctx context.Context, enforceCapacity *bool, capa
 
 	// update capacity of the volume by updating quota object on its root directory (or XATTR)
 	logger.Info().Int64("desired_capacity", capacityLimit).Msg("Updating volume capacity")
-	var fallback = true // whether we should try to use xAttr fallback or not if setting quota was attempted and failed. note that in certain cases a fallbackFunc will be used right away:
 	primaryFunc := func() error { return v.updateCapacityQuota(ctx, enforceCapacity, capacityLimit) }
 	fallbackFunc := func() error { return v.updateCapacityXattr(ctx, enforceCapacity, capacityLimit) }
+	capacityEntity := "quota"
 	if v.server.isInDevMode() {
 		logger.Trace().Msg("Updating quota via API is not possible since running in DEV mode")
 		primaryFunc = fallbackFunc
-		fallback = false
+		capacityEntity = "xattr"
 	} else if v.apiClient == nil {
 		logger.Trace().Msg("Volume has no API client bound, updating capacity in legacy mode")
 		primaryFunc = fallbackFunc
-		fallback = false
+		capacityEntity = "xattr"
 	} else if !v.apiClient.SupportsQuotaDirectoryAsVolume() {
 		logger.Warn().Msg("Updating quota via API not supported by Weka cluster, updating capacity in legacy mode")
 		primaryFunc = fallbackFunc
-		fallback = false
+		capacityEntity = "xattr"
 	} else if !v.apiClient.SupportsAuthenticatedMounts() && v.apiClient.Credentials.Organization != "Root" {
-		logger.Warn().Msg("Updating quota via API is not supported by Weka cluster since filesystem is located in non-default organization, updating capacity in legacy mode")
+		logger.Warn().Msg("Updating quota via API is not supported by Weka cluster since filesystem is located in non-default organization, updating capacity in legacy mode. Upgrade to latest version of Weka software to enable quota enforcement")
 		primaryFunc = fallbackFunc
-		fallback = false
+		capacityEntity = "xattr"
 	} else if !v.apiClient.SupportsQuotaOnSnapshots() && v.isOnSnapshot() {
 		logger.Warn().Msg("Quota enforcement is not supported for snapshot-backed volumes on current version of Weka software. Upgrade to latest version of Weka software to enable quota enforcement")
 	}
 	err := primaryFunc()
 	if err == nil {
-		logger.Info().Int64("new_capacity", capacityLimit).Msg("Successfully updated capacity for volume")
-	} else if fallback {
-		// it means that fallback is false, and used for updating xattr if quota set failed.
-		// this is not intended to run Xattr for a second time
-		logger.Warn().Err(err).Msg("Failed to set quota via API, failing back to xattr")
-		err := fallbackFunc()
-		if err != nil {
-			logger.Error().Err(err).Msg("Failed to set capacity even in failback mode")
-		}
-		return err
+		logger.Info().Int64("new_capacity", capacityLimit).Str("capacity_entity", capacityEntity).Msg("Successfully updated capacity for volume")
+	} else {
+		logger.Error().Err(err).Str("capacity_entity", capacityEntity).Msg("Failed to set volume capacity")
 	}
 	return err
 }


### PR DESCRIPTION
### TL;DR

Simplified volume capacity update logic by removing the fallback mechanism and improving logging.

### What changed?

- Removed the fallback mechanism that would try to use xattr if setting quota failed
- Added a `capacityEntity` variable to track which method is being used (quota or xattr)
- Improved logging by including the capacity entity in success and error messages
- Enhanced warning message for non-default organization to suggest upgrading to the latest Weka software
- Streamlined error handling logic to be more consistent

### How to test?

1. Test volume capacity updates in different scenarios:
   - With a regular Weka cluster that supports quota
   - In in DEV mode
   - With a volume that has no API client bound
   - With a cluster that doesn't support quota directory as volume
   - With a non-default organization
   - With a snapshot-backed volume

2. Verify that appropriate logs are generated with the correct capacity entity. xattr should be used only when using quota is not supported, not when it fails with error.

### Why make this change?

The previous implementation had unnecessary complexity with a fallback mechanism that wasn't being used effectively. As a result, upon failure to set up quota a volume would be created using xattr failback mode, possibly concealing the fact that the quota is not actually set. This change simplifies the code flow, makes the behavior more predictable, and improves logging to make it clearer which capacity update method is being used, making troubleshooting easier.