### PR TITLE
chore(deps): update sidecars as of 2025-07-27

### DIFF
--- a/charts/csi-wekafsplugin/values.yaml
+++ b/charts/csi-wekafsplugin/values.yaml
@@ -8,17 +8,17 @@ csiDriverName: "csi.weka.io"
 csiDriverVersion: &csiDriverVersion 2.8.0-SNAPSHOT.8.sha.988f46d
 images:
   # -- CSI liveness probe sidecar image URL
-  livenessprobesidecar: registry.k8s.io/sig-storage/livenessprobe:v2.15.0
+  livenessprobesidecar: registry.k8s.io/sig-storage/livenessprobe:v2.16.0
   # -- CSI attacher sidecar image URL
-  attachersidecar: registry.k8s.io/sig-storage/csi-attacher:v4.8.0
+  attachersidecar: registry.k8s.io/sig-storage/csi-attacher:v4.9.0
   # -- CSI provisioner sidecar image URL
-  provisionersidecar: registry.k8s.io/sig-storage/csi-provisioner:v5.1.0
+  provisionersidecar: registry.k8s.io/sig-storage/csi-provisioner:v5.3.0
   # -- CSI registrar sidercar
-  registrarsidecar: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.13.0
+  registrarsidecar: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.14.0
   # -- CSI resizer sidecar image URL
-  resizersidecar: registry.k8s.io/sig-storage/csi-resizer:v1.13.1
+  resizersidecar: registry.k8s.io/sig-storage/csi-resizer:v1.14.0
   # -- CSI snapshotter sidecar image URL
-  snapshottersidecar: registry.k8s.io/sig-storage/csi-snapshotter:v8.2.0
+  snapshottersidecar: registry.k8s.io/sig-storage/csi-snapshotter:v8.3.0
   # -- CSI nodeinfo sidecar image URL, used for reading node metadata
   nodeinfo: quay.io/weka.io/csi-wekafs
   # -- CSI driver main image URL


### PR DESCRIPTION
### TL;DR

Updated all CSI sidecar container images to their latest versions.

### What changed?

Updated the following CSI sidecar container images to newer versions:
- livenessprobe: v2.15.0 → v2.16.0
- csi-attacher: v4.8.0 → v4.9.0
- csi-provisioner: v5.1.0 → v5.3.0
- csi-node-driver-registrar: v2.13.0 → v2.14.0
- csi-resizer: v1.13.1 → v1.14.0
- csi-snapshotter: v8.2.0 → v8.3.0

### How to test?

1. Deploy the CSI WekaFS plugin with the updated values
2. Verify that all pods start correctly with the new container images
3. Test basic CSI operations (volume provisioning, mounting, resizing, snapshots) to ensure functionality

### Why make this change?

Keeping the CSI sidecar containers updated ensures we benefit from the latest bug fixes, security patches, and performance improvements from the Kubernetes storage SIG. These updates help maintain compatibility with newer Kubernetes versions and follow best practices for container image management.