### PR TITLE
feat(CSI-361): support prometheus metrics for ControllerServer and NodeServer

### DIFF
--- a/pkg/wekafs/metrics.go
+++ b/pkg/wekafs/metrics.go
@@ -1,0 +1,473 @@
+package wekafs
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"slices"
+)
+
+var (
+	CsiCommonLabels                             = []string{"csi_driver_name"}
+	CsiControllerConcurrencyMetricsLabels       = []string{"status"}
+	CsiControllerVolumeOperationMetricsLabels   = []string{"status", "backing_type"}
+	CsiControllerSnapshotOperationMetricsLabels = []string{"status"}
+	CsiNodeConcurrencyMetricsLabels             = []string{"status"}
+	CsiNodeVolumeOperationMetricsLabels         = []string{"status"}
+)
+
+const MetricsPrefix = "weka_csi"
+
+type ControllerOperationMetrics struct {
+	CreateVolumeCounter       *prometheus.CounterVec
+	CreateVolumeDuration      *prometheus.HistogramVec
+	CreateVolumeTotalCapacity *prometheus.CounterVec
+	DeleteVolumeCounter       *prometheus.CounterVec
+	DeleteVolumeDuration      *prometheus.HistogramVec
+	DeleteVolumeTotalCapacity *prometheus.CounterVec
+	ExpandVolumeCounter       *prometheus.CounterVec
+	ExpandVolumeDuration      *prometheus.HistogramVec
+	ExpandVolumeTotalCapacity *prometheus.CounterVec
+	CreateSnapshotCounter     *prometheus.CounterVec
+	CreateSnapshotDuration    *prometheus.HistogramVec
+	DeleteSnapshotCounter     *prometheus.CounterVec
+	DeleteSnapshotDuration    *prometheus.HistogramVec
+}
+
+func (c *ControllerOperationMetrics) Init() {
+	// Initialize the metrics by registering them with Prometheus
+
+	initMetrics([]prometheus.Collector{
+		c.CreateVolumeCounter,
+		c.CreateVolumeDuration,
+		c.CreateVolumeTotalCapacity,
+		c.DeleteVolumeCounter,
+		c.DeleteVolumeDuration,
+		c.DeleteVolumeTotalCapacity,
+		c.ExpandVolumeCounter,
+		c.ExpandVolumeDuration,
+		c.ExpandVolumeTotalCapacity,
+		c.CreateSnapshotCounter,
+		c.CreateSnapshotDuration,
+		c.DeleteSnapshotCounter,
+		c.DeleteSnapshotDuration,
+	})
+}
+
+func NewControllerOperationMetrics(volumeLabels, snapshotLabels []string) *ControllerOperationMetrics {
+	return &ControllerOperationMetrics{
+		CreateVolumeCounter: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: MetricsPrefix,
+				Subsystem: "controller",
+				Name:      "create_volume_total",
+				Help:      "Total number of ControllerCreateVolume calls",
+			},
+			slices.Concat(CsiCommonLabels, volumeLabels),
+		),
+		CreateVolumeDuration: prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Namespace: MetricsPrefix,
+				Subsystem: "controller",
+				Name:      "create_volume_duration_seconds",
+				Help:      "Duration of ControllerCreateVolume calls in seconds",
+			},
+			slices.Concat(CsiCommonLabels, volumeLabels),
+		),
+		CreateVolumeTotalCapacity: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: MetricsPrefix,
+				Subsystem: "controller",
+				Name:      "create_volume_total_capacity_bytes",
+				Help:      "Total capacity of volumes created by ControllerCreateVolume in bytes",
+			},
+			slices.Concat(CsiCommonLabels, volumeLabels),
+		),
+		DeleteVolumeCounter: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: MetricsPrefix,
+				Subsystem: "controller",
+				Name:      "delete_volume_total",
+				Help:      "Total number of ControllerDeleteVolume calls",
+			},
+			slices.Concat(CsiCommonLabels, volumeLabels),
+		),
+		DeleteVolumeDuration: prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Namespace: MetricsPrefix,
+				Subsystem: "controller",
+				Name:      "delete_volume_duration_seconds",
+				Help:      "Duration of ControllerDeleteVolume calls in seconds",
+			},
+			slices.Concat(CsiCommonLabels, volumeLabels),
+		),
+		DeleteVolumeTotalCapacity: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: MetricsPrefix,
+				Subsystem: "controller",
+				Name:      "delete_volume_total_capacity_bytes",
+				Help:      "Total capacity of volumes deleted by ControllerDeleteVolume in bytes",
+			},
+			slices.Concat(CsiCommonLabels, volumeLabels),
+		),
+		ExpandVolumeCounter: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: MetricsPrefix,
+				Subsystem: "controller",
+				Name:      "expand_volume_total",
+				Help:      "Total number of ControllerExpandVolume calls",
+			},
+			slices.Concat(CsiCommonLabels, volumeLabels),
+		),
+		ExpandVolumeDuration: prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Namespace: MetricsPrefix,
+				Subsystem: "controller",
+				Name:      "expand_volume_duration_seconds",
+				Help:      "Duration of ControllerExpandVolume calls in seconds",
+			},
+			slices.Concat(CsiCommonLabels, volumeLabels),
+		),
+		ExpandVolumeTotalCapacity: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: MetricsPrefix,
+				Subsystem: "controller",
+				Name:      "expand_volume_total_capacity_bytes",
+				Help:      "Total capacity of volumes expanded by ControllerExpandVolume in bytes",
+			},
+			slices.Concat(CsiCommonLabels, volumeLabels),
+		),
+		CreateSnapshotCounter: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: MetricsPrefix,
+				Subsystem: "controller",
+				Name:      "create_snapshot_total",
+				Help:      "Total number of ControllerCreateSnapshot calls",
+			},
+			slices.Concat(CsiCommonLabels, snapshotLabels),
+		),
+		CreateSnapshotDuration: prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Namespace: MetricsPrefix,
+				Subsystem: "controller",
+				Name:      "create_snapshot_duration_seconds",
+				Help:      "Duration of ControllerCreateSnapshot calls in seconds",
+			},
+			slices.Concat(CsiCommonLabels, snapshotLabels),
+		),
+		DeleteSnapshotCounter: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: MetricsPrefix,
+				Subsystem: "controller",
+				Name:      "delete_snapshot_total",
+				Help:      "Total number of ControllerDeleteSnapshot calls",
+			},
+			slices.Concat(CsiCommonLabels, snapshotLabels),
+		),
+		DeleteSnapshotDuration: prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Namespace: MetricsPrefix,
+				Subsystem: "controller",
+				Name:      "delete_snapshot_duration_seconds",
+				Help:      "Duration of ControllerDeleteSnapshot calls in seconds",
+			},
+			slices.Concat(CsiCommonLabels, snapshotLabels),
+		),
+	}
+}
+
+type ControllerConcurrencyMetrics struct {
+	CreateVolume               *prometheus.GaugeVec
+	DeleteVolume               *prometheus.GaugeVec
+	ExpandVolume               *prometheus.GaugeVec
+	CreateSnapshot             *prometheus.GaugeVec
+	DeleteSnapshot             *prometheus.GaugeVec
+	CreateVolumeWaitDuration   *prometheus.HistogramVec
+	DeleteVolumeWaitDuration   *prometheus.HistogramVec
+	ExpandVolumeWaitDuration   *prometheus.HistogramVec
+	CreateSnapshotWaitDuration *prometheus.HistogramVec
+	DeleteSnapshotWaitDuration *prometheus.HistogramVec
+}
+
+func NewControllerConcurrencyMetrics(labels []string) *ControllerConcurrencyMetrics {
+	return &ControllerConcurrencyMetrics{
+		CreateVolume: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: MetricsPrefix,
+				Subsystem: "controller",
+				Name:      "concurrency_create_volume",
+				Help:      "Current number of concurrent ControllerCreateVolume operations",
+			},
+			slices.Concat(CsiCommonLabels, labels),
+		),
+		DeleteVolume: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: MetricsPrefix,
+				Subsystem: "controller",
+				Name:      "concurrency_delete_volume",
+				Help:      "Current number of concurrent ControllerDeleteVolume operations",
+			},
+			slices.Concat(CsiCommonLabels, labels),
+		),
+		ExpandVolume: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: MetricsPrefix,
+				Subsystem: "controller",
+				Name:      "concurrency_expand_volume",
+				Help:      "Current number of concurrent ControllerExpandVolume operations",
+			},
+			slices.Concat(CsiCommonLabels, labels),
+		),
+		CreateSnapshot: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: MetricsPrefix,
+				Subsystem: "controller",
+				Name:      "concurrency_create_snapshot",
+				Help:      "Current number of concurrent ControllerCreateSnapshot operations",
+			},
+			slices.Concat(CsiCommonLabels, labels),
+		),
+		DeleteSnapshot: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: MetricsPrefix,
+				Subsystem: "controller",
+				Name:      "concurrency_delete_snapshot",
+				Help:      "Current number of concurrent ControllerDeleteSnapshot operations",
+			},
+			slices.Concat(CsiCommonLabels, labels),
+		),
+		CreateVolumeWaitDuration: prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Namespace: MetricsPrefix,
+				Subsystem: "controller",
+				Name:      "concurrency_create_volume_wait_duration_seconds",
+				Help:      "Duration of waiting for ControllerCreateVolume semaphore in seconds",
+			},
+			slices.Concat(CsiCommonLabels, labels),
+		),
+		DeleteVolumeWaitDuration: prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Namespace: MetricsPrefix,
+				Subsystem: "controller",
+				Name:      "concurrency_delete_volume_wait_duration_seconds",
+				Help:      "Duration of waiting for ControllerDeleteVolume semaphore in seconds",
+			},
+			slices.Concat(CsiCommonLabels, labels),
+		),
+		ExpandVolumeWaitDuration: prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Namespace: MetricsPrefix,
+				Subsystem: "controller",
+				Name:      "concurrency_expand_volume_wait_duration_seconds",
+				Help:      "Duration of waiting for ControllerExpandVolume semaphore in seconds",
+			},
+			slices.Concat(CsiCommonLabels, labels),
+		),
+		CreateSnapshotWaitDuration: prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Namespace: MetricsPrefix,
+				Subsystem: "controller",
+				Name:      "concurrency_create_snapshot_wait_duration_seconds",
+				Help:      "Duration of waiting for ControllerCreateSnapshot semaphore in seconds",
+			},
+			slices.Concat(CsiCommonLabels, labels),
+		),
+		DeleteSnapshotWaitDuration: prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Namespace: MetricsPrefix,
+				Subsystem: "controller",
+				Name:      "concurrency_delete_snapshot_wait_duration_seconds",
+				Help:      "Duration of waiting for ControllerDeleteSnapshot semaphore in seconds",
+			},
+			slices.Concat(CsiCommonLabels, labels),
+		),
+	}
+}
+
+func (c *ControllerConcurrencyMetrics) Init() {
+	// Initialize the metrics by registering them with Prometheus
+	initMetrics([]prometheus.Collector{
+		c.CreateVolume,
+		c.DeleteVolume,
+		c.ExpandVolume,
+		c.CreateSnapshot,
+		c.DeleteSnapshot,
+		c.CreateVolumeWaitDuration,
+		c.DeleteVolumeWaitDuration,
+		c.ExpandVolumeWaitDuration,
+		c.CreateSnapshotWaitDuration,
+		c.DeleteSnapshotWaitDuration,
+	})
+}
+
+type ControllerServerMetrics struct {
+	Concurrency *ControllerConcurrencyMetrics
+	Operations  *ControllerOperationMetrics
+}
+
+func NewControllerServerMetrics() *ControllerServerMetrics {
+	ret := &ControllerServerMetrics{
+		Operations:  NewControllerOperationMetrics(CsiControllerVolumeOperationMetricsLabels, CsiControllerSnapshotOperationMetricsLabels),
+		Concurrency: NewControllerConcurrencyMetrics(CsiControllerConcurrencyMetricsLabels),
+	}
+	ret.Init()
+	return ret
+}
+
+func (m *ControllerServerMetrics) Init() {
+	// Initialize the metrics by registering them with Prometheus
+	m.Operations.Init()
+	m.Concurrency.Init()
+}
+
+type NodeServerConcurrencyMetrics struct {
+	PublishVolume               *prometheus.GaugeVec
+	UnpublishVolume             *prometheus.GaugeVec
+	PublishVolumeWaitDuration   *prometheus.HistogramVec
+	UnpublishVolumeWaitDuration *prometheus.HistogramVec
+}
+
+func (m *NodeServerConcurrencyMetrics) Init(labels []string) {
+	// Initialize the metrics by registering them with Prometheus
+	// Currently, no metrics are defined for NodeServer
+	initMetrics([]prometheus.Collector{
+		m.PublishVolume,
+		m.UnpublishVolume},
+	)
+}
+
+func NewNodeConcurrencyMetrics(labels []string) *NodeServerConcurrencyMetrics {
+	// Currently, no metrics are defined for NodeServer concurrency
+	return &NodeServerConcurrencyMetrics{
+		PublishVolume: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: MetricsPrefix,
+				Subsystem: "node",
+				Name:      "concurrency_node_publish_volume",
+			},
+			slices.Concat(CsiCommonLabels, labels),
+		),
+		UnpublishVolume: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: MetricsPrefix,
+				Subsystem: "node",
+				Name:      "concurrency_node_unpublish_volume",
+			},
+			slices.Concat(CsiCommonLabels, labels),
+		),
+		PublishVolumeWaitDuration: prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Namespace: MetricsPrefix,
+				Subsystem: "node",
+				Name:      "concurrency_node_publish_volume_wait_duration_seconds",
+			},
+			slices.Concat(CsiCommonLabels, labels),
+		),
+		UnpublishVolumeWaitDuration: prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Namespace: MetricsPrefix,
+				Subsystem: "node",
+				Name:      "concurrency_node_unpublish_volume_wait_duration_seconds",
+			},
+			slices.Concat(CsiCommonLabels, labels),
+		),
+	}
+}
+
+type NodeServerOperationMetrics struct {
+	PublishVolume           *prometheus.CounterVec
+	PublishVolumeDuration   *prometheus.HistogramVec
+	UnpublishVolume         *prometheus.CounterVec
+	UnpublishVolumeDuration *prometheus.HistogramVec
+	GetVolumeStats          *prometheus.CounterVec
+	GetVolumeStatsDuration  *prometheus.HistogramVec
+}
+
+func (m *NodeServerOperationMetrics) Init(labels []string) {
+	// Initialize the metrics by registering them with Prometheus
+	// Currently, no metrics are defined for NodeServer
+	initMetrics([]prometheus.Collector{
+		m.PublishVolume,
+		m.UnpublishVolume,
+		m.PublishVolumeDuration,
+		m.UnpublishVolumeDuration,
+	})
+}
+
+func NewNodeOperationMetrics(volumeLabels []string) *NodeServerOperationMetrics {
+	// Currently, no metrics are defined for NodeServer operations
+	return &NodeServerOperationMetrics{
+		PublishVolume: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: MetricsPrefix,
+				Subsystem: "node",
+				Name:      "publish_volume_total",
+			},
+			slices.Concat(CsiCommonLabels, volumeLabels),
+		),
+		PublishVolumeDuration: prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Namespace: MetricsPrefix,
+				Subsystem: "node",
+				Name:      "publish_volume_duration_seconds",
+			},
+			slices.Concat(CsiCommonLabels, volumeLabels),
+		),
+		UnpublishVolume: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: MetricsPrefix,
+				Subsystem: "node",
+				Name:      "unpublish_volume_total",
+			},
+			slices.Concat(CsiCommonLabels, volumeLabels),
+		),
+		UnpublishVolumeDuration: prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Namespace: MetricsPrefix,
+				Subsystem: "node",
+				Name:      "unpublish_volume_duration_seconds",
+			},
+			slices.Concat(CsiCommonLabels, volumeLabels),
+		),
+		GetVolumeStats: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: MetricsPrefix,
+				Subsystem: "node",
+				Name:      "get_volume_stats_total",
+			},
+			slices.Concat(CsiCommonLabels, volumeLabels),
+		),
+		GetVolumeStatsDuration: prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Namespace: MetricsPrefix,
+				Subsystem: "node",
+				Name:      "get_volume_stats_duration_seconds",
+			},
+			slices.Concat(CsiCommonLabels, volumeLabels),
+		),
+	}
+}
+
+type NodeServerMetrics struct {
+	Concurrency *NodeServerConcurrencyMetrics
+	Operations  *NodeServerOperationMetrics
+}
+
+func (m *NodeServerMetrics) Init() {
+	// Initialize the metrics by registering them with Prometheus
+	// Currently, no metrics are defined for NodeServer
+	m.Concurrency.Init(CsiNodeConcurrencyMetricsLabels)
+	m.Operations.Init(CsiNodeVolumeOperationMetricsLabels)
+}
+
+func NewNodeServerMetrics() *NodeServerMetrics {
+	ret := &NodeServerMetrics{
+		Operations:  NewNodeOperationMetrics(CsiNodeVolumeOperationMetricsLabels),
+		Concurrency: NewNodeConcurrencyMetrics(CsiNodeConcurrencyMetricsLabels),
+	}
+	ret.Init()
+	return ret
+}
+
+func initMetrics(c []prometheus.Collector) {
+	// Register the metric with Prometheus
+	prometheus.MustRegister(c...)
+}

