### PR TITLE
fix(CSI-358): rotation to another API andpoint does not happen on error 503

### DIFF
--- a/pkg/wekafs/apiclient/apiendpoint.go
+++ b/pkg/wekafs/apiclient/apiendpoint.go
@@ -23,6 +23,7 @@ type ApiEndPoint struct {
 	http404ErrCount      int64
 	http409ErrCount      int64
 	http500ErrCount      int64
+	http503ErrCount      int64
 	generalErrCount      int64
 	transportErrCount    int64
 	noRespCount          int64
@@ -151,7 +152,7 @@ func (a *ApiClient) UpdateApiEndpoints(ctx context.Context) error {
 // rotateEndpoint returns a random endpoint of the configured ones
 func (a *ApiClient) rotateEndpoint(ctx context.Context) {
 	logger := log.Ctx(ctx)
-	if len(a.actualApiEndpoints) == 0 {
+	if len(a.actualApiEndpoints) == 0 || a.actualApiEndpoints == nil {
 		a.resetDefaultEndpoints(ctx)
 	}
 	if len(a.actualApiEndpoints) == 0 {

--- a/pkg/wekafs/apiclient/errors.go
+++ b/pkg/wekafs/apiclient/errors.go
@@ -143,6 +143,33 @@ func (e ApiInternalError) getType() string {
 	return "ApiInternalError"
 }
 
+type ApiNotAvailableError ApiError
+
+func (e ApiNotAvailableError) Error() string {
+	return fmt.Sprintf("%s: %s, status code: %d, original error: %e, raw response: %s, json: %s",
+		e.getType(),
+		e.Text,
+		e.StatusCode,
+		e.Err,
+		func() string {
+			if e.RawData != nil {
+				return string(*e.RawData)
+			}
+			return ""
+		}(),
+		func() json.RawMessage {
+			if e.ApiResponse != nil {
+				return e.ApiResponse.Data
+			}
+			return json.RawMessage{}
+		}(),
+	)
+}
+
+func (e ApiNotAvailableError) getType() string {
+	return "ApiNotAvailableError"
+}
+
 type ApiNotFoundError ApiError
 
 func (e ApiNotFoundError) Error() string {


### PR DESCRIPTION
### TL;DR

Improved error handling in the API client by adding support for more error types and enhancing transient error detection.

### What changed?

- Renamed `handleNetworkErrors` to `handleTransientErrors` to better reflect its purpose
- Added handling for additional error types:
  - `transportError`
  - `ApiInternalError`
  - `ApiNotAvailableError`
- Added a new `ApiNotAvailableError` type for HTTP 503 Service Unavailable responses
- Added tracking for HTTP 503 errors in the `ApiEndPoint` struct
- Enhanced error handling in the request method to properly handle different HTTP status codes
- Added comprehensive test cases for various API client error scenarios

### How to test?

Run the new test cases added in `apiclient_test.go`:
```
go test -v ./pkg/wekafs/apiclient -run TestApiClientRequest
```

The tests cover various error scenarios including:
- Timeout errors
- Connection resets
- HTTP 500 Internal Server Error
- HTTP 404 Not Found
- HTTP 503 Service Unavailable

### Why make this change?

This change improves the robustness of the API client by properly handling more types of transient errors. By correctly identifying and handling different error types, the client can make better decisions about when to retry operations and when to fail fast, leading to more reliable behavior in unstable network conditions or when the server is experiencing issues.