### PR TITLE
feat(CSI-379): support pagination for REST API client

### DIFF
--- a/pkg/wekafs/apiclient/apiclient.go
+++ b/pkg/wekafs/apiclient/apiclient.go
@@ -188,6 +188,8 @@ func (a *ApiClient) retryBackoff(ctx context.Context, attempts int, sleep time.D
 	maxAttempts := attempts
 	if err := f(); err != nil {
 		switch s := err.(type) {
+		case ApiResponseNextPage:
+			return s // This is not an error, just a signal to continue with the next page
 		case ApiNonTransientError:
 			log.Ctx(ctx).Trace().Msg("Non-transient error returned from API, stopping further attempts")
 			// Return the original error for later checking

--- a/pkg/wekafs/apiclient/apiendpoint.go
+++ b/pkg/wekafs/apiclient/apiendpoint.go
@@ -80,7 +80,7 @@ func (a *ApiClient) resetDefaultEndpoints(ctx context.Context) {
 func (a *ApiClient) fetchMountEndpoints(ctx context.Context) error {
 	log.Ctx(ctx).Trace().Msg("Fetching mount endpoints")
 	a.MountEndpoints = []string{}
-	nodes := &[]WekaNode{}
+	nodes := &WekaNodes{}
 	err := a.GetNodesByRole(ctx, NodeRoleBackend, nodes)
 	if err != nil {
 		return err
@@ -96,7 +96,7 @@ func (a *ApiClient) fetchMountEndpoints(ctx context.Context) error {
 // UpdateApiEndpoints fetches current management IP addresses of the cluster
 func (a *ApiClient) UpdateApiEndpoints(ctx context.Context) error {
 	logger := log.Ctx(ctx)
-	nodes := &[]WekaNode{}
+	nodes := &WekaNodes{}
 	err := a.GetNodesByRole(ctx, NodeRoleManagement, nodes)
 	if err != nil {
 		return err

--- a/pkg/wekafs/apiclient/apiobject.go
+++ b/pkg/wekafs/apiclient/apiobject.go
@@ -2,7 +2,6 @@ package apiclient
 
 import (
 	"encoding/json"
-	"github.com/google/uuid"
 )
 
 // ApiObject generic interface of API object of any type (FileSystem, Quota, etc.)
@@ -20,8 +19,16 @@ type ApiResponse struct {
 	Data           json.RawMessage `json:"data"` // Data, may be either object, dict or list
 	ErrorCodes     []string        `json:"data.exceptionClass,omitempty"`
 	Message        string          `json:"message,omitempty"`    // Optional, can have error message
-	NextToken      uuid.UUID       `json:"next_token,omitempty"` // For paginated objects
+	NextToken      string          `json:"next_token,omitempty"` // For paginated objects
 	HttpStatusCode int
+}
+
+func (a ApiResponse) SupportsPagination() bool {
+	return false
+}
+
+func (a ApiResponse) CombinePartialResponse(next ApiObjectResponse) error {
+	panic("not implemented")
 }
 
 // ApiObjectRequest interface that describes a request for an ApiObject CRUD operation
@@ -31,4 +38,9 @@ type ApiObjectRequest interface {
 	getRelatedObject() ApiObject   // returns the type of object that is being requested
 	getApiUrl(a *ApiClient) string // returns the full URL of the object consisting of base path and object UID
 	String() string                // returns a string representation of the object request
+}
+
+type ApiObjectResponse interface {
+	SupportsPagination() bool
+	CombinePartialResponse(next ApiObjectResponse) error // combines partial response with the current one
 }

--- a/pkg/wekafs/apiclient/cluster.go
+++ b/pkg/wekafs/apiclient/cluster.go
@@ -94,6 +94,14 @@ type LoginResponse struct {
 	RefreshToken string `json:"refresh_token,omitempty"`
 }
 
+func (lr *LoginResponse) CombinePartialResponse(next ApiObjectResponse) error {
+	panic("not implemented")
+}
+
+func (lr *LoginResponse) SupportsPagination() bool {
+	return false
+}
+
 type RefreshRequest struct {
 	RefreshToken string `json:"refresh_token,omitempty"`
 }
@@ -105,10 +113,27 @@ type RefreshResponse struct {
 	RefreshToken string `json:"refresh_token"`
 }
 
+func (rr *RefreshResponse) CombinePartialResponse(next ApiObjectResponse) error {
+	panic("not implemented")
+}
+
+func (rr *RefreshResponse) SupportsPagination() bool {
+	return false
+}
+
 type TokenExpiryResponse struct {
 	AccessTokenExpiry  int64 `json:"access_token_expiry"`
 	RefreshTokenExpiry int64 `json:"refresh_token_expiry"`
 }
+
+func (ter *TokenExpiryResponse) CombinePartialResponse(next ApiObjectResponse) error {
+	panic("not implemented")
+}
+
+func (ter *TokenExpiryResponse) SupportsPagination() bool {
+	return false
+}
+
 type Capacity struct {
 	TotalBytes         uint64 `json:"total_bytes"`
 	HotSpareBytes      uint64 `json:"hot_spare_bytes"`
@@ -124,6 +149,14 @@ type ClusterInfoResponse struct {
 	Capacity    Capacity  `json:"capacity,omitempty"`
 }
 
+func (cir *ClusterInfoResponse) CombinePartialResponse(next ApiObjectResponse) error {
+	panic("not implemented")
+}
+
+func (cir *ClusterInfoResponse) SupportsPagination() bool {
+	return false
+}
+
 type WhoamiResponse struct {
 	OrgId    int         `json:"org_id,omitempty"`
 	Username string      `json:"username,omitempty"`
@@ -131,6 +164,14 @@ type WhoamiResponse struct {
 	Uid      uuid.UUID   `json:"uid,omitempty"`
 	Role     ApiUserRole `json:"role,omitempty"`
 	OrgName  string      `json:"org_name,omitempty"`
+}
+
+func (war *WhoamiResponse) CombinePartialResponse(next ApiObjectResponse) error {
+	panic("not implemented")
+}
+
+func (war *WhoamiResponse) SupportsPagination() bool {
+	return false
 }
 
 type Container struct {
@@ -196,6 +237,18 @@ type Container struct {
 }
 
 type ContainersResponse []Container
+
+func (c *ContainersResponse) SupportsPagination() bool {
+	return true
+}
+
+func (c *ContainersResponse) CombinePartialResponse(next ApiObjectResponse) error {
+	if nextContainers, ok := next.(*ContainersResponse); ok {
+		*c = append(*c, *nextContainers...)
+		return nil
+	}
+	return fmt.Errorf("cannot combine response of type %T with ContainersResponse", next)
+}
 
 func (a *ApiClient) getContainers(ctx context.Context) (*ContainersResponse, error) {
 	a.containersLock.RLock()

--- a/pkg/wekafs/apiclient/errors.go
+++ b/pkg/wekafs/apiclient/errors.go
@@ -229,3 +229,15 @@ func (e transportError) Error() string {
 func (e transportError) getType() string {
 	return "transportError"
 }
+
+type ApiResponseNextPage struct {
+	NextPageToken string
+}
+
+func (a ApiResponseNextPage) Error() string {
+	return ""
+}
+
+func (a ApiResponseNextPage) getType() string {
+	return a.NextPageToken
+}

--- a/pkg/wekafs/apiclient/interfacegroup.go
+++ b/pkg/wekafs/apiclient/interfacegroup.go
@@ -29,6 +29,28 @@ type InterfaceGroup struct {
 	Status          string             `json:"status"`
 }
 
+type InterfaceGroups []*InterfaceGroup
+
+func (i *InterfaceGroups) SupportsPagination() bool {
+	return true
+}
+
+func (i *InterfaceGroups) CombinePartialResponse(next ApiObjectResponse) error {
+	if partialList, ok := next.(*InterfaceGroups); ok {
+		*i = append(*i, *partialList...)
+		return nil
+	}
+	return fmt.Errorf("invalid partial response")
+}
+
+func (i *InterfaceGroup) SupportsPagination() bool {
+	return false
+}
+
+func (i *InterfaceGroup) CombinePartialResponse(next ApiObjectResponse) error {
+	panic("not implemented")
+}
+
 func (i *InterfaceGroup) String() string {
 	return fmt.Sprintln("InterfaceGroup ", i.Name, "Uid:", i.Uid.String(), "type:", i.Type, "status:", i.Status)
 }
@@ -108,7 +130,7 @@ func (i *InterfaceGroup) GetRandomIpAddress(ctx context.Context) (string, error)
 	return ip, nil
 }
 
-func (a *ApiClient) GetInterfaceGroups(ctx context.Context, interfaceGroups *[]InterfaceGroup) error {
+func (a *ApiClient) GetInterfaceGroups(ctx context.Context, interfaceGroups *InterfaceGroups) error {
 	ig := &InterfaceGroup{}
 
 	err := a.Get(ctx, ig.GetBasePath(a), nil, interfaceGroups)
@@ -118,8 +140,8 @@ func (a *ApiClient) GetInterfaceGroups(ctx context.Context, interfaceGroups *[]I
 	return nil
 }
 
-func (a *ApiClient) GetInterfaceGroupsByType(ctx context.Context, groupType InterfaceGroupType, interfaceGroups *[]InterfaceGroup) error {
-	res := &[]InterfaceGroup{}
+func (a *ApiClient) GetInterfaceGroupsByType(ctx context.Context, groupType InterfaceGroupType, interfaceGroups *InterfaceGroups) error {
+	res := &InterfaceGroups{}
 	err := a.GetInterfaceGroups(ctx, res)
 	if err != nil {
 		return nil
@@ -144,7 +166,7 @@ func (a *ApiClient) GetInterfaceGroupByUid(ctx context.Context, uid uuid.UUID, i
 }
 
 func (a *ApiClient) fetchNfsInterfaceGroup(ctx context.Context, name string) error {
-	igs := &[]InterfaceGroup{}
+	igs := &InterfaceGroups{}
 	err := a.GetInterfaceGroupsByType(ctx, InterfaceGroupTypeNFS, igs)
 	if err != nil {
 		return errors.Join(errors.New("failed to fetch nfs interface groups"), err)
@@ -164,7 +186,7 @@ func (a *ApiClient) fetchNfsInterfaceGroup(ctx context.Context, name string) err
 				}
 				return errors.New("no IP addresses found for nfs interface group \"" + name + "\"")
 			}
-			a.NfsInterfaceGroups[igname] = &ig
+			a.NfsInterfaceGroups[igname] = ig
 			return nil
 		}
 	}

--- a/pkg/wekafs/apiclient/kms.go
+++ b/pkg/wekafs/apiclient/kms.go
@@ -21,6 +21,14 @@ type Kms struct {
 	Params  KmsParams `json:"params"`
 }
 
+func (k *Kms) SupportsPagination() bool {
+	return false
+}
+
+func (k *Kms) CombinePartialResponse(next ApiObjectResponse) error {
+	panic("not implemented")
+}
+
 type KmsParams struct {
 	MasterKeyName string        `json:"master_key_name"`
 	BaseUrl       string        `json:"base_url"`

--- a/pkg/wekafs/apiclient/nfs.go
+++ b/pkg/wekafs/apiclient/nfs.go
@@ -87,6 +87,14 @@ type NfsPermission struct {
 	EnableAuthTypes   []NfsAuthType           `json:"enable_auth_types,omitempty" url:"-"`
 }
 
+func (n *NfsPermission) SupportsPagination() bool {
+	return false
+}
+
+func (n *NfsPermission) CombinePartialResponse(next ApiObjectResponse) error {
+	panic("not implemented")
+}
+
 func (n *NfsPermission) GetType() string {
 	return "nfsPermission"
 }
@@ -134,12 +142,25 @@ func (n *NfsPermission) IsEligibleForCsi() bool {
 		n.SquashMode == NfsPermissionSquashModeNone
 }
 
-func (a *ApiClient) FindNfsPermissionsByFilter(ctx context.Context, query *NfsPermission, resultSet *[]NfsPermission) error {
+type NfsPermissions []NfsPermission
+
+func (n *NfsPermissions) SupportsPagination() bool {
+	return true
+}
+func (n *NfsPermissions) CombinePartialResponse(next ApiObjectResponse) error {
+	if partialList, ok := next.(*NfsPermissions); ok {
+		*n = append(*n, *partialList...)
+		return nil
+	}
+	return fmt.Errorf("invalid partial response")
+}
+
+func (a *ApiClient) FindNfsPermissionsByFilter(ctx context.Context, query *NfsPermission, resultSet *NfsPermissions) error {
 	op := "FindNfsPermissionsByFilter"
 	ctx, span := otel.Tracer(TracerName).Start(ctx, op)
 	defer span.End()
 	ctx = log.With().Str("trace_id", span.SpanContext().TraceID().String()).Str("span_id", span.SpanContext().SpanID().String()).Str("op", op).Logger().WithContext(ctx)
-	ret := &[]NfsPermission{}
+	ret := &NfsPermissions{}
 	q, _ := qs.Values(query)
 	err := a.Get(ctx, query.GetBasePath(a), q, ret)
 	if err != nil {
@@ -153,12 +174,12 @@ func (a *ApiClient) FindNfsPermissionsByFilter(ctx context.Context, query *NfsPe
 	return nil
 }
 
-func (a *ApiClient) FindNfsPermissionsByFilesystem(ctx context.Context, fsName string, resultSet *[]NfsPermission) error {
+func (a *ApiClient) FindNfsPermissionsByFilesystem(ctx context.Context, fsName string, resultSet *NfsPermissions) error {
 	op := "FindNfsPermissionsByFilter"
 	ctx, span := otel.Tracer(TracerName).Start(ctx, op)
 	defer span.End()
 	ctx = log.With().Str("trace_id", span.SpanContext().TraceID().String()).Str("span_id", span.SpanContext().SpanID().String()).Str("op", op).Logger().WithContext(ctx)
-	ret := &[]NfsPermission{}
+	ret := &NfsPermissions{}
 	query := &NfsPermission{Filesystem: fsName}
 	q, _ := qs.Values(query)
 	err := a.Get(ctx, query.GetBasePath(a), q, ret)
@@ -175,7 +196,7 @@ func (a *ApiClient) FindNfsPermissionsByFilesystem(ctx context.Context, fsName s
 
 // GetNfsPermissionByFilter expected to return exactly one result of FindNfsPermissionsByFilter (error)
 func (a *ApiClient) GetNfsPermissionByFilter(ctx context.Context, query *NfsPermission) (*NfsPermission, error) {
-	rs := &[]NfsPermission{}
+	rs := &NfsPermissions{}
 	err := a.FindNfsPermissionsByFilter(ctx, query, rs)
 	if err != nil {
 		return &NfsPermission{}, err
@@ -190,7 +211,7 @@ func (a *ApiClient) GetNfsPermissionByFilter(ctx context.Context, query *NfsPerm
 	return result, nil
 }
 
-func (a *ApiClient) GetNfsPermissionsByFilesystemName(ctx context.Context, fsName string, permissions *[]NfsPermission) error {
+func (a *ApiClient) GetNfsPermissionsByFilesystemName(ctx context.Context, fsName string, permissions *NfsPermissions) error {
 	query := &NfsPermission{Path: fsName}
 	return a.FindNfsPermissionsByFilter(ctx, query, permissions)
 }
@@ -344,6 +365,14 @@ type NfsClientGroup struct {
 	Name  string               `json:"name,omitempty" url:"name,omitempty"`
 }
 
+func (g *NfsClientGroup) SupportsPagination() bool {
+	return false
+}
+
+func (g *NfsClientGroup) CombinePartialResponse(next ApiObjectResponse) error {
+	panic("not implemented")
+}
+
 func (g *NfsClientGroup) GetType() string {
 	return "clientGroup"
 }
@@ -373,7 +402,7 @@ func (g *NfsClientGroup) String() string {
 	return fmt.Sprintln("NfsClientGroup name:", g.Name)
 }
 
-func (a *ApiClient) GetNfsClientGroups(ctx context.Context, clientGroups *[]NfsClientGroup) error {
+func (a *ApiClient) GetNfsClientGroups(ctx context.Context, clientGroups *NfsClientGroups) error {
 	cg := &NfsClientGroup{}
 
 	err := a.Get(ctx, cg.GetBasePath(a), nil, clientGroups)
@@ -383,14 +412,29 @@ func (a *ApiClient) GetNfsClientGroups(ctx context.Context, clientGroups *[]NfsC
 	return nil
 }
 
-func (a *ApiClient) FindNfsClientGroupsByFilter(ctx context.Context, query *NfsClientGroup, resultSet *[]NfsClientGroup) error {
+type NfsClientGroups []*NfsClientGroup
+
+func (n *NfsClientGroups) SupportsPagination() bool {
+	return true
+}
+
+func (n *NfsClientGroups) CombinePartialResponse(next ApiObjectResponse) error {
+	if partialList, ok := next.(*NfsClientGroups); ok {
+		// this is a list, so we just append the data
+		*n = append(*n, *partialList...)
+		return nil
+	}
+	return fmt.Errorf("invalid partial response")
+}
+
+func (a *ApiClient) FindNfsClientGroupsByFilter(ctx context.Context, query *NfsClientGroup, resultSet *NfsClientGroups) error {
 	op := "FindNfsClientGroupsByFilter"
 	ctx, span := otel.Tracer(TracerName).Start(ctx, op)
 	defer span.End()
 	ctx = log.With().Str("trace_id", span.SpanContext().TraceID().String()).Str("span_id", span.SpanContext().SpanID().String()).Str("op", op).Logger().WithContext(ctx)
 	logger := log.Ctx(ctx)
 	logger.Trace().Str("client_group_query", query.String()).Msg("Finding client groups by filter")
-	ret := &[]NfsClientGroup{}
+	ret := &NfsClientGroups{}
 	q, _ := qs.Values(query)
 	err := a.Get(ctx, query.GetBasePath(a), q, ret)
 	if err != nil {
@@ -411,7 +455,7 @@ func (a *ApiClient) GetNfsClientGroupByFilter(ctx context.Context, query *NfsCli
 	defer span.End()
 	ctx = log.With().Str("trace_id", span.SpanContext().TraceID().String()).Str("span_id", span.SpanContext().SpanID().String()).Str("op", op).Logger().WithContext(ctx)
 	logger := log.Ctx(ctx)
-	rs := &[]NfsClientGroup{}
+	rs := &NfsClientGroups{}
 	err := a.FindNfsClientGroupsByFilter(ctx, query, rs)
 	logger.Trace().Str("client_group", query.String()).Msg("Getting client group by filter")
 	if err != nil {
@@ -423,7 +467,7 @@ func (a *ApiClient) GetNfsClientGroupByFilter(ctx context.Context, query *NfsCli
 	if len(*rs) > 1 {
 		return &NfsClientGroup{}, MultipleObjectsFoundError
 	}
-	result := &(*rs)[0]
+	result := (*rs)[0]
 	return result, nil
 }
 
@@ -582,6 +626,14 @@ type NfsClientGroupRule struct {
 	Uid               uuid.UUID              `json:"uid,omitempty" url:"-"`
 	Rule              string                 `json:"rule,omitempty" url:"-"`
 	Id                string                 `json:"id,omitempty" url:"-"`
+}
+
+func (r *NfsClientGroupRule) SupportsPagination() bool {
+	return false
+}
+
+func (r *NfsClientGroupRule) CombinePartialResponse(next ApiObjectResponse) error {
+	panic("not implemented")
 }
 
 func (r *NfsClientGroupRule) GetType() string {

--- a/pkg/wekafs/apiclient/nfs_test.go
+++ b/pkg/wekafs/apiclient/nfs_test.go
@@ -11,7 +11,7 @@ import (
 func TestFindNfsPermissionsByFilesystemName(t *testing.T) {
 	apiClient := GetApiClientForTest(t)
 
-	var permissions []NfsPermission
+	var permissions NfsPermissions
 	err := apiClient.FindNfsPermissionsByFilesystem(context.Background(), "snapvolFilesystem", &permissions)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, permissions)
@@ -31,7 +31,7 @@ func TestFindNfsPermissionsByFilesystemName(t *testing.T) {
 func TestNfsClientGroup(t *testing.T) {
 	apiClient := GetApiClientForTest(t)
 
-	var clientGroups []NfsClientGroup
+	clientGroups := &NfsClientGroups{}
 	var cg = &NfsClientGroup{
 		Uid: uuid.New(),
 	}
@@ -61,7 +61,7 @@ func TestNfsClientGroup(t *testing.T) {
 	assert.Empty(t, cg.Rules)
 
 	// Test GetGroups
-	err = apiClient.GetNfsClientGroups(context.Background(), &clientGroups)
+	err = apiClient.GetNfsClientGroups(context.Background(), clientGroups)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, clientGroups)
 
@@ -83,9 +83,9 @@ func TestNfsClientGroup(t *testing.T) {
 	r := &NfsClientGroupDeleteRequest{Uid: cg.Uid}
 	err = apiClient.DeleteNfsClientGroup(context.Background(), r)
 	assert.NoError(t, err)
-	err = apiClient.GetNfsClientGroups(context.Background(), &clientGroups)
+	err = apiClient.GetNfsClientGroups(context.Background(), clientGroups)
 	assert.NoError(t, err)
-	for _, r := range clientGroups {
+	for _, r := range *clientGroups {
 		if r.Uid == cg.Uid {
 			t.Errorf("Failed to delete group")
 		}
@@ -152,7 +152,7 @@ func TestNfsEnsureNfsPermissions(t *testing.T) {
 func TestInterfaceGroup(t *testing.T) {
 	apiClient := GetApiClientForTest(t)
 
-	var igs []InterfaceGroup
+	igs := &InterfaceGroups{}
 	var ig = &InterfaceGroup{
 		Uid: uuid.New(),
 	}
@@ -175,11 +175,11 @@ func TestInterfaceGroup(t *testing.T) {
 
 	// Test Create
 	// Test GetGroups
-	err := apiClient.GetInterfaceGroups(context.Background(), &igs)
+	err := apiClient.GetInterfaceGroups(context.Background(), igs)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, igs)
-	if len(igs) > 0 {
-		assert.NotEmpty(t, igs[0].Ips)
+	if len(*igs) > 0 {
+		assert.NotEmpty(t, (*igs)[0].Ips)
 	}
 }
 

--- a/pkg/wekafs/apiclient/quota.go
+++ b/pkg/wekafs/apiclient/quota.go
@@ -38,6 +38,14 @@ type Quota struct {
 	Status         string    `json:"status,omitempty"`
 }
 
+func (q *Quota) SupportsPagination() bool {
+	return false
+}
+
+func (q *Quota) CombinePartialResponse(next ApiObjectResponse) error {
+	panic("not implemented")
+}
+
 func (q *Quota) String() string {
 	return fmt.Sprintln("Quota(fsUid:", q.FilesystemUid, "inodeId:", q.InodeId, "type:", q.GetQuotaType(), "capacity:", q.GetCapacityLimit(), "status:", q.Status, ")")
 }
@@ -86,6 +94,20 @@ func (q *Quota) GetCapacityLimit() uint64 {
 		return q.HardLimitBytes
 	}
 	return q.SoftLimitBytes
+}
+
+type Quotas []*Quota
+
+func (q *Quotas) SupportsPagination() bool {
+	return true
+}
+func (q *Quotas) CombinePartialResponse(next ApiObjectResponse) error {
+	// this is a list, so we just append the data
+	if partialList, ok := next.(*Quotas); ok {
+		*q = append(*q, *partialList...)
+		return nil
+	}
+	return fmt.Errorf("invalid partial response")
 }
 
 type QuotaCreateRequest struct {
@@ -267,11 +289,11 @@ func (a *ApiClient) WaitForQuotaActive(ctx context.Context, q *Quota) error {
 	return nil
 }
 
-func (a *ApiClient) FindQuotaByFilter(ctx context.Context, query *Quota, resultSet *[]Quota) error {
+func (a *ApiClient) FindQuotaByFilter(ctx context.Context, query *Quota, resultSet *Quotas) error {
 	if query.FilesystemUid == uuid.Nil {
 		return RequestMissingParams
 	}
-	ret := &[]Quota{}
+	ret := &Quotas{}
 	err := a.Get(ctx, query.GetBasePath(a), nil, ret)
 	if err != nil {
 		return err
@@ -324,7 +346,7 @@ func (a *ApiClient) GetQuotaByFileSystemAndInode(ctx context.Context, fs *FileSy
 }
 
 func (a *ApiClient) GetQuotaByFilter(ctx context.Context, query *Quota) (*Quota, error) {
-	rs := &[]Quota{}
+	rs := &Quotas{}
 	err := a.FindQuotaByFilter(ctx, query, rs)
 	if err != nil {
 		return nil, err
@@ -335,7 +357,7 @@ func (a *ApiClient) GetQuotaByFilter(ctx context.Context, query *Quota) (*Quota,
 	if len(*rs) > 1 {
 		return nil, MultipleObjectsFoundError
 	}
-	result := &(*rs)[0]
+	result := (*rs)[0]
 	return result, nil
 }
 

--- a/pkg/wekafs/apiclient/requests.go
+++ b/pkg/wekafs/apiclient/requests.go
@@ -17,6 +17,7 @@ import (
 
 // do Makes a basic API call to the client, returns an *ApiResponse that includes raw data, error message etc.
 func (a *ApiClient) do(ctx context.Context, Method string, Path string, Payload *[]byte, Query url.Values) (*ApiResponse, apiError) {
+	ctx = context.WithValue(ctx, "startTime", time.Now())
 	//construct URL path
 	if len(a.Credentials.Endpoints) < 1 {
 		return &ApiResponse{}, &ApiNoEndpointsError{
@@ -196,13 +197,15 @@ func (a *ApiClient) do(ctx context.Context, Method string, Path string, Payload 
 }
 
 // request wraps do with retries and some more error handling
-func (a *ApiClient) request(ctx context.Context, Method string, Path string, Payload *[]byte, Query url.Values, v interface{}) apiError {
-	op := "ApiClientRequest"
-	ctx, span := otel.Tracer(TracerName).Start(ctx, op)
-	defer span.End()
-	ctx = log.With().Str("span_id", span.SpanContext().SpanID().String()).Logger().WithContext(ctx)
+func (a *ApiClient) request(ctx context.Context, Method string, Path string, Payload *[]byte, Query url.Values, v ApiObjectResponse) apiError {
+	//op := "ApiClientRequest"
+	//ctx, span := otel.Tracer(TracerName).Start(ctx, op)
+	//defer span.End()
+	//ctx = log.With().Str("trace_id", span.SpanContext().TraceID().String()).Str("span_id", span.SpanContext().SpanID().String()).Str("op", op).Logger().WithContext(ctx)
 	logger := log.Ctx(ctx)
 	f := func() apiError {
+
+		// perform the request here
 		rawResponse, reqErr := a.do(ctx, Method, Path, Payload, Query)
 		if a.handleTransientErrors(ctx, reqErr) != nil { // transient network errors
 			a.rotateEndpoint(ctx)
@@ -231,6 +234,16 @@ func (a *ApiClient) request(ctx context.Context, Method string, Path string, Pay
 		}
 		switch s {
 		case http.StatusOK:
+			if rawResponse.NextToken != "" {
+				_, ok := v.(ApiObjectResponse)
+				if ok {
+					if v.SupportsPagination() {
+						if rawResponse.NextToken != "" {
+							return ApiResponseNextPage{NextPageToken: rawResponse.NextToken}
+						}
+					}
+				}
+			}
 			return nil
 		case http.StatusUnauthorized:
 			logger.Warn().Msg("Got Authorization failure on request, trying to re-login")
@@ -251,34 +264,75 @@ func (a *ApiClient) request(ctx context.Context, Method string, Path string, Pay
 }
 
 // Request makes sure that client is logged in and has a non-expired token
-func (a *ApiClient) Request(ctx context.Context, Method string, Path string, Payload *[]byte, Query url.Values, Response interface{}) error {
+func (a *ApiClient) Request(ctx context.Context, Method string, Path string, Payload *[]byte, Query url.Values, Response ApiObjectResponse) error {
+	ctx, span := otel.Tracer(TracerName).Start(ctx, "ApiClientRequest")
+	defer span.End()
+	logger := log.Ctx(ctx)
+
 	if err := a.Init(ctx); err != nil {
-		log.Ctx(ctx).Error().Err(err).Msg("Failed to re-authenticate on repeating request")
+		logger.Error().Err(err).Msg("Failed to re-authenticate on repeating request")
 		return err
 	}
-	err := a.request(ctx, Method, Path, Payload, Query, Response)
-	if err != nil {
-		return err
+
+	rt := reflect.TypeOf(Response)
+	newObj := reflect.New(rt.Elem()).Interface().(ApiObjectResponse)
+
+	nextPageNeeded := true
+	pagesFetched := 0
+	for nextPageNeeded {
+		pagesFetched++
+		err := a.request(ctx, Method, Path, Payload, Query, Response)
+		if err != nil {
+			switch e := err.(type) {
+			case ApiResponseNextPage:
+				if Response.SupportsPagination() {
+					err2 := newObj.CombinePartialResponse(Response)
+					if err2 != nil {
+						log.Ctx(ctx).Error().Err(err2).Msg("Failed to combine partial response")
+						return err2
+					}
+					Response = newObj
+				} else {
+					break
+				}
+
+				if e.NextPageToken != "" {
+					Query.Set("next_token", e.NextPageToken)
+					nextPageNeeded = true
+
+				} else {
+					nextPageNeeded = false
+				}
+			default:
+				return err
+			}
+		} else {
+			nextPageNeeded = false
+		}
+		if pagesFetched > 1 {
+			logger.Trace().Int("pages_fetched", pagesFetched).Msg("Fetched more than one page response")
+		}
+
 	}
 	return nil
 }
 
 // Get is shortcut for Request("GET" ...)
-func (a *ApiClient) Get(ctx context.Context, Path string, Query url.Values, Response interface{}) error {
+func (a *ApiClient) Get(ctx context.Context, Path string, Query url.Values, Response ApiObjectResponse) error {
 	return a.Request(ctx, "GET", Path, nil, Query, Response)
 }
 
 // Post is shortcut for Request("POST" ...)
-func (a *ApiClient) Post(ctx context.Context, Path string, Payload *[]byte, Query url.Values, Response interface{}) error {
+func (a *ApiClient) Post(ctx context.Context, Path string, Payload *[]byte, Query url.Values, Response ApiObjectResponse) error {
 	return a.Request(ctx, "POST", Path, Payload, Query, Response)
 }
 
 // Put is shortcut for Request("PUT" ...)
-func (a *ApiClient) Put(ctx context.Context, Path string, Payload *[]byte, Query url.Values, Response interface{}) error {
+func (a *ApiClient) Put(ctx context.Context, Path string, Payload *[]byte, Query url.Values, Response ApiObjectResponse) error {
 	return a.Request(ctx, "PUT", Path, Payload, Query, Response)
 }
 
 // Delete is shortcut for Request("DELETE" ...)
-func (a *ApiClient) Delete(ctx context.Context, Path string, Payload *[]byte, Query url.Values, Response interface{}) error {
+func (a *ApiClient) Delete(ctx context.Context, Path string, Payload *[]byte, Query url.Values, Response ApiObjectResponse) error {
 	return a.Request(ctx, "DELETE", Path, Payload, Query, Response)
 }

--- a/pkg/wekafs/apiclient/resolvepath.go
+++ b/pkg/wekafs/apiclient/resolvepath.go
@@ -18,6 +18,14 @@ type FilesystemResolvePath struct {
 	Path    string    `json:"-" url:"path,omitempty"`
 }
 
+func (fsr *FilesystemResolvePath) SupportsPagination() bool {
+	return false
+}
+
+func (fsr *FilesystemResolvePath) CombinePartialResponse(next ApiObjectResponse) error {
+	panic("not implemented")
+}
+
 func (fsr *FilesystemResolvePath) GetType() string {
 	return "resolvePath"
 }

--- a/pkg/wekafs/apiclient/snapshot.go
+++ b/pkg/wekafs/apiclient/snapshot.go
@@ -31,17 +31,38 @@ type Snapshot struct {
 	Id            string    `json:"id" url:"-"`
 }
 
+func (snap *Snapshot) SupportsPagination() bool {
+	return false
+}
+
+func (snap *Snapshot) CombinePartialResponse(next ApiObjectResponse) error {
+	panic("not implemented")
+}
+
 func (snap *Snapshot) String() string {
 	return fmt.Sprintln("Snapshot(snapUid:", snap.Uid, "name:", snap.Name, "writable:", snap.IsWritable, "locator:", snap.Locator, "created on:", snap.CreationTime)
 }
 
+type Snapshots []*Snapshot
+
+func (s *Snapshots) SupportsPagination() bool {
+	return true
+}
+func (s *Snapshots) CombinePartialResponse(next ApiObjectResponse) error {
+	if nextSnap, ok := next.(*Snapshots); ok {
+		*s = append(*s, *nextSnap...)
+		return nil
+	}
+	return fmt.Errorf("invalid partial response type: %T", next)
+}
+
 // FindSnapshotsByFilter returns result set of 0-many objects matching filter
-func (a *ApiClient) FindSnapshotsByFilter(ctx context.Context, query *Snapshot, resultSet *[]Snapshot) error {
+func (a *ApiClient) FindSnapshotsByFilter(ctx context.Context, query *Snapshot, resultSet *Snapshots) error {
 	op := "FindSnapshotsByFilter"
 	ctx, span := otel.Tracer(TracerName).Start(ctx, op)
 	defer span.End()
 	ctx = log.With().Str("trace_id", span.SpanContext().TraceID().String()).Str("span_id", span.SpanContext().SpanID().String()).Str("op", op).Logger().WithContext(ctx)
-	ret := &[]Snapshot{}
+	ret := &Snapshots{}
 	q, _ := qs.Values(query)
 	err := a.Get(ctx, query.GetBasePath(a), q, ret)
 	if err != nil {
@@ -55,7 +76,7 @@ func (a *ApiClient) FindSnapshotsByFilter(ctx context.Context, query *Snapshot, 
 	return nil
 }
 
-func (a *ApiClient) FindSnapshotsByFilesystem(ctx context.Context, query *FileSystem, resultSet *[]Snapshot) error {
+func (a *ApiClient) FindSnapshotsByFilesystem(ctx context.Context, query *FileSystem, resultSet *Snapshots) error {
 	if query == nil || query.Uid == uuid.Nil {
 		return errors.New("cannot search for snapshots without explicit filesystem Uid")
 	}
@@ -72,7 +93,7 @@ func (a *ApiClient) GetSnapshotByFilter(ctx context.Context, query *Snapshot) (*
 	defer span.End()
 	ctx = log.With().Str("trace_id", span.SpanContext().TraceID().String()).Str("span_id", span.SpanContext().SpanID().String()).Str("op", op).Logger().WithContext(ctx)
 
-	rs := &[]Snapshot{}
+	rs := &Snapshots{}
 	err := a.FindSnapshotsByFilter(ctx, query, rs)
 	if err != nil {
 		return &Snapshot{}, err
@@ -83,7 +104,7 @@ func (a *ApiClient) GetSnapshotByFilter(ctx context.Context, query *Snapshot) (*
 	if len(*rs) > 1 {
 		return &Snapshot{}, MultipleObjectsFoundError
 	}
-	result := &(*rs)[0]
+	result := (*rs)[0]
 	return result, nil
 }
 

--- a/pkg/wekafs/volume.go
+++ b/pkg/wekafs/volume.go
@@ -299,14 +299,14 @@ func (v *Volume) isAllowedForDeletion(ctx context.Context) bool {
 }
 
 // getUnderlyingSnapshots intended to return list of Weka snapshots that exist for filesystem
-func (v *Volume) getUnderlyingSnapshots(ctx context.Context) (*[]apiclient.Snapshot, error) {
+func (v *Volume) getUnderlyingSnapshots(ctx context.Context) (*apiclient.Snapshots, error) {
 	op := "getUnderlyingSnapshots"
 	ctx, span := otel.Tracer(TracerName).Start(ctx, op)
 	defer span.End()
 	ctx = log.With().Str("trace_id", span.SpanContext().TraceID().String()).Str("span_id", span.SpanContext().SpanID().String()).Str("op", op).Logger().WithContext(ctx)
 	logger := log.Ctx(ctx).With().Str("volume_id", v.GetId()).Str("filesystem", v.FilesystemName).Logger()
 
-	snapshots := &[]apiclient.Snapshot{}
+	snapshots := &apiclient.Snapshots{}
 	if v.apiClient == nil {
 		return nil, errors.New("cannot check for underlying snaphots as volume is not bound to API")
 	}


### PR DESCRIPTION
### TL;DR

Refactored the API client to improve pagination support, endpoint management, and added caching for filesystem objects.

### What changed?

- Restructured `ApiClient` to use a dedicated `ApiEndPoints` type for better endpoint management
- Added pagination support for API responses with a new `ApiObjectResponse` interface
- Implemented filesystem caching to reduce redundant API calls
- Added metrics collection for API requests
- Created a new `ApiClientOptions` struct for more flexible client initialization
- Improved error handling for API requests, including support for paginated responses
- Added support for performance statistics on filesystems and quotas
- Extracted `ApiStore` into its own file for better code organization

### How to test?

1. Verify that API clients can be created with the new `ApiClientOptions` structure
2. Test pagination by retrieving large result sets from the API
3. Confirm that filesystem caching works by making repeated calls to `CachedGetFileSystemByName`
4. Check that metrics are being properly collected and exposed
5. Verify that endpoint rotation works correctly with the new `ApiEndPoints` structure

### Why make this change?

This refactoring improves the API client's performance and reliability by:
- Supporting pagination for large result sets to prevent timeouts
- Adding caching to reduce API load for frequently accessed objects
- Providing better metrics for monitoring API performance
- Improving endpoint management for better fault tolerance
- Making the code more maintainable with clearer separation of concerns