### PR TITLE
fix(CSI-371): remove legacy volume secret mount

### DIFF
--- a/charts/csi-wekafsplugin/templates/nodeserver-daemonset.yaml
+++ b/charts/csi-wekafsplugin/templates/nodeserver-daemonset.yaml
@@ -164,11 +164,6 @@ spec:
               name: csi-data-dir
             - mountPath: /dev
               name: dev-dir
-            {{- if .Values.legacyVolumeSecretName }}
-            - mountPath: /legacy-volume-access
-              name: legacy-volume-access
-              readOnly: true
-            {{- end }}
             {{- if or (.Capabilities.APIVersions.Has "security.openshift.io/v1/SecurityContextConstraints") (eq .Values.selinuxSupport "enforced") }}
             - mountPath: /etc/selinux/config
               name: selinux-config
@@ -264,9 +259,4 @@ spec:
             path: /sys/fs/selinux
             type: Directory
           name: selinux-fs
-      {{- end }}
-      {{- if .Values.legacyVolumeSecretName }}
-        - name: legacy-volume-access
-          secret:
-            secretName: {{ .Values.legacyVolumeSecretName }}
       {{- end }}


### PR DESCRIPTION
### TL;DR

Removed legacy volume secret mount from the nodeserver daemonset.

### What changed?

Removed the conditional mount of the legacy volume secret in the nodeserver daemonset template. Specifically:
- Removed the volume mount at `/legacy-volume-access` from the container spec
- Removed the corresponding volume definition that referenced `legacyVolumeSecretName`

### How to test?

1. Deploy the chart with and without `legacyVolumeSecretName` defined
2. Verify that the nodeserver daemonset no longer attempts to mount the legacy volume secret
3. Ensure that existing functionality works correctly without this mount

### Why make this change?

This change removes support for a legacy feature that is no longer needed, and complements the removal of legacy volume support