### PR TITLE
feat(CSI-360): make node topology labeling configurable in favor of auxilary management via operator

### DIFF
--- a/charts/csi-wekafsplugin/templates/nodeserver-daemonset.yaml
+++ b/charts/csi-wekafsplugin/templates/nodeserver-daemonset.yaml
@@ -110,6 +110,9 @@ spec:
           {{- if .Values.pluginConfig.mountProtocol.nfsProtocolVersion }}
             - "--nfsprotocolversion={{ .Values.pluginConfig.mountProtocol.nfsProtocolVersion | toString}}"
           {{- end }}
+          {{- if .Values.pluginConfig.manageNodeTopologyLabels }}
+            - "--managenodetopologylabels"
+          {{- end }}
           ports:
             - containerPort: 9899
               name: healthz

--- a/charts/csi-wekafsplugin/values.yaml
+++ b/charts/csi-wekafsplugin/values.yaml
@@ -199,3 +199,6 @@ pluginConfig:
   skipGarbageCollection: false
   # -- Wait for WEKA filesystem / snapshot deletion before acknowledging the corresponding CSI volume deletion. Default false
   waitForObjectDeletion: false
+  # -- Allow CSI plugin to manage node topology labels. For Operator-managed clusters, this should be set to false.
+  manageNodeTopologyLabels: true
+

--- a/cmd/wekafsplugin/main.go
+++ b/cmd/wekafsplugin/main.go
@@ -99,6 +99,7 @@ var (
 	skipGarbageCollection                = flag.Bool("skipgarbagecollection", false, "Skip garbage collection of directory volumes data, only move to trash")
 	waitForObjectDeletion                = flag.Bool("waitforobjectdeletion", false, "Wait for object deletion before returning from DeleteVolume")
 	allowEncryptionWithoutKms            = flag.Bool("allowencryptionwithoutkms", false, "Allow encryption without KMS, for testing purposes only")
+	manageNodeTopologyLabels             = flag.Bool("managenodetopologylabels", false, "Manage node topology labels for CSI driver")
 	// Set by the build process
 	version = ""
 )
@@ -236,6 +237,7 @@ func handle(ctx context.Context) {
 		*waitForObjectDeletion,
 		*allowEncryptionWithoutKms,
 		*tracingUrl,
+		*manageNodeTopologyLabels,
 	)
 	driver, err := wekafs.NewWekaFsDriver(*driverName, *nodeID, *endpoint, *maxVolumesPerNode, version, *debugPath, csiMode, *selinuxSupport, config)
 	if err != nil {

--- a/pkg/wekafs/driverconfig.go
+++ b/pkg/wekafs/driverconfig.go
@@ -44,6 +44,7 @@ type DriverConfig struct {
 	allowEncryptionWithoutKms        bool
 	driverRef                        *WekaFsDriver
 	tracingUrl                       string
+	manageNodeTopologyLabels         bool
 }
 
 func (dc *DriverConfig) Log() {
@@ -69,6 +70,7 @@ func (dc *DriverConfig) Log() {
 		Bool("skip_garbage_collection", dc.skipGarbageCollection).
 		Bool("wait_for_object_deletion", dc.waitForObjectDeletion).
 		Str("tracing_url", dc.tracingUrl).
+		Bool("manage_node_topology_labels", dc.manageNodeTopologyLabels).
 		Msg("Starting driver with the following configuration")
 
 }
@@ -85,6 +87,7 @@ func NewDriverConfig(dynamicVolPath, VolumePrefix, SnapshotPrefix, SeedSnapshotP
 	skipGarbageCollection, waitForObjectDeletion bool,
 	allowEncryptionWithoutKms bool,
 	tracingUrl string,
+	manageNodeTopologyLabels bool,
 ) *DriverConfig {
 
 	var MutuallyExclusiveMountOptions []mutuallyExclusiveMountOptionSet
@@ -134,6 +137,7 @@ func NewDriverConfig(dynamicVolPath, VolumePrefix, SnapshotPrefix, SeedSnapshotP
 		waitForObjectDeletion:            waitForObjectDeletion,
 		allowEncryptionWithoutKms:        allowEncryptionWithoutKms,
 		tracingUrl:                       tracingUrl,
+		manageNodeTopologyLabels:         manageNodeTopologyLabels,
 	}
 }
 

--- a/pkg/wekafs/nodeserver.go
+++ b/pkg/wekafs/nodeserver.go
@@ -528,10 +528,14 @@ func (ns *NodeServer) NodeGetInfo(ctx context.Context, req *csi.NodeGetInfoReque
 		TopologyKeyNode:         ns.nodeID,
 		TopologyLabelWekaGlobal: "true", // for backward compatibility remains as is
 	}
-	// this will either overwrite or add the keys based on the driver name
-	segments[fmt.Sprintf(TopologyLabelNodePattern, driverName)] = ns.nodeID
-	segments[fmt.Sprintf(TopologyLabelTransportPattern, driverName)] = string(ns.getMounter().getTransport())
-	segments[fmt.Sprintf(TopologyLabelWekaLocalPattern, driverName)] = "true"
+	if ns.config.manageNodeTopologyLabels {
+		// this will either overwrite or add the keys based on the driver name
+		segments[fmt.Sprintf(TopologyLabelNodePattern, driverName)] = ns.nodeID
+		segments[fmt.Sprintf(TopologyLabelTransportPattern, driverName)] = string(ns.getMounter().getTransport())
+		segments[fmt.Sprintf(TopologyLabelWekaLocalPattern, driverName)] = "true"
+	} else {
+		logger.Warn().Msg("Node topology labels management is disabled, using global label only")
+	}
 
 	topology := &csi.Topology{
 		Segments: segments,

--- a/pkg/wekafs/volume_test.go
+++ b/pkg/wekafs/volume_test.go
@@ -16,7 +16,8 @@ func GetDriverForTest(t *testing.T) *WekaFsDriver {
 		"", true, true, true, true, true,
 		true, true, mutuallyExclusive,
 		1, 1, 1, 1, 1, 1, 1, 10,
-		true, true, true, "", "", "4.1", "v1", false, false, true, "")
+		true, true, true, "", "", "4.1", "v1", false, false, true,
+		"", false)
 	driver, err := NewWekaFsDriver("csi.weka.io", nodeId, "unix://tmp/csi.sock", 10, "v1.0", "", CsiModeAll, false, driverConfig)
 	if err != nil {
 		t.Fatalf("Failed to create new driver: %v", err)


### PR DESCRIPTION
### TL;DR

Added a new configuration option to control whether the CSI plugin manages node topology labels.

### What changed?

- Added a new configuration parameter `manageNodeTopologyLabels` (default: true) to control whether the CSI plugin manages node topology labels
- Added a new command-line flag `--managenodetopologylabels` to the plugin
- Modified the Helm chart to expose this configuration option
- Updated the node server and identity server logic to respect this setting
- Added a warning log when topology label management is disabled

### How to test?

1. Deploy the CSI plugin with default settings (labels will be managed)
2. Deploy the CSI plugin with `pluginConfig.manageNodeTopologyLabels: false` and verify that node topology labels are not being managed
3. For Operator-managed clusters, set this value to `false` to avoid conflicts

### Why make this change?

This change allows for better integration with WEKA Kubernetes operator that might want to manage node topology labels. As noted in the configuration comment, "For Operator-managed clusters, this should be set to false" to prevent conflicts between the CSI plugin and the operator when managing the same labels.