### PR TITLE
feat(CSI-381): make WEKA API timeout configurable

### DIFF
--- a/charts/csi-wekafsplugin/templates/controllerserver-deployment.yaml
+++ b/charts/csi-wekafsplugin/templates/controllerserver-deployment.yaml
@@ -129,6 +129,9 @@ spec:
           {{- if .Values.pluginConfig.encryption.allowEncryptionWithoutKms}}
             - "--allowencryptionwithoutkms"
           {{- end}}
+          {{- if .Values.pluginConfig.apiTimeoutSeconds }}
+            - "--wekaapitimeoutseconds={{ .Values.pluginConfig.apiTimeoutSeconds }}"
+          {{- end }}
           ports:
             - containerPort: 9898
               name: healthz

--- a/charts/csi-wekafsplugin/templates/nodeserver-daemonset.yaml
+++ b/charts/csi-wekafsplugin/templates/nodeserver-daemonset.yaml
@@ -113,6 +113,9 @@ spec:
           {{- if .Values.pluginConfig.manageNodeTopologyLabels }}
             - "--managenodetopologylabels"
           {{- end }}
+          {{- if .Values.pluginConfig.apiTimeoutSeconds }}
+            - "--wekaapitimeoutseconds={{ .Values.pluginConfig.apiTimeoutSeconds }}"
+          {{- end }}
           ports:
             - containerPort: 9899
               name: healthz

--- a/charts/csi-wekafsplugin/values.yaml
+++ b/charts/csi-wekafsplugin/values.yaml
@@ -201,3 +201,5 @@ pluginConfig:
   skipGarbageCollection: false
   # -- Allow CSI plugin to manage node topology labels. For Operator-managed clusters, this should be set to false.
   manageNodeTopologyLabels: true
+  # -- WEKA API timeout, default 60 seconds
+  apiTimeoutSeconds: 60

--- a/cmd/wekafsplugin/main.go
+++ b/cmd/wekafsplugin/main.go
@@ -97,6 +97,7 @@ var (
 	allowAsyncObjectDeletion             = flag.Bool("allowasyncobjectdeletion", false, "Allow deletion of volumes in asynchronous manner. Improves speed of multiple volume deletions but might leave some objects in Weka cluster. Use with caution.")
 	allowEncryptionWithoutKms            = flag.Bool("allowencryptionwithoutkms", false, "Allow encryption without KMS, for testing purposes only")
 	manageNodeTopologyLabels             = flag.Bool("managenodetopologylabels", false, "Manage node topology labels for CSI driver")
+	wekaApiTimeoutSeconds                = flag.Int("wekaapitimeoutseconds", 60, "Timeout for Weka API requests in seconds")
 	// Set by the build process
 	version = ""
 )
