### PR TITLE
feat(CSI-363): implement counters for API endpoints

### DIFF
--- a/pkg/wekafs/apiclient/apiclient.go
+++ b/pkg/wekafs/apiclient/apiclient.go
@@ -52,6 +52,7 @@ type ApiClient struct {
 	containerName               string
 	NfsInterfaceGroupName       string
 	NfsClientGroupName          string
+	metrics                     *ApiMetrics
 	driverName                  string
 	RotateEndpointOnEachRequest bool // to be used in metrics server only (atm) to increase concurrency of requests across endpoints
 

--- a/pkg/wekafs/apiclient/apiclient.go
+++ b/pkg/wekafs/apiclient/apiclient.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"github.com/google/uuid"
 	"github.com/rs/zerolog/log"
-	"hash/fnv"
 	"k8s.io/helm/pkg/urlutil"
 	"math/rand"
 	"net"
@@ -111,7 +110,6 @@ func NewApiClient(ctx context.Context, credentials Credentials, opts ApiClientOp
 	}
 
 	logger.Trace().Bool("insecure_skip_verify", opts.AllowInsecureHttps).Bool("custom_ca_cert", useCustomCACert).Msg("Creating new API client")
-	a.clientHash = a.generateHash()
 	return a, nil
 }
 
@@ -170,29 +168,6 @@ func (a *ApiClient) handleTransientErrors(ctx context.Context, err error) error 
 func (a *ApiClient) getUrl(ctx context.Context, path string) string {
 	u, _ := urlutil.URLJoin(a.getBaseUrl(ctx), path)
 	return u
-}
-
-// generateHash used for storing multiple clients in hash table. Hash() is created once as connection params might change
-func (a *ApiClient) generateHash() uint32 {
-	h := fnv.New32a()
-	s := fmt.Sprintln(
-		a.Credentials.Username,
-		a.Credentials.Password,
-		a.Credentials.Organization,
-		a.Credentials.Endpoints,
-		a.Credentials.NfsTargetIPs,
-		a.Credentials.LocalContainerName,
-		a.Credentials.CaCertificate,
-		a.Credentials.KmsPreexistingCredentialsForVolumeEncryption.InsecureString(),
-		a.Credentials.KmsKeyManagementCredentials.InsecureString(),
-	)
-	_, _ = h.Write([]byte(s))
-	return h.Sum32()
-}
-
-// Hash returns the client hash as it was generated once client was initialized
-func (a *ApiClient) Hash() uint32 {
-	return a.clientHash
 }
 
 // retryBackoff performs operation and retries on transient failures. Does not retry on ApiNonTransientError

--- a/pkg/wekafs/apiclient/apiclient_test.go
+++ b/pkg/wekafs/apiclient/apiclient_test.go
@@ -18,20 +18,17 @@ func TestGenerateHash(t *testing.T) {
 		Password:  "testpassword",
 		Endpoints: []string{"127.0.0.1:14000"},
 	}
-	apiClient := &ApiClient{
-		Credentials: credentials,
-	}
 
-	hash := apiClient.generateHash()
+	hash := credentials.Hash()
 	assert.NotZero(t, hash, "Expected non-zero hash value")
 
 	// Test that the hash is consistent for the same credentials
-	hash2 := apiClient.generateHash()
+	hash2 := credentials.Hash()
 	assert.Equal(t, hash, hash2, "Expected hash values to be equal for the same credentials")
 
 	// Test that the hash changes for different credentials
-	apiClient.Credentials.Username = "differentuser"
-	hash3 := apiClient.generateHash()
+	credentials.Username = "differentuser"
+	hash3 := credentials.Hash()
 	assert.NotEqual(t, hash, hash3, "Expected hash values to be different for different credentials")
 }
 

