### PR TITLE
refactor: unify mounters functions and fix refcount issues

### DIFF
--- a/pkg/wekafs/anymount.go
+++ b/pkg/wekafs/anymount.go
@@ -1,0 +1,91 @@
+package wekafs
+
+import (
+	"context"
+	"errors"
+	"github.com/rs/zerolog/log"
+	"github.com/wekafs/csi-wekafs/pkg/wekafs/apiclient"
+	"os"
+)
+
+func anyMountIncref(ctx context.Context, apiClient *apiclient.ApiClient, m AnyMount) error {
+	logger := log.Ctx(ctx)
+	if m.getMounter() == nil {
+		logger.Error().Msg("Mounter is nil")
+		return errors.New("mounter is nil")
+	}
+
+	refCount, lock := m.getMounter().getMountMap().LoadOrStore(m.getRefCountIndex())
+	lock.Lock()
+	defer lock.Unlock()
+	if refCount.Load() > 0 && !m.isMounted() {
+		logger.Fatal().Msgf("RefCount is %d but mount point %s does not exist", refCount.Load(), m.getMountPoint())
+	}
+	if refCount.Load() == 0 {
+		if err := m.doMount(ctx, apiClient, m.getMountOptions()); err != nil {
+			return err
+		}
+	}
+	refCount.Inc()
+	logger.Trace().
+		Int32("refcount", refCount.Load()).
+		Strs("mount_options", m.getMountOptions().Strings()).
+		Str("filesystem_name", m.getFsName()).
+		Str("mount_point", m.getMountPoint()).
+		Msg("RefCount increased")
+	return nil
+}
+
+func anyMountDecRef(ctx context.Context, m AnyMount) error {
+	logger := log.Ctx(ctx)
+	if m.getMounter() == nil {
+		logger.Error().Msg("Mounter is nil")
+		return errors.New("mounter is nil")
+	}
+	refCount, lock := m.getMounter().getMountMap().LoadOrStore(m.getRefCountIndex())
+	lock.Lock()
+	defer lock.Unlock()
+
+	if refCount.Load() <= 1 {
+		if err := m.doUnmount(ctx); err != nil {
+			return err
+		}
+	}
+	refCount.Dec()
+	if refCount.Load() < 0 {
+		logger.Fatal().Msgf("RefCount became negative on unmounting %s", m.getMountPoint())
+	}
+	logger.Trace().
+		Int32("refcount", refCount.Load()).
+		Strs("mount_options", m.getMountOptions().Strings()).
+		Str("filesystem_name", m.getFsName()).
+		Str("mount_point", m.getMountPoint()).
+		Msg("RefCount decreased")
+	return nil
+}
+
+func anyMountDoUnmount(ctx context.Context, m AnyMount) error {
+	logger := log.Ctx(ctx).With().Str("mount_point", m.getMountPoint()).Str("filesystem", m.getFsName()).Logger()
+	logger.Trace().Strs("mount_options", m.getMountOptions().Strings()).Msg("Performing umount via k8s native mounter")
+	err := m.getKMounter().Unmount(m.getMountPoint())
+	if err != nil {
+		logger.Error().Err(err).Msg("Failed to unmount")
+	} else {
+		logger.Trace().Msg("Unmounted successfully")
+		if err := os.Remove(m.getMountPoint()); err != nil {
+			logger.Error().Err(err).Msg("Failed to remove mount point")
+			return err
+		} else {
+			logger.Trace().Msg("Removed mount point successfully")
+		}
+	}
+	return err
+}
+
+func anyMountGetRefCountIndex(m AnyMount) string {
+	return m.getMountPoint() + "\x00" + m.getMountOptions().String()
+}
+
+func anyMountIsMounted(m AnyMount) bool {
+	return PathExists(m.getMountPoint()) && PathIsWekaMount(m.getMountPoint())
+}

