### PR TITLE
fix: add controller missing priority class set and controller and node requests and limits config

### DIFF
--- a/.github/workflows/sanity.yaml
+++ b/.github/workflows/sanity.yaml
@@ -47,6 +47,8 @@ jobs:
     runs-on: self-hosted
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: Cleanup any existing containers
+        run: docker-compose -f tests/csi-sanity/docker-compose-nosnapshotcaps.yaml down -v 2>/dev/null || true
       - run: docker-compose -f tests/csi-sanity/docker-compose-nosnapshotcaps.yaml up $COMPOSE_DEFAULTS
         env:
           SANITY_FUNCTION: legacy_sanity
@@ -56,6 +58,8 @@ jobs:
     runs-on: self-hosted
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: Cleanup any existing containers
+        run: docker-compose -f tests/csi-sanity/docker-compose-snapshotcaps.yaml down -v 2>/dev/null || true
       - run: docker-compose -f tests/csi-sanity/docker-compose-snapshotcaps.yaml up $COMPOSE_DEFAULTS
         env:
           SANITY_FUNCTION: directory_volume_and_snapshots
@@ -65,6 +69,8 @@ jobs:
     runs-on: self-hosted
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: Cleanup any existing containers
+        run: docker-compose -f tests/csi-sanity/docker-compose-nfs-snapshotcaps.yaml down -v 2>/dev/null || true
       - run: docker-compose -f tests/csi-sanity/docker-compose-nfs-snapshotcaps.yaml up $COMPOSE_DEFAULTS
         env:
           SANITY_FUNCTION: directory_volume_and_snapshots_nfs
@@ -74,6 +80,8 @@ jobs:
     runs-on: self-hosted
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: Cleanup any existing containers
+        run: docker-compose -f tests/csi-sanity/docker-compose-snapshotcaps.yaml down -v 2>/dev/null || true
       - run: docker-compose -f tests/csi-sanity/docker-compose-snapshotcaps.yaml up $COMPOSE_DEFAULTS
         env:
           SANITY_FUNCTION: snaphot_volumes_with_2nd_level_shapshots
@@ -83,6 +91,8 @@ jobs:
     runs-on: self-hosted
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: Cleanup any existing containers
+        run: docker-compose -f tests/csi-sanity/docker-compose-nfs-snapshotcaps.yaml down -v 2>/dev/null || true
       - run: docker-compose -f tests/csi-sanity/docker-compose-nfs-snapshotcaps.yaml up $COMPOSE_DEFAULTS
         env:
           SANITY_FUNCTION: snaphot_volumes_with_2nd_level_shapshots_nfs
@@ -92,6 +102,8 @@ jobs:
     runs-on: self-hosted
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: Cleanup any existing containers
+        run: docker-compose -f tests/csi-sanity/docker-compose-snapshotcaps.yaml down -v 2>/dev/null || true
       - run: docker-compose -f tests/csi-sanity/docker-compose-snapshotcaps.yaml up $COMPOSE_DEFAULTS
         env:
           SANITY_FUNCTION: filesystem_volumes
@@ -101,6 +113,8 @@ jobs:
     runs-on: self-hosted
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: Cleanup any existing containers
+        run: docker-compose -f tests/csi-sanity/docker-compose-nfs-snapshotcaps.yaml down -v 2>/dev/null || true
       - run: docker-compose -f tests/csi-sanity/docker-compose-nfs-snapshotcaps.yaml up $COMPOSE_DEFAULTS
         env:
           SANITY_FUNCTION: filesystem_volumes_nfs

--- a/charts/csi-wekafsplugin/templates/controllerserver-deployment.yaml
+++ b/charts/csi-wekafsplugin/templates/controllerserver-deployment.yaml
@@ -46,6 +46,9 @@ spec:
         {{- toYaml $nodeSelector | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ .Release.Name }}-controller
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+      {{- end }}
       {{- if or .Values.hostNetwork .Values.pluginConfig.mountProtocol.useNfs .Values.pluginConfig.mountProtocol.allowNfsFailback}}
       hostNetwork: true
       {{- end }}
@@ -190,6 +193,10 @@ spec:
               name: legacy-volume-access
               readOnly: true
             {{- end }}
+          {{- if .Values.controller.resources.wekafs }}
+          resources:
+            {{- toYaml .Values.controller.resources.wekafs | nindent 12 }}
+          {{- end }}
         - name: csi-attacher
           image: {{ required "csi attacher sidercar image." .Values.images.attachersidecar }}
           securityContext:
@@ -221,6 +228,10 @@ spec:
             - containerPort: {{ .Values.metrics.attacherPort | default 9095 }}
               name: pr-metrics
               protocol: TCP
+          {{- end }}
+          {{- if .Values.controller.resources.csiAttacher }}
+          resources:
+            {{- toYaml .Values.controller.resources.csiAttacher | nindent 12 }}
           {{- end }}
         - name: csi-provisioner
           {{- if and .Values.hostNetwork (.Capabilities.APIVersions.Has "security.openshift.io/v1/SecurityContextConstraints") }}