--- a/pkg/wekafs/apiclient/login.go
+++ b/pkg/wekafs/apiclient/login.go
@@ -66,6 +66,9 @@ func (a *ApiClient) Login(ctx context.Context) error {
 
 // Init checks if API token refresh is required and transparently refreshes or fails back to (re)login
 func (a *ApiClient) Init(ctx context.Context) error {
+	if a.metrics == nil {
+		a.metrics = NewApiMetrics(a)
+	}
 	if a.apiTokenExpiryDate.After(time.Now()) {
 		return nil
 	} else {

--- a/pkg/wekafs/apiclient/metrics.go
+++ b/pkg/wekafs/apiclient/metrics.go
@@ -1,0 +1,60 @@
+package apiclient
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+type ApiMetrics struct {
+	client           *ApiClient
+	Endpoints        *prometheus.GaugeVec
+	requestCounters  *prometheus.CounterVec
+	requestDurations *prometheus.HistogramVec
+}
+
+var GlobalApiMetrics *ApiMetrics
+
+func NewApiMetrics(client *ApiClient) *ApiMetrics {
+	if GlobalApiMetrics != nil {
+		return GlobalApiMetrics
+	}
+	ret := &ApiMetrics{
+		client: client,
+		Endpoints: prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: "weka_csi",
+				Subsystem: "api",
+				Name:      "endpoints_count",
+				Help:      "Total number of API endpoints",
+			},
+			[]string{"csi_driver_name", "cluster_guid", "endpoint_status"},
+		),
+		requestCounters: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: "weka_csi",
+				Subsystem: "api",
+				Name:      "request_count",
+				Help:      "Total number of API requests broken down by endpoint, method, url, status",
+			},
+			[]string{"csi_driver_name", "cluster_guid", "endpoint", "method", "url", "status"},
+		),
+		requestDurations: prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Namespace: "weka_csi",
+				Subsystem: "api",
+				Name:      "request_duration_seconds",
+				Help:      "Duration of API requests in seconds broken down by endpoint, method, url, status",
+				Buckets:   []float64{0.1, 0.25, 0.5, 1, 2.5, 5, 7.5, 10, 15, 30, 60, 120, 300},
+			},
+			[]string{"csi_driver_name", "cluster_guid", "endpoint", "method", "url", "status"},
+		),
+	}
+	ret.Init()
+	GlobalApiMetrics = ret
+	return ret
+}
+
+func (m *ApiMetrics) Init() {
+	prometheus.MustRegister(m.Endpoints)
+	prometheus.MustRegister(m.requestCounters)
+	prometheus.MustRegister(m.requestDurations)
+}

--- a/pkg/wekafs/apiclient/utils.go
+++ b/pkg/wekafs/apiclient/utils.go
@@ -233,3 +233,16 @@ func maskPayload(payload string) string {
 	ret, _ := json.Marshal(masked)
 	return string(ret)
 }
+
+func generalizeUrlPathForMetrics(urlPath string) string {
+	// Replace any numeric IDs in the URL path with a placeholder
+	re := regexp.MustCompile(`[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}`)
+	// Replace GUIDs with a placeholder
+	path := re.ReplaceAllString(urlPath, "{guid}")
+	re = regexp.MustCompile(`\b\d+\b`)
+	path = re.ReplaceAllString(path, "{id}")
+	if strings.HasSuffix(path, "/") {
+		return path[:len(path)-1]
+	}
+	return path
+}


### PR DESCRIPTION
### TL;DR

Added API metrics collection for the Weka CSI driver to track API requests and performance.

### What changed?

- Created a new `ApiMetrics` struct and implementation in `metrics.go` to collect Prometheus metrics
- Added metrics for tracking:
  - Number of API endpoints
  - API request counts (broken down by endpoint, method, URL, status)
  - API request durations (with histogram buckets)
- Added metrics initialization in the API client's `Init` method
- Implemented request tracking in the `do` method with proper labeling
- Added URL path generalization to prevent cardinality explosion in metrics

### How to test?

1. Deploy the CSI driver with Prometheus enabled
2. Check that the new metrics are being collected:
   - `weka_csi_api_endpoints_count`
   - `weka_csi_api_request_count`
   - `weka_csi_api_request_duration_seconds`
3. Verify metrics are properly labeled with driver name, cluster GUID, endpoint, method, URL, and status

### Why make this change?

This change enables better observability of the CSI driver's API interactions with Weka clusters. The metrics will help:
- Monitor API performance and identify slow requests
- Track API usage patterns
- Detect errors and issues with specific endpoints
- Provide data for capacity planning and performance optimization