--- a/pkg/wekafs/anymounter.go
+++ b/pkg/wekafs/anymounter.go
@@ -1,0 +1,71 @@
+package wekafs
+
+import (
+	"context"
+	"github.com/rs/zerolog/log"
+	"strings"
+	"time"
+)
+
+func anyMounterLogActiveMounts(m AnyMounter) {
+	if m.getMountMap().Len() > 0 {
+		count := 0
+		for _, refIndex := range m.getMountMap().getIndexes() {
+			// no need to lock here, as this is a periodic check
+			// and we are not modifying the map, just reading it
+			refCount, _ := m.getMountMap().Load(refIndex)
+			parts := strings.Split(refIndex, "\x00")
+			c := int32(0)
+			if refCount != nil {
+				c = refCount.Load()
+				logger := log.With().Str("mount_point", parts[0]).Str("mount_options", parts[1]).Str("ref_index", refIndex).Int32("refcount", c).Logger()
+				if c > 0 {
+					logger.Trace().Msg("Mount is active")
+					count++
+				} else {
+					logger.Trace().Msg("Mount is not active")
+				}
+
+			}
+		}
+		log.Debug().Int("total", m.getMountMap().Len()).Int("active", count).Msg("Periodic checkup on mount map")
+	}
+}
+
+func anyMounterGcInactiveMounts(m AnyMounter) {
+	if m.getMountMap().Len() > 0 {
+		for _, refIndex := range m.getMountMap().getIndexes() {
+			refCount, lock := m.getMountMap().Load(refIndex)
+			lock.Lock()
+			c := refCount.Load()
+			if c == 0 {
+				parts := strings.Split(refIndex, "\x00")
+				logger := log.With().Str("mount_point", parts[0]).Str("mount_options", parts[1]).Str("ref_index", refIndex).Logger()
+				logger.Trace().Msg("Removing inactive mount from map")
+				m.getMountMap().Prune(refIndex)
+			}
+			lock.Unlock()
+		}
+	}
+}
+
+func anyMounterGetSelinuxStatus(ctx context.Context, m AnyMounter) bool {
+	s := m.getSelinuxSupport()
+	if s != nil && *s {
+		return true
+	}
+	selinuxSupport := getSelinuxStatus(ctx)
+	m.setSelinuxSupport(selinuxSupport)
+	return selinuxSupport
+}
+
+func anyMounterSchedulePeriodicMountGc(m AnyMounter) {
+	go func() {
+		log.Debug().Msgf("Initializing periodic mount GC for %s transport", m.getTransport())
+		for true {
+			m.LogActiveMounts()
+			m.gcInactiveMounts()
+			time.Sleep(10 * time.Minute)
+		}
+	}()
+}

--- a/pkg/wekafs/gc.go
+++ b/pkg/wekafs/gc.go
@@ -61,7 +61,7 @@ func (gc *innerPathVolGc) moveVolumeToTrash(ctx context.Context, volume *Volume)
 	}
 	volumeTrashLoc := filepath.Join(path, garbagePath)
 	fullPath := filepath.Join(path, volume.GetFullPath(ctx))
-	if !fileExists(fullPath) {
+	if !PathExists(fullPath) {
 		logger.Debug().Str("full_path", fullPath).Msg("Volume contents not found, maybe already moved to trash, skipping")
 		return nil
 	}

--- a/pkg/wekafs/mountmap.go
+++ b/pkg/wekafs/mountmap.go
@@ -1,0 +1,69 @@
+package wekafs
+
+import (
+	"go.uber.org/atomic"
+	"sync"
+)
+
+type mountMap struct {
+	m sync.Map
+	l sync.Map
+}
+
+func newMountMap() *mountMap {
+	return &mountMap{
+		m: sync.Map{},
+		l: sync.Map{},
+	}
+}
+
+func (mm *mountMap) LoadOrStore(s string) (*atomic.Int32, *sync.Mutex) {
+	lock := mm.getLock(s)
+	lock.Lock()
+	defer lock.Unlock()
+	val, _ := mm.m.LoadOrStore(s, atomic.NewInt32(0))
+	return val.(*atomic.Int32), lock
+}
+
+func (mm *mountMap) Load(s string) (*atomic.Int32, *sync.Mutex) {
+	lock := mm.getLock(s)
+	lock.Lock()
+	defer lock.Unlock()
+	if refCount, ok := mm.m.Load(s); ok {
+		return refCount.(*atomic.Int32), lock
+	}
+	mm.l.Delete(s)
+	return nil, nil
+}
+
+func (mm *mountMap) getLock(s string) *sync.Mutex {
+	lock, _ := mm.l.LoadOrStore(s, &sync.Mutex{})
+	return lock.(*sync.Mutex)
+}
+
+func (mm *mountMap) Prune(s string) {
+	lock := mm.getLock(s)
+	lock.Lock()
+	defer lock.Unlock()
+	mm.m.Delete(s)
+	// TODO: need to return it?
+	// mm.l.Delete(s)
+}
+
+func (mm *mountMap) getIndexes() []string {
+	var indexes []string
+	mm.m.Range(func(key, value interface{}) bool {
+		indexes = append(indexes, key.(string))
+		return true
+	})
+	return indexes
+}
+
+func (mm *mountMap) Len() int {
+	count := 0
+	mm.m.Range(func(_, _ interface{}) bool {
+		count++
+		return true
+	})
+	return count
+}

--- a/pkg/wekafs/utilities_test.go
+++ b/pkg/wekafs/utilities_test.go
@@ -71,3 +71,28 @@ default /run/weka-fs-mounts/default-DTQLAJ6KO6IUCZE23RBIM26YYUQNWKAA-mystrangecl
 	assert.Equal(t, "", containerName)
 
 }
