### PR TITLE
fix(CSI-335): initializeSemaphore should set 1 for unknown operations

### DIFF
--- a/pkg/wekafs/controllerserver.go
+++ b/pkg/wekafs/controllerserver.go
@@ -211,7 +211,10 @@ func (cs *ControllerServer) initializeSemaphore(ctx context.Context, op string) 
 	if _, ok := cs.semaphores[op]; ok {
 		return
 	}
-	m := cs.getConfig().maxConcurrencyPerOp[op]
+	m, ok := cs.getConfig().maxConcurrencyPerOp[op]
+	if !ok { // if not set, default to 1
+		m = 1
+	}
 	logger := log.Ctx(ctx)
 	logger.Info().Str("op", op).Int64("max_concurrency", m).Msg("Initializing semaphore")
 	sem := semaphore.NewWeighted(m)

--- a/pkg/wekafs/nodeserver.go
+++ b/pkg/wekafs/nodeserver.go
@@ -239,10 +239,13 @@ func (ns *NodeServer) initializeSemaphore(ctx context.Context, op string) {
 		return
 	}
 
-	max := ns.getConfig().maxConcurrencyPerOp[op]
+	m, ok := ns.getConfig().maxConcurrencyPerOp[op]
+	if !ok { // if not set, default to 1
+		m = 1
+	}
 	logger := log.Ctx(ctx)
-	logger.Info().Str("op", op).Int64("max_concurrency", max).Msg("Initializing semaphore")
-	sem := semaphore.NewWeighted(max)
+	logger.Info().Str("op", op).Int64("max_concurrency", m).Msg("Initializing semaphore")
+	sem := semaphore.NewWeighted(m)
 	ns.semaphores[op] = sem
 }
 


### PR DESCRIPTION
### TL;DR

Added default concurrency limit for operations without explicit configuration.

### What changed?

Modified the `initializeSemaphore` method in both `ControllerServer` and `NodeServer` to handle cases where an operation doesn't have a configured concurrency limit. Now, if an operation's concurrency limit is not explicitly set in `maxConcurrencyPerOp`, it defaults to 1 instead of potentially causing issues with an undefined value.

### How to test?

1. Deploy the CSI driver without specifying concurrency limits for some operations
2. Verify that operations without explicit concurrency limits work correctly
3. Check logs to confirm that semaphores are initialized with the default value of 1 for these operations

### Why make this change?

This change improves robustness by ensuring all operations have a valid concurrency limit, even when not explicitly configured. This prevents potential issues when new operations are added without corresponding concurrency configurations, providing a safe default behavior.