@@ -236,6 +237,7 @@ func handle(ctx context.Context) {
 		*allowEncryptionWithoutKms,
 		*tracingUrl,
 		*manageNodeTopologyLabels,
+		time.Duration(*wekaApiTimeoutSeconds)*time.Second,
 	)
 	driver, err := wekafs.NewWekaFsDriver(*driverName, *nodeID, *endpoint, *maxVolumesPerNode, version, csiMode, *selinuxSupport, config)
 	if err != nil {

--- a/pkg/wekafs/driverconfig.go
+++ b/pkg/wekafs/driverconfig.go
@@ -44,6 +44,7 @@ type DriverConfig struct {
 	driverRef                        *WekaFsDriver
 	tracingUrl                       string
 	manageNodeTopologyLabels         bool
+	wekaApiTimeout                    time.Duration // Timeout for Weka API requests
 }
 
 func (dc *DriverConfig) Log() {
@@ -70,6 +71,8 @@ func (dc *DriverConfig) Log() {
 		Bool("allow_async_object_deletion", dc.allowAsyncObjectDeletion).
 		Str("tracing_url", dc.tracingUrl).
 		Bool("manage_node_topology_labels", dc.manageNodeTopologyLabels).
+		Dur("weka_api_timeout", dc.wekaApiTimeout).
+		Str("nfs_protocol_version", dc.nfsProtocolVersion).
 		Msg("Starting driver with the following configuration")
 
 }
@@ -87,6 +90,7 @@ func NewDriverConfig(dynamicVolPath, VolumePrefix, SnapshotPrefix, SeedSnapshotP
 	allowEncryptionWithoutKms bool,
 	tracingUrl string,
 	manageNodeTopologyLabels bool,
+	wekaApiTimeout time.Duration,
 ) *DriverConfig {
 
 	var MutuallyExclusiveMountOptions []mutuallyExclusiveMountOptionSet
@@ -136,6 +140,7 @@ func NewDriverConfig(dynamicVolPath, VolumePrefix, SnapshotPrefix, SeedSnapshotP
 		allowEncryptionWithoutKms:        allowEncryptionWithoutKms,
 		tracingUrl:                       tracingUrl,
 		manageNodeTopologyLabels:         manageNodeTopologyLabels,
+		wekaApiTimeout:                    wekaApiTimeout,
 	}
 }
 

--- a/pkg/wekafs/identityserver.go
+++ b/pkg/wekafs/identityserver.go
@@ -72,6 +72,13 @@ func NewIdentityServer(driver *WekaFsDriver) *identityServer {
 	}
 }
 
+func (ids *identityServer) GetConfig() *DriverConfig {
+	if ids.config == nil {
+		panic("DriverConfig is nil")
+	}
+	return ids.config
+}
+
 //goland:noinspection GoUnusedParameter
 func (ids *identityServer) GetPluginInfo(ctx context.Context, req *csi.GetPluginInfoRequest) (*csi.GetPluginInfoResponse, error) {
 	op := "GetPluginInfo"

--- a/pkg/wekafs/volume_test.go
+++ b/pkg/wekafs/volume_test.go
@@ -13,12 +13,40 @@ func GetDriverForTest(t *testing.T) *WekaFsDriver {
 	ctx := context.Background()
 	nodeId := "localhost"
 	mutuallyExclusive := MutuallyExclusiveMountOptsStrings{"readcache,writecache,coherent,forcedirect", "sync,async", "ro,rw"}
-	driverConfig := NewDriverConfig("csi-volumes", "csi-vol-", "csi-snap-", "csi-seed-snap-",
-		true, true, true, true, true,
-		true, true, mutuallyExclusive,
-		1, 1, 1, 1, 1, 1, 1, 10,
-		true, true, true, "", "", "4.1", "v1", false, false, true,
-		"", false)
+	driverConfig := NewDriverConfig(
+		"csi-volumes",
+		"csi-vol-", "csi-snap-",
+		"csi-seed-snap-",
+		true,
+		true,
+		true,
+		true,
+		true,
+		true,
+		true,
+		mutuallyExclusive,
+		1,
+		1,
+		1,
+		1,
+		1,
+		1,
+		1,
+		10,
+		true,
+		true,
+		true,
+		"",
+		"",
+		"4.1",
+		"v1",
+		false,
+		false,
+		true,
+		"",
+		false,
+		120*time.Second,
+	)
 	driver, err := NewWekaFsDriver("csi.weka.io", nodeId, "unix://tmp/csi.sock", 10, "v1.0", CsiModeAll, false, driverConfig)
 	if err != nil {
 		t.Fatalf("Failed to create new driver: %v", err)


### PR DESCRIPTION
### TL;DR

Added configurable timeout for Weka API requests in the CSI driver.

### What changed?

- Added a new configuration parameter `apiTimeoutSeconds` to control the timeout for Weka API requests
- Set a default value of 60 seconds in the Helm chart values
- Added the `--wekaapitimeoutseconds` flag to both controller and node server deployments
- Updated the driver configuration to store and use this timeout value
- Modified the code to pass this timeout duration to the appropriate components

### How to test?

1. Deploy the CSI driver with a custom API timeout:
   ```yaml
   pluginConfig:
     apiTimeoutSeconds: 120
   ```
2. Verify that the timeout is correctly passed to the controller and node server pods
3. Test operations that interact with the Weka API to ensure they respect the configured timeout

### Why make this change?

The default API timeout may not be suitable for all environments, especially in cases where the Weka cluster might be under heavy load or network conditions cause higher latency. This change allows administrators to tune the timeout according to their specific deployment needs, improving reliability in environments where API operations might take longer than the default timeout.