### PR TITLE
fix: readiness probe might fail under load due to too small max concurrency of GRPC server

### DIFF
--- a/charts/csi-wekafsplugin/values.yaml
+++ b/charts/csi-wekafsplugin/values.yaml
@@ -50,7 +50,7 @@ machineConfigLabels:
 controller:
   # -- Controller number of replicas
   replicas: 2
-  # -- Maximum concurrent requests from sidecars (global)
+  # -- Maximum concurrent requests from sidecars (for each sidecar)
   maxConcurrentRequests: 25
   # -- maximum concurrent operations per operation type
   concurrency:

--- a/cmd/metricsserver/main.go
+++ b/cmd/metricsserver/main.go
@@ -95,8 +95,9 @@ func main() {
 			http.Handle("/metrics", promhttp.Handler())
 			if err := http.ListenAndServe(fmt.Sprintf(":%s", *metricsPort), nil); err != nil {
 				log.Error().Str("metrics_port", *metricsPort).Err(err).Msg("Failed to start metrics service")
+			} else {
+				log.Debug().Str("metrics_port", *metricsPort).Msg("Started metrics service")
 			}
-			log.Debug().Str("metrics_port", *metricsPort).Msg("Started metrics service")
 		}()
 	}
 

--- a/pkg/wekafs/driver.go
+++ b/pkg/wekafs/driver.go
@@ -125,7 +125,7 @@ func (driver *WekaFsDriver) Run(ctx context.Context) {
 		driver.ms.Start(ctx)
 	}
 
-	s := NewNonBlockingGRPCServer(driver.csiMode)
+	s := NewNonBlockingGRPCServer(driver.csiMode, driver.config)
 
 	termContext, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
 	defer stop()
@@ -283,9 +283,10 @@ func (d *WekaFsDriver) initManager(ctx context.Context) {
 				log.Error().Err(err).Msg("Failed to create config from kubeconfig file")
 				return
 			}
+		} else {
+			logger.Error().Err(err).Msg("Failed to create K8s API config")
+			return
 		}
-		logger.Error().Err(err).Msg("Failed to create K8s API config")
-		return
 	}
 
 	scheme := runtime.NewScheme()

--- a/pkg/wekafs/metricsserver.go
+++ b/pkg/wekafs/metricsserver.go
@@ -1092,6 +1092,7 @@ func (ms *MetricsServer) Start(ctx context.Context) {
 	logger := log.Ctx(ctx)
 	logger.Info().Msg("Starting MetricsServer")
 	ms.Lock()
+
 	if ms.running {
 		return // Already running
 	}


### PR DESCRIPTION
### TL;DR

Updated the description of `maxConcurrentRequests` parameter and implemented dynamic calculation of gRPC server's `MaxConcurrentStreams`.

### What changed?

- Clarified the description of `maxConcurrentRequests` in the Helm chart values file to indicate it applies "for each sidecar" rather than "global"
- Added logic to dynamically calculate the appropriate value for `MaxConcurrentStreams` in the gRPC server options:
  - Sums all maximum concurrency values per operation
  - Doubles the result to provide extra capacity for liveness probes and other operations
  - Sets a minimum value of 256 if the calculated value is lower

### How to test?

1. Deploy the CSI plugin with various concurrency settings
2. Verify that the gRPC server correctly handles the expected number of concurrent requests
3. Check that under high load, the server properly manages request concurrency according to the configured limits

### Why make this change?

This change improves the server's ability to handle concurrent requests by dynamically setting the `MaxConcurrentStreams` parameter based on the actual concurrency configuration. The previous implementation didn't properly account for the total number of potential concurrent operations, which could lead to connection issues under high load. The updated parameter description also provides clearer guidance to users configuring the Helm chart.