### PR TITLE
ci: make sure to use latest docker buildx to support GH cache v2

### DIFF
--- a/.github/workflows/sanity.yaml
+++ b/.github/workflows/sanity.yaml
@@ -27,6 +27,8 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - run: echo "${{ secrets.WEKAFS_API_SECRET_YAML }}" > tests/csi-sanity/wekafs-api-secret.yaml
       - uses: docker/setup-buildx-action@v3
+        with:
+          version: latest
       - uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}


### PR DESCRIPTION
### TL;DR

Update Docker Buildx to latest version in the sanity workflow.

### What changed?

Added configuration to the `docker/setup-buildx-action@v3` step in the GitHub workflow to explicitly use the latest version of Buildx.

### How to test?

Run the sanity workflow to verify that the Docker Buildx setup completes successfully with the latest version.

### Why make this change?

Using the latest version of Buildx ensures we have access to the most recent features and bug fixes, which can improve build performance and reliability in our CI pipeline.
Also it comes to resolve issues with GitHub Actions Cache update to v2