+
+func TestPathExistsAndFileExists(t *testing.T) {
+	// Create a temporary directory
+	tmpDir, err := os.MkdirTemp("", "testdir")
+	assert.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	// Create a temporary file
+	tmpFile, err := os.CreateTemp("", "testfile")
+	assert.NoError(t, err)
+	tmpFileName := tmpFile.Name()
+	tmpFile.Close()
+	defer os.Remove(tmpFileName)
+
+	// PathExists should return true for directory, false for file
+	assert.True(t, PathExists(tmpDir))
+
+	// fileExists should return true for file, false for directory
+	assert.True(t, fileExists(tmpFileName))
+	assert.False(t, fileExists(tmpDir))
+
+	// Non-existent path
+	assert.False(t, PathExists("/nonexistent/path"))
+	assert.False(t, fileExists("/nonexistent/file"))
+}

--- a/pkg/wekafs/volume.go
+++ b/pkg/wekafs/volume.go
@@ -1867,6 +1867,6 @@ func (v *Volume) CanBeOperated() error {
 	return nil
 }
 
-func (v *Volume) isMounted(ctx context.Context) bool {
-	return v.mountPath != "" && PathIsWekaMount(ctx, v.mountPath)
+func (v *Volume) isMounted() bool {
+	return v.mountPath != "" && PathIsWekaMount(v.mountPath)
 }

--- a/pkg/wekafs/wekafsmount.go
+++ b/pkg/wekafs/wekafsmount.go
@@ -6,10 +6,8 @@ import (
 	"fmt"
 	"github.com/rs/zerolog/log"
 	"github.com/wekafs/csi-wekafs/pkg/wekafs/apiclient"
-	"go.uber.org/atomic"
 	"k8s.io/mount-utils"
 	"os"
-	"sync"
 	"time"
 )
 
@@ -17,8 +15,6 @@ type wekafsMount struct {
 	mounter                 *wekafsMounter
 	fsName                  string
 	mountPoint              string
-	refCount                int
-	lock                    sync.Mutex
 	kMounter                mount.Interface
 	mountOptions            MountOptions
 	lastUsed                time.Time
@@ -26,98 +22,48 @@ type wekafsMount struct {
 	containerName           string
 }
 
-func (m *wekafsMount) getMountPoint() string {
-	if m.containerName != "" {
-		return fmt.Sprintf("%s-%s", m.mountPoint, m.containerName)
-	}
-	return m.mountPoint
+func (m *wekafsMount) getKMounter() mount.Interface {
+	return m.kMounter
 }
 
-func (m *wekafsMount) getRefCount() int {
-	return m.refCount
+func (m *wekafsMount) getFsName() string {
+	return m.fsName
+}
+
+func (m *wekafsMount) getMounter() AnyMounter {
+	return m.mounter
+}
+
+func (m *wekafsMount) getMountPoint() string {
+	return fmt.Sprintf("%s-%s", m.mountPoint, m.containerName)
 }
 
 func (m *wekafsMount) getMountOptions() MountOptions {
-	return m.mountOptions
+	return m.mountOptions.AddOption(fmt.Sprintf("container_name=%s", m.containerName))
 }
+
 func (m *wekafsMount) getLastUsed() time.Time {
 	return m.lastUsed
 }
 
 func (m *wekafsMount) isMounted() bool {
-	return PathExists(m.getMountPoint()) && PathIsWekaMount(context.Background(), m.getMountPoint())
+	return anyMountIsMounted(m)
 }
 
-func (m *wekafsMount) getRefcountIdx() string {
-	return m.getMountPoint() + "^" + m.getMountOptions().String()
+func (m *wekafsMount) getRefCountIndex() string {
+	return anyMountGetRefCountIndex(m)
 }
 
 func (m *wekafsMount) incRef(ctx context.Context, apiClient *apiclient.ApiClient) error {
-	logger := log.Ctx(ctx)
-	if m.mounter == nil {
-		logger.Error().Msg("Mounter is nil")
-		return errors.New("mounter is nil")
-	}
-
-	m.mounter.lock.Lock()
-	defer m.mounter.lock.Unlock()
-	refCount, ok := m.mounter.mountMap[m.getRefcountIdx()]
-
-	if !ok || refCount == nil {
-		refCount = atomic.NewInt32(0)
-		m.mounter.mountMap[m.getRefcountIdx()] = refCount
-	}
-
-	if refCount.Load() > 0 && !m.isMounted() {
-		logger.Warn().Str("mount_point", m.getMountPoint()).Int32("refcount", refCount.Load()).Msg("Mount not exists although should!")
-	}
-
-	if refCount.Load() == 0 {
-		if err := m.doMount(ctx, apiClient, m.getMountOptions()); err != nil {
-			return err
-		}
-	}
-	refCount.Inc()
-	logger.Trace().
-		Int32("refcount", refCount.Load()).
-		Strs("mount_options", m.getMountOptions().Strings()).
-		Str("filesystem_name", m.fsName).
-		Str("mount_point", m.getMountPoint()).
-		Msg("RefCount increased")
-	return nil
+	return anyMountIncref(ctx, apiClient, m)
 }
 
 func (m *wekafsMount) decRef(ctx context.Context) error {
-	logger := log.Ctx(ctx)
-	if m.mounter == nil {
-		logger.Error().Msg("Mounter is nil")
-		return errors.New("mounter is nil")
-	}
-	m.mounter.lock.Lock()
-	defer m.mounter.lock.Unlock()
-	refCount, ok := m.mounter.mountMap[m.getRefcountIdx()]
-	if !ok {
-		logger.Error().Str("mount_options", m.getMountOptions().String()).Str("mount_point", m.getMountPoint()).Msg("During decRef refcount not found")
-		refCount = atomic.NewInt32(0)
-		m.mounter.mountMap[m.getRefcountIdx()] = refCount
-	}
+	return anyMountDecRef(ctx, m)
+}
 
-	if refCount.Load() < 0 {
-		logger.Error().Int32("refcount", refCount.Load()).Msg("During decRef negative refcount encountered, probably due to failed unmount")
-	}
-	if refCount.Load() > 0 {
-		refCount.Dec()
-		logger.Trace().Int32("refcount", refCount.Load()).Strs("mount_options", m.getMountOptions().Strings()).Str("filesystem_name", m.fsName).Msg("RefCount decreased")
-	}
-	if refCount.Load() <= 0 {
-		if m.isMounted() {
-			if err := m.doUnmount(ctx); err != nil {
-				return err
-			}
-			refCount.Store(0) // Reset refCount to 0 after unmount
-		}
-	}
-	return nil
+func (m *wekafsMount) doUnmount(ctx context.Context) error {
+	return anyMountDoUnmount(ctx, m)
 }
 
 func (m *wekafsMount) locateContainerName() error {
@@ -131,26 +77,8 @@ func (m *wekafsMount) locateContainerName() error {
 	return nil
 }
 
-func (m *wekafsMount) doUnmount(ctx context.Context) error {
-	logger := log.Ctx(ctx).With().Str("mount_point", m.getMountPoint()).Str("filesystem", m.fsName).Logger()
-	logger.Trace().Strs("mount_options", m.getMountOptions().Strings()).Msg("Performing umount via k8s native mounter")
-	err := m.kMounter.Unmount(m.getMountPoint())
-	if err != nil {
-		logger.Error().Err(err).Msg("Failed to unmount")
-	} else {
-		logger.Trace().Msg("Unmounted successfully")
-		if err := os.Remove(m.getMountPoint()); err != nil {
-			logger.Error().Err(err).Msg("Failed to remove mount point")
-			return err
-		} else {
-			logger.Trace().Msg("Removed mount point successfully")
-		}
-	}
-	return err
-}
-
 func (m *wekafsMount) ensureLocalContainerName(ctx context.Context, apiClient *apiclient.ApiClient) error {
-	logger := log.Ctx(ctx).With().Str("mount_point", m.getMountPoint()).Str("filesystem", m.fsName).Logger()
+	logger := log.Ctx(ctx).With().Str("filesystem", m.fsName).Logger()
 
 	// already set
 	if m.containerName != "" {
@@ -161,12 +89,18 @@ func (m *wekafsMount) ensureLocalContainerName(ctx context.Context, apiClient *a
 	if m.containerName, err = apiClient.EnsureLocalContainer(ctx, m.allowProtocolContainers); err != nil {
 		logger.Error().Err(err).Msg("Failed to ensure local container")
 	}
+	m.mountOptions.AddOption(fmt.Sprintf("container_name=%s", m.containerName))
 	return nil
 }
 
 func (m *wekafsMount) doMount(ctx context.Context, apiClient *apiclient.ApiClient, mountOptions MountOptions) error {
 	logger := log.Ctx(ctx).With().Str("mount_point", m.getMountPoint()).Str("filesystem", m.fsName).Logger()
 	var mountOptionsSensitive []string
+	if apiClient == nil {
+		logger.Trace().Msg("No API client for mount, cannot proceed")
+		return errors.New("no api client bound, cannot obtain mount token")
+	}
+
 	if err := os.MkdirAll(m.getMountPoint(), DefaultVolumePermissions); err != nil {
 		return err
 	}
@@ -174,19 +108,13 @@ func (m *wekafsMount) doMount(ctx context.Context, apiClient *apiclient.ApiClien
 		logger.Error().Msg("WEKA is not running, cannot mount. Make sure WEKA client software is running on the host")
 		return errors.New("weka is not running, cannot mount")
 	}
-	if apiClient == nil {
-		return errors.New("no api client bound, cannot obtain mount token")
-	}
+
+	logger.Trace().Strs("mount_options", m.getMountOptions().Strings()).Msg("Performing mount")
 
 	if mountToken, err := apiClient.GetMountTokenForFilesystemName(ctx, m.fsName); err != nil {
 		return err
 	} else {
 		mountOptionsSensitive = append(mountOptionsSensitive, fmt.Sprintf("token=%s", mountToken))
-	}
-
-	// if needed, add containerName to the mount options
-	if m.containerName != "" {
-		mountOptions = mountOptions.AddOption(fmt.Sprintf("container_name=%s", m.containerName))
 	}
 
 	logger.Trace().Strs("mount_options", mountOptions.Strings()).Msg("Performing mount")


### PR DESCRIPTION
### TL;DR

Refactored mount handling code to reduce duplication between NFS and WekaFS implementations by extracting common functionality into shared methods.

### What changed?

- Created new files `anymount.go` and `anymounter.go` with shared mount handling logic
- Implemented a thread-safe `mountMap` structure to track mount references
- Extracted common mount/unmount functionality into shared methods like `anyMountIncref`, `anyMountDecRef`, and `anyMountDoUnmount`
- Updated `PathIsWekaMount` to remove unnecessary context parameter
- Standardized interfaces for mount operations across different transport types
- Fixed container name handling in WekaFS mounts
- Improved error handling and logging in mount operations

### How to test?

1. Test mounting and unmounting volumes using both NFS and WekaFS transports
2. Verify reference counting works correctly by mounting the same volume multiple times
3. Check that mount points are properly cleaned up after unmounting
4. Verify SELinux support is correctly detected and applied to mount options

### Why make this change?

The previous implementation had significant code duplication between the NFS and WekaFS mount handlers. This refactoring improves code maintainability by centralizing common functionality, making it easier to add new transport types in the future while ensuring consistent behavior across all mount types. The thread-safe mount map implementation also improves reliability in concurrent scenarios.