### PR TITLE
feat(CSI-359): allow retention of SElinux policy machine configuration on OCP clusters

### DIFF
--- a/charts/csi-wekafsplugin/templates/selinux-policy-machineconfig.yaml
+++ b/charts/csi-wekafsplugin/templates/selinux-policy-machineconfig.yaml
@@ -6,6 +6,10 @@ metadata:
   name: 50-{{ $.Release.Name }}-selinux-policy-{{ . }}
   labels:
     machineconfiguration.openshift.io/role: {{ . }}
+  {{- if $.Values.selinuxOcpRetainMachineConfig }}
+  annotations:
+    helm.sh/resource-policy: keep
+  {{- end }}
 spec:
   osImageURL: ''
   config:

--- a/charts/csi-wekafsplugin/values.yaml
+++ b/charts/csi-wekafsplugin/values.yaml
@@ -120,6 +120,9 @@ selinuxSupport: "off"
 #    e.g., to run the node server in secure mode on SELinux-enabled node, the node must have label
 #    `csi.weka.io/selinux_enabled="true"`
 selinuxNodeLabel: "csi.weka.io/selinux_enabled"
+# -- If true, the SELinux policy machine configuration will not be removed when uninstalling the plugin.
+#    This is useful for OpenShift Container Platform clusters, to not cause machine config pool update on plugin reinstall
+selinuxOcpRetainMachineConfig: false
 # -- kubelet path, in cases Kubernetes is installed not in default folder
 kubeletPath: "/var/lib/kubelet"
 metrics:


### PR DESCRIPTION
### TL;DR

Added an option to retain SELinux policy machine configuration when uninstalling the CSI WekaFS plugin on OpenShift Container Platform.

### What changed?

- Added a new configuration parameter `selinuxOcpRetainMachineConfig` (default: false) in `values.yaml`
- Modified the SELinux policy machine configuration template to include the `helm.sh/resource-policy: keep` annotation when the new parameter is enabled

### How to test?

1. Deploy the CSI WekaFS plugin on an OpenShift Container Platform cluster with `selinuxOcpRetainMachineConfig: true`
2. Uninstall the plugin
3. Verify that the SELinux policy machine configuration is not removed
4. Reinstall the plugin and confirm that no machine config pool update is triggered

### Why make this change?

This change prevents unnecessary machine config pool updates when reinstalling the CSI WekaFS plugin on OpenShift Container Platform clusters. By retaining the SELinux policy machine configuration during uninstallation, we avoid the need to reapply these configurations during reinstallation, which would otherwise trigger node reboots and disrupt cluster operations.