@@ -259,6 +270,10 @@ spec:
             - containerPort: {{ .Values.metrics.provisionerPort }}
               name: pr-metrics
               protocol: TCP
+          {{- if .Values.controller.resources.csiProvisioner }}
+          resources:
+            {{- toYaml .Values.controller.resources.csiProvisioner | nindent 12 }}
+          {{- end }}
         - name: csi-resizer
           {{- if and .Values.hostNetwork (.Capabilities.APIVersions.Has "security.openshift.io/v1/SecurityContextConstraints") }}
           securityContext:
@@ -294,6 +309,10 @@ spec:
             - containerPort: {{ .Values.metrics.resizerPort }}
               name: rs-metrics
               protocol: TCP
+          {{- if .Values.controller.resources.csiResizer }}
+          resources:
+            {{- toYaml .Values.controller.resources.csiResizer | nindent 12 }}
+          {{- end }}
         - name: csi-snapshotter
           {{- if and .Values.hostNetwork (.Capabilities.APIVersions.Has "security.openshift.io/v1/SecurityContextConstraints") }}
           securityContext:
@@ -330,7 +349,10 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
-
+          {{- if .Values.controller.resources.csiSnapshotter }}
+          resources:
+            {{- toYaml .Values.controller.resources.csiSnapshotter | nindent 12 }}
+          {{- end }}
         - name: liveness-probe
           volumeMounts:
             - mountPath: /csi
@@ -345,6 +367,10 @@ spec:
               value: unix:///csi/csi.sock
             - name: HEALTH_PORT
               value: "9898"
