### PR TITLE
feat(CSI-366): support KUBECONFIG for CSI component rather than only inClusterConfig

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -56,6 +56,7 @@ require (
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.64.0 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.36.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -163,7 +163,6 @@ golang.org/x/sync v0.15.0/go.mod h1:1dzgHSNfp02xaA81J2MS99Qcpr2w7fw1gpm99rleRqA=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20220408201424-a24fb2fb8a0f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.12.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=


### PR DESCRIPTION
### TL;DR

Added support for using local kubeconfig when running outside of a Kubernetes cluster.

### What changed?

- Added fallback logic to use the local kubeconfig file when the driver is not running inside a Kubernetes cluster
- The driver now checks for the `KUBECONFIG` environment variable and attempts to build a client configuration from it
- Added `github.com/spf13/pflag` dependency to go.mod
- Removed an unused dependency entry for `golang.org/x/sys v0.0.0-20220408201424-a24fb2fb8a0f`

### How to test?

1. Set the `KUBECONFIG` environment variable to point to a valid kubeconfig file
2. Run the driver outside of a Kubernetes cluster
3. Verify that the driver can connect to the Kubernetes API server and function properly

### Why make this change?

This change improves the developer experience by allowing the driver to be tested and run outside of a Kubernetes cluster. This is particularly useful for local development and debugging, where running the driver directly on a development machine with access to a remote cluster is more convenient than deploying it to the cluster first.