### PR TITLE
fix: skip disconnected containers when parsing proc/wekafs/interface

### DIFF
--- a/pkg/wekafs/apiclient/cluster.go
+++ b/pkg/wekafs/apiclient/cluster.go
@@ -5,15 +5,16 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/google/uuid"
-	"github.com/rs/zerolog/log"
-	"golang.org/x/exp/slices"
-	"k8s.io/apimachinery/pkg/util/rand"
 	"net"
 	"os"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/google/uuid"
+	"github.com/rs/zerolog/log"
+	"golang.org/x/exp/slices"
+	"k8s.io/apimachinery/pkg/util/rand"
 )
 
 const ApiPathLogin = "login"
@@ -353,7 +354,7 @@ func (a *ApiClient) getLocalContainersFromDriver(ctx context.Context) ([]ProcFsC
 		if len(line) == 0 {
 			continue
 		}
-		if !strings.Contains(line, "Container=") {
+		if !strings.Contains(line, "Container=") || strings.Contains(line, "not connected") {
 			continue
 		}
 		logger.Trace().Str("line", line).Msg("Found line in proc fs")

--- a/pkg/wekafs/driver.go
+++ b/pkg/wekafs/driver.go
@@ -4,6 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
 	"github.com/go-logr/zerologr"
 	"github.com/rs/zerolog/log"
 	v1 "k8s.io/api/core/v1"
@@ -13,11 +17,8 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
-	"os"
-	"os/signal"
 	ctrl "sigs.k8s.io/controller-runtime"
 	clog "sigs.k8s.io/controller-runtime/pkg/log"
-	"syscall"
 )
 
 type WekaFsDriver struct {
@@ -66,7 +67,7 @@ func NewWekaFsDriver(
 
 	log.Info().Msg(fmt.Sprintf("csiMode: %s", csiMode))
 	config.Log()
-
+	
 	return &WekaFsDriver{
 		name:              driverName,
 		nodeID:            nodeID,


### PR DESCRIPTION
### TL;DR

Skip containers that are not connected when parsing local containers from the driver.

### What changed?

Modified the container parsing logic in `getLocalContainersFromDriver` to filter out containers that are marked as "not connected". Previously, the function would only check if a line contains "Container=" but now it also excludes lines that contain "not connected".

### How to test?

1. Run the code in an environment where some Weka containers are in a "not connected" state
2. Verify that these containers are properly excluded from the results
3. Confirm that normal, connected containers are still properly detected

### Why make this change?

This change prevents the system from attempting to use containers that are in a "not connected" state, which could lead to failed operations or errors when trying to interact with these unavailable containers. This improves the reliability of the container discovery process.