+          {{- if .Values.controller.resources.livenessProbe }}
+          resources:
+            {{- toYaml .Values.controller.resources.livenessProbe | nindent 12 }}
+          {{- end }}
       {{- with .Values.controllerPluginTolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/charts/csi-wekafsplugin/templates/nodeserver-daemonset.yaml
+++ b/charts/csi-wekafsplugin/templates/nodeserver-daemonset.yaml
@@ -173,6 +173,10 @@ spec:
             - mountPath: /etc/selinux/config
               name: selinux-config
             {{- end }}
+          {{- if .Values.node.resources.wekafs }}
+          resources:
+            {{- toYaml .Values.node.resources.wekafs | nindent 12 }}
+          {{- end }}
         - name: liveness-probe
           volumeMounts:
             - mountPath: /csi
@@ -187,7 +191,10 @@ spec:
               value: unix:///csi/csi.sock
             - name: HEALTH_PORT
               value: "9899"
-
+          {{- if .Values.node.resources.livenessProbe }}
+          resources:
+            {{- toYaml .Values.node.resources.livenessProbe | nindent 12 }}
+          {{- end }}
         - name: csi-registrar
           image: {{ required "Provide the csi node registrar sidecar container image." .Values.images.registrarsidecar }}
           args:
@@ -220,6 +227,10 @@ spec:
               name: registration-dir
             - mountPath: /var/lib/csi-wekafs-data
               name: csi-data-dir
+          {{- if .Values.node.resources.csiRegistrar }}
+          resources:
+            {{- toYaml .Values.node.resources.csiRegistrar | nindent 12 }}
+          {{- end }}
       {{- with .Values.nodePluginTolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/charts/csi-wekafsplugin/values.yaml
+++ b/charts/csi-wekafsplugin/values.yaml
@@ -79,6 +79,50 @@ controller:
   podLabels: {}
   # -- termination grace period for controller pods
   terminationGracePeriodSeconds: 10
+  # -- resource requests and limits for controller containers
+  resources:
+    wekafs:
+      limits:
+        cpu: 8m
+        memory: 64Mi
+      requests:
+        cpu: 2m
+        memory: 16Mi
+    csiAttacher:
+      limits:
+        cpu: 4m
+        memory: 48Mi
+      requests:
+        cpu: 1m
+        memory: 12Mi
+    csiProvisioner:
+      limits:
+        cpu: 8m
+        memory: 48Mi
+      requests:
+        cpu: 2m
+        memory: 12Mi
+    csiResizer:
+      limits:
+        cpu: 4m
+        memory: 48Mi
+      requests:
+        cpu: 1m
+        memory: 12Mi
+    csiSnapshotter:
+      limits:
+        cpu: 4m
+        memory: 48Mi
+      requests:
+        cpu: 1m
+        memory: 12Mi
+    livenessProbe:
+      limits:
+        cpu: 12m
+        memory: 48Mi
+      requests:
+        cpu: 3m
+        memory: 12Mi
 # Node-specific parameters, please do not change unless explicitly guided
 node:
   # -- Maximum concurrent requests from sidecars (global)
@@ -99,6 +143,29 @@ node:
   podLabels: {}
   # -- termination grace period for node pods
   terminationGracePeriodSeconds: 10
+  # -- resource requests and limits for node containers
+  resources:
+    wekafs:
+      limits:
+        cpu: 8m
+        memory: 160Mi
+      requests:
+        cpu: 2m
+        memory: 40Mi
+    livenessProbe:
+      limits:
+        cpu: 12m
+        memory: 44Mi
+      requests:
+        cpu: 3m
+        memory: 11Mi
+    csiRegistrar:
+      limits:
+        cpu: 8m
+        memory: 52Mi
+      requests:
+        cpu: 2m
+        memory: 13Mi
 # -- Log level of CSI plugin
 logLevel: 5
 # -- Use JSON structured logging instead of human-readable logging format (for exporting logs to structured log parser)

--- a/charts/csi-wekafsplugin/values.yaml
+++ b/charts/csi-wekafsplugin/values.yaml
@@ -83,46 +83,46 @@ controller:
   resources:
     wekafs:
       limits:
-        cpu: 8m
-        memory: 64Mi
+        cpu: 1
+        memory: 2Gi
       requests:
-        cpu: 2m
-        memory: 16Mi
+        cpu: 128m
+        memory: 128Mi
     csiAttacher:
       limits:
+        cpu: 1
+        memory: 1Gi
+      requests:
         cpu: 4m
         memory: 48Mi
-      requests:
-        cpu: 1m
-        memory: 12Mi
     csiProvisioner:
       limits:
-        cpu: 8m
-        memory: 48Mi
+        cpu: 1
+        memory: 2Gi
       requests:
-        cpu: 2m
-        memory: 12Mi
+        cpu: 128m
+        memory: 128Mi
     csiResizer:
       limits:
+        cpu: 1
+        memory: 1Gi
+      requests:
         cpu: 4m
         memory: 48Mi
-      requests:
-        cpu: 1m
-        memory: 12Mi
     csiSnapshotter:
       limits:
+        cpu: 1
+        memory: 1Gi
+      requests:
         cpu: 4m
         memory: 48Mi
-      requests:
-        cpu: 1m
-        memory: 12Mi
     livenessProbe:
       limits:
+        cpu: 1
+        memory: 1Gi
+      requests:
         cpu: 12m
         memory: 48Mi
-      requests:
-        cpu: 3m
-        memory: 12Mi
 # Node-specific parameters, please do not change unless explicitly guided
 node:
   # -- Maximum concurrent requests from sidecars (global)
@@ -147,25 +147,25 @@ node:
   resources:
     wekafs:
       limits:
-        cpu: 8m
-        memory: 160Mi
+        cpu: 1
+        memory: 2Gi
       requests:
-        cpu: 2m
-        memory: 40Mi
+        cpu: 128m
+        memory: 128Mi
     livenessProbe:
       limits:
+        cpu: 1
+        memory: 1Gi
+      requests:
         cpu: 12m
         memory: 44Mi
-      requests:
-        cpu: 3m
-        memory: 11Mi
     csiRegistrar:
       limits:
+        cpu: 1
+        memory: 1Gi
+      requests:
         cpu: 8m
         memory: 52Mi
-      requests:
-        cpu: 2m
-        memory: 13Mi
 # -- Log level of CSI plugin
 logLevel: 5
 # -- Use JSON structured logging instead of human-readable logging format (for exporting logs to structured log parser)


### PR DESCRIPTION
Default request values in the PR are taken from current longevity csi pods values and limits is 4x

```
│ M1    wekafs          ●  quay.io/weka.io/csi-wekafs:v2.7.7                              true  Running         0 on:off:off      2    0:0    n/a    n/a  40    0:0    n/a    n/a :0 │
│ M2    liveness-probe  ●  registry.k8s.io/sig-storage/livenessprobe:v2.16.0              true  Running         0 off:off:off     3    0:0    n/a    n/a  11    0:0    n/a    n/a :0 │
│ M3    csi-registrar   ●  registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.14.0  true  Running         0 on:off:off      2    0:0    n/a    n/a  13    0:0    n/a    n/a :0 │





[4:11](https://wekaio.slack.com/archives/DLU8PEDD3/p1761833461144309)
│ M1    wekafs           ●  quay.io/weka.io/csi-wekafs:v2.7.7                   true  Running        41 on:off:off      2    0:0    n/a    n/a  16    0:0    n/a    n/a    0:0 healt │
│ M2    csi-attacher     ●  registry.k8s.io/sig-storage/csi-attacher:v4.9.0     true  Running        15 on:off:off      1    0:0    n/a    n/a  12    0:0    n/a    n/a    0:0 pr-me │
│ M3    csi-provisioner  ●  registry.k8s.io/sig-storage/csi-provisioner:v5.3.0  true  Running        15 on:off:off      2    0:0    n/a    n/a  12    0:0    n/a    n/a    0:0 pr-me │
│ M4    csi-resizer      ●  registry.k8s.io/sig-storage/csi-resizer:v1.14.0     true  Running        15 on:off:off      1    0:0    n/a    n/a  12    0:0    n/a    n/a    0:0 rs-me │
│ M5    csi-snapshotter  ●  registry.k8s.io/sig-storage/csi-snapshotter:v8.3.0  true  Running        15 on:off:off      1    0:0    n/a    n/a  12    0:0    n/a    n/a    0:0 sn-me │
│ M6    liveness-probe   ●  registry.k8s.io/sig-storage/livenessprobe:v2.16.0   true  Running         1 off:off:off     3    0:0    n/a    n/a  12    0:0    n/a    n/a    0:0       │
````