### PR TITLE
feat(CSI-370): add PodMonitors for CSI plugin components

### DIFF
--- a/charts/csi-wekafsplugin/templates/controllerserver-deployment.yaml
+++ b/charts/csi-wekafsplugin/templates/controllerserver-deployment.yaml
@@ -138,7 +138,7 @@ spec:
               protocol: TCP
           {{- if .Values.metrics.enabled }}
             - containerPort: {{ .Values.metrics.controllerPort | default 9090 }}
-              name: metrics
+              name: cs-metrics
               protocol: TCP
           {{- end }}
           livenessProbe:
@@ -217,7 +217,7 @@ spec:
               path: /healthz/leader-election
           ports:
             - containerPort: {{ .Values.metrics.attacherPort | default 9095 }}
-              name: pr-metrics
+              name: at-metrics
               protocol: TCP
           {{- end }}
         - name: csi-provisioner

--- a/charts/csi-wekafsplugin/templates/controllerserver-podmonitor.yaml
+++ b/charts/csi-wekafsplugin/templates/controllerserver-podmonitor.yaml
@@ -1,0 +1,27 @@
+# only if metrics.enabled is true and the node metrics port is set and Prometheus stack is installed
+{{- if .Values.metrics.enabled }}
+{{- if .Values.metrics.controllerPort }}
+{{- if .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ .Release.Name }}-controller
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Release.Name }}-controller
+    component: {{ .Release.Name }}-controller
+spec:
+  selector:
+    matchLabels:
+    app: {{ .Release.Name }}-controller
+    component: {{ .Release.Name }}-controller
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  podMetricsEndpoints:
+    - port: cs-metrics
+
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/csi-wekafsplugin/templates/nodeserver-daemonset.yaml
+++ b/charts/csi-wekafsplugin/templates/nodeserver-daemonset.yaml
@@ -122,7 +122,7 @@ spec:
               protocol: TCP
           {{- if .Values.metrics.enabled }}
             - containerPort: {{ .Values.metrics.nodePort }}
-              name: metrics
+              name: ns-metrics
               protocol: TCP
           {{- end }}
           livenessProbe:

--- a/charts/csi-wekafsplugin/templates/nodeserver-podmonitor.yaml
+++ b/charts/csi-wekafsplugin/templates/nodeserver-podmonitor.yaml
@@ -1,0 +1,27 @@
+# only if metrics.enabled is true and the node metrics port is set and Prometheus stack is installed
+{{- if .Values.metrics.enabled }}
+{{- if .Values.metrics.nodePort }}
+{{- if .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ .Release.Name }}-node
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Release.Name }}-node
+    component: {{ .Release.Name }}-node
+spec:
+  selector:
+    matchLabels:
+    app: {{ .Release.Name }}-node
+    component: {{ .Release.Name }}-node
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  podMetricsEndpoints:
+    - port: ns-metrics
+
+{{- end }}
+{{- end }}
+{{- end }}


### PR DESCRIPTION
### TL;DR

Added PodMonitor resources for Prometheus metrics collection and renamed metrics ports for better identification.

### What changed?

- Added two new files: `controllerserver-podmonitor.yaml` and `nodeserver-podmonitor.yaml` to create PodMonitor resources for Prometheus metrics collection
- Renamed metrics port names to be more specific:
  - Changed `metrics` to `cs-metrics` in controller server
  - Changed `pr-metrics` to `at-metrics` in attacher container
  - Changed `metrics` to `ns-metrics` in node server
- The PodMonitor resources are conditionally created based on metrics being enabled, ports being set, and Prometheus CRDs being available

### How to test?

1. Install the chart with metrics enabled in a cluster with Prometheus Operator installed
2. Verify that the PodMonitor resources are created:
   ```
   kubectl get podmonitors -n <namespace>
   ```
3. Check that Prometheus is scraping metrics from the CSI controller and node servers
4. Verify metrics are available in the Prometheus UI

### Why make this change?

This change enables automatic discovery and scraping of CSI plugin metrics by Prometheus when using the Prometheus Operator. The port name changes provide better identification of which component is exposing which metrics endpoint, making monitoring and troubleshooting easier.