### PR TITLE
feat(CSI-367): API clients for same credentials are initialized multiple times rather than once

### DIFF
--- a/pkg/wekafs/apiclient/credentials.go
+++ b/pkg/wekafs/apiclient/credentials.go
@@ -1,6 +1,9 @@
 package apiclient
 
-import "fmt"
+import (
+	"fmt"
+	"hash/fnv"
+)
 
 type KmsVaultCredentials struct {
 	KeyIdentifier string
@@ -36,4 +39,21 @@ type Credentials struct {
 func (c *Credentials) String() string {
 	return fmt.Sprintf("%s://%s:%s@%s",
 		c.HttpScheme, c.Username, c.Organization, c.Endpoints)
+}
+
+func (c *Credentials) Hash() uint32 {
+	h := fnv.New32a()
+	s := fmt.Sprintln(
+		c.Username,
+		c.Password,
+		c.Organization,
+		c.Endpoints,
+		c.NfsTargetIPs,
+		c.LocalContainerName,
+		c.CaCertificate,
+		c.KmsPreexistingCredentialsForVolumeEncryption.InsecureString(),
+		c.KmsKeyManagementCredentials.InsecureString(),
+	)
+	h.Write([]byte(s))
+	return h.Sum32()
 }

--- a/pkg/wekafs/utilities.go
+++ b/pkg/wekafs/utilities.go
@@ -20,6 +20,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -597,6 +598,11 @@ func GetCsiPluginMode(mode *string) CsiPluginMode {
 		log.Fatal().Str("required_plugin_mode", string(ret)).Msg("Unsupported plugin mode")
 		return ""
 	}
+}
+
+func (api *ApiStore) getLockForHash(hash uint32) *sync.Mutex {
+	lockIface, _ := api.locks.LoadOrStore(hash, &sync.Mutex{})
+	return lockIface.(*sync.Mutex)
 }
 
 // Die used to intentionally panic and exit, while updating termination log


### PR DESCRIPTION
### TL;DR

Added credential hashing and mutex locking to prevent race conditions when creating API clients.

### What changed?

- Added a `Hash()` method to the `Credentials` struct that generates a unique hash based on credential properties
- Implemented a per-hash locking mechanism in the `ApiStore` using a sync.Map to store mutexes
- Modified the `fromCredentials` method to use these locks when creating new API clients
- Fixed potential race conditions by properly managing lock/unlock operations

### How to test?

- Test concurrent API client creation with the same credentials to verify no race conditions occur
- Verify that identical credentials result in the same hash value
- Ensure API clients are properly cached and reused when the same credentials are provided

### Why make this change?

This change prevents race conditions that could occur when multiple goroutines attempt to create API clients with the same credentials simultaneously. The previous implementation had potential deadlocks and race conditions during client initialization. By adding per-credential locking, we ensure thread safety while maintaining performance by only locking operations for the specific credentials being processed.
Moreover, in this case, API client creation is serialized, so only single authentication is performed on the WEKA cluster