### PR TITLE
fix: add namespace to controller Role

### DIFF
--- a/charts/csi-wekafsplugin/templates/controllerserver-role.yaml
+++ b/charts/csi-wekafsplugin/templates/controllerserver-role.yaml
@@ -2,6 +2,7 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ .Release.Name }}-controller
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Release.Name }}-controller
     component: {{ .Release.Name }}-controller


### PR DESCRIPTION
This commit addresses an issue where the Role for the controller server was not consistently created in the intended release namespace.

The metadata.namespace field was missing in controllerserver-role.yaml. This  could lead to the Role being created in the default namespace of the user  running Helm, rather than the one specified for the release via the -n flag.

By adding namespace: {{ .Release.Namespace }}, we ensure the Role is always  created in the correct namespace, allowing the RoleBinding to properly  associate the ServiceAccount with its required permissions.