--- a/pkg/wekafs/nodeserver.go
+++ b/pkg/wekafs/nodeserver.go
@@ -21,10 +21,10 @@ import (
 	"errors"
 	"fmt"
 	"github.com/container-storage-interface/spec/lib/go/csi"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"go.opentelemetry.io/otel"
-	"golang.org/x/sync/semaphore"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"k8s.io/mount-utils"
@@ -44,8 +44,10 @@ type NodeServer struct {
 	mounters          *MounterGroup
 	api               *ApiStore
 	config            *DriverConfig
-	semaphores        map[string]*semaphore.Weighted
+	semaphores        map[string]*SemaphoreWrapper
 	backgroundTasksWg *sync.WaitGroup // used to wait for background tasks to finish before shutting down the server
+
+	metrics           *NodeServerMetrics
 	sync.Mutex
 }
 
@@ -85,7 +87,7 @@ func (ns *NodeServer) NodeExpandVolume(ctx context.Context, request *csi.NodeExp
 func (ns *NodeServer) NodeGetVolumeStats(ctx context.Context, req *csi.NodeGetVolumeStatsRequest) (*csi.NodeGetVolumeStatsResponse, error) {
 	volumeID := req.GetVolumeId()
 	volumePath := req.GetVolumePath()
-
+	ctx = context.WithValue(ctx, "startTime", time.Now())
 	// Validate request fields
 	if volumeID == "" {
 		return nil, status.Error(codes.InvalidArgument, "Volume ID must be provided")
@@ -108,8 +110,15 @@ func (ns *NodeServer) NodeGetVolumeStats(ctx context.Context, req *csi.NodeGetVo
 		return nil, status.Errorf(codes.InvalidArgument, "invalid volume ID %s: %v", volumeID, err)
 	}
 
+	st := "FAILURE"
+	defer func() {
+		ns.metrics.Operations.GetVolumeStats.WithLabelValues(ns.getConfig().GetDriver().name, st).Inc()
+		ns.metrics.Operations.GetVolumeStatsDuration.WithLabelValues(ns.getConfig().GetDriver().name, st).Observe(time.Since(ctx.Value("startTime").(time.Time)).Seconds())
+	}()
+
 	stats, err := getVolumeStats(volumePath)
 	if err != nil || stats == nil {
+		st = "SUCCESS"
 		return &csi.NodeGetVolumeStatsResponse{
 			Usage: nil,
 			VolumeCondition: &csi.VolumeCondition{
@@ -188,8 +197,9 @@ func NewNodeServer(driver *WekaFsDriver) *NodeServer {
 		mounters:          driver.mounters,
 		api:               driver.api,
 		config:            driver.config,
-		semaphores:        make(map[string]*semaphore.Weighted),
+		semaphores:        make(map[string]*SemaphoreWrapper),
 		backgroundTasksWg: new(sync.WaitGroup),
+		metrics:           NewNodeServerMetrics(),
 	}
 }
 
@@ -202,9 +212,35 @@ func (ns *NodeServer) acquireSemaphore(ctx context.Context, op string) (error, r
 	start := time.Now()
 	err := sem.Acquire(ctx, 1)
 	elapsed := time.Since(start)
+
+	// select metrics histogram based on the operation type
+	var histogram *prometheus.HistogramVec
+	var gauge *prometheus.GaugeVec
+	switch op {
+	case "PublishVolume":
+		histogram = ns.metrics.Concurrency.PublishVolumeWaitDuration
+		gauge = ns.metrics.Concurrency.PublishVolume
+	case "UnpublishVolume":
+		histogram = ns.metrics.Concurrency.UnpublishVolumeWaitDuration
+		gauge = ns.metrics.Concurrency.UnpublishVolume
+	}
+	driverName := ns.getConfig().GetDriver().name
+
+	// update concurrent operations
+	currentOps := func() {
+		if gauge != nil {
+			gauge.WithLabelValues(driverName, "acquired").Set(float64(sem.CurrentCount()))
+		}
+	}
+	currentOps()
+
 	if err == nil {
 		logger.Trace().Dur("acquire_duration", elapsed).Str("op", op).Msg("Successfully acquired semaphore")
+		if histogram != nil {
+			histogram.WithLabelValues(driverName, "success").Observe(elapsed.Seconds())
+		}
 		return nil, func() {
+			defer currentOps()
 			elapsed = time.Since(start)
 			logger.Trace().Dur("total_operation_time", elapsed).Str("op", op).Msg("Releasing semaphore")
 			sem.Release(1)
@@ -231,7 +267,8 @@ func (ns *NodeServer) initializeSemaphore(ctx context.Context, op string) {
 	}
 	logger := log.Ctx(ctx)
 	logger.Info().Str("op", op).Int64("max_concurrency", m).Msg("Initializing semaphore")
-	sem := semaphore.NewWeighted(m)
+	sem := NewSemaphoreWrapper(m)
+
 	ns.semaphores[op] = sem
 }
 
@@ -247,6 +284,7 @@ func (ns *NodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 	ctx, span := otel.Tracer(TracerName).Start(ctx, op)
 	defer span.End()
 	ctx = log.With().Str("trace_id", span.SpanContext().TraceID().String()).Str("span_id", span.SpanContext().SpanID().String()).Str("op", op).Logger().WithContext(ctx)
+	ctx = context.WithValue(ctx, "startTime", time.Now())
 
 	logger := log.Ctx(ctx)
 	result := "FAILURE"
@@ -257,6 +295,10 @@ func (ns *NodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 		if result != "SUCCESS" {
 			level = zerolog.ErrorLevel
 		}
+
+		ns.metrics.Operations.UnpublishVolumeDuration.WithLabelValues(ns.getConfig().GetDriver().name, result).Observe(time.Since(ctx.Value("startTime").(time.Time)).Seconds())
+		ns.metrics.Operations.UnpublishVolume.WithLabelValues(ns.getConfig().GetDriver().name, result).Inc()
+
 		logger.WithLevel(level).Str("result", result).Msg("<<<< Completed processing request")
 	}()
 
@@ -550,4 +592,19 @@ func getNodeServiceCapabilities(nl []csi.NodeServiceCapability_RPC_Type) []*csi.
 	}
 
 	return nsc
+}
+
+func (ns *NodeServer) GetAcquiredSemaphoreCount(op string) (int64, error) {
+	ns.Lock()
+	defer ns.Unlock()
+
+	sem, ok := ns.semaphores[op]
+	if !ok {
+		return 0, fmt.Errorf("semaphore for operation %s not found", op)
+	}
+
+	sem.mu.Lock()
+	defer sem.mu.Unlock()
+
+	return sem.CurrentCount(), nil
 }

--- a/pkg/wekafs/semaphore.go
+++ b/pkg/wekafs/semaphore.go
@@ -1,0 +1,47 @@
+package wekafs
+
+import (
+	"context"
+	"golang.org/x/sync/semaphore"
+	"sync"
+)
+
+// SemaphoreWrapper wraps semaphore.Weighted and tracks acquired permits.
+type SemaphoreWrapper struct {
+	sem             *semaphore.Weighted
+	acquiredPermits int64
+	mu              sync.Mutex
+}
+
+// NewSemaphoreWrapper creates a new SemaphoreWrapper.
+func NewSemaphoreWrapper(weight int64) *SemaphoreWrapper {
+	return &SemaphoreWrapper{
+		sem: semaphore.NewWeighted(weight),
+	}
+}
+
+// Acquire acquires the specified number of permits.
+func (sw *SemaphoreWrapper) Acquire(ctx context.Context, n int64) error {
+	err := sw.sem.Acquire(ctx, n)
+	if err == nil {
+		sw.mu.Lock()
+		sw.acquiredPermits += n
+		sw.mu.Unlock()
+	}
+	return err
+}
+
+// Release releases the specified number of permits.
+func (sw *SemaphoreWrapper) Release(n int64) {
+	sw.sem.Release(n)
+	sw.mu.Lock()
+	sw.acquiredPermits -= n
+	sw.mu.Unlock()
+}
+
+// CurrentCount returns the current number of acquired permits.
+func (sw *SemaphoreWrapper) CurrentCount() int64 {
+	sw.mu.Lock()
+	defer sw.mu.Unlock()
+	return sw.acquiredPermits
+}


### PR DESCRIPTION
### TL;DR

Added Prometheus metrics to the CSI driver to monitor controller and node operations.

### What changed?

- Added comprehensive Prometheus metrics for CSI driver operations
- Created metrics for tracking volume and snapshot operations (create, delete, expand)
- Added concurrency metrics to monitor semaphore usage and wait times
- Implemented metrics for operation durations, success/failure counts, and capacity changes
- Replaced standard semaphores with a custom `SemaphoreWrapper` that tracks acquired permits
- Added timing measurements for all CSI operations
- Integrated metrics collection into controller and node server operations

### How to test?

1. Deploy the CSI driver with Prometheus enabled
2. Perform various volume operations (create, delete, expand)
3. Perform snapshot operations (create, delete)
4. Check Prometheus metrics with prefix `weka_csi_` to verify data collection
5. Verify metrics show operation counts, durations, and concurrency information
6. Test under load to observe semaphore wait times and concurrency metrics

### Why make this change?

This change provides critical observability into the CSI driver's performance and behavior. The metrics will help:

- Monitor operation success rates and identify failures
- Track operation durations to detect performance issues
- Observe resource usage patterns through capacity metrics
- Identify potential bottlenecks through concurrency metrics
- Enable better capacity planning and troubleshooting
- Support SLA monitoring and performance optimization