### PR TITLE
feat(CSI-316): support per-filesystem encryption with custom KMS settings

### DIFF
--- a/examples/dynamic_filesystem_encryption_key_in_secret/README.md
+++ b/examples/dynamic_filesystem_encryption_key_in_secret/README.md
@@ -1,0 +1,47 @@
+# Overview
+This example demonstrates how to create a Weka Filesystem-backed volume with encryption enabled, where the encryption key is stored in a Kubernetes secret. 
+This allows for encryption of filesystem-backed volumes with custom set of encryption keys.
+Only HashiCorp Vault KMS servers are supported for this configuration.
+
+## Example Intentions
+1. This example concentrates on Weka Filesystem-backed volume backed by Encrypted filesystem
+2. Filesystem is provisioned automatically when volume is created, and encryption is enabled for the filesystem
+3. The encryption is stored in a Kubernetes secret, which is referenced in the StorageClass
+
+## Configuration Requirements
+This example introduces automatic provisioning of encrypted filesystems. 
+For this functionality to work, the WEKA cluster must be configured with a valid KMS server.
+If KMS server is not configured, volume will fail to create with error stating:
+```
+Encryption is not enabled on the cluster
+```
+If WEKA cluster does not support encryption with per-filesystem keys, the following error will be displayed:
+```
+Encryption is not supported on the cluster
+```
+
+> **NOTE:** Encryption is supported only for filesystem-backed volumes, 
+>   since only a whole WEKA filesystem can be encrypted.
+>   When trying to create encrypted volumes of other backing types, 
+>   the plugin will check state of encryption of the underlying filesystem 
+>   and fail if it is not encrypted.
+
+## StorageClass Highlights
+- Refer to highlights described in [../dynamic_filesystem/storageclass-wekafs-api.yaml]
+- Storage class includes a parameter `parameters.encryption` that defines whether the filesystem should be encrypted or not. This is a string and not boolean
+    - `true` - filesystem is encrypted using WEKA-managed encryption keys.
+    - `false` - filesystem is not encrypted
+
+## Notes regarding object deletion:
+1. Filesystem-backed volume maps directly to Weka filesystem. 
+2. Filesystem is encrypted
+3. Encryption key is stored in a KMS server
+4. The encryption key identifier, KMS namespace, role ID and secret ID must be specified in the API secret
+
+
+# Workflow
+> All commands below may be executed by `kubectl apply -f <FILE>.yaml`
+1. Create storageclass `storageclass-wekafs-fs-encryption-key-in-secret`
+2. Create CSI secret `csi-wekafs-api-secret-kms-encryption-key-in-secret` 
+3. Provision a new filesystem volume `pvc-wekafs-fs-encryption-key-in-secret`
+4. Create a pod `csi-app-on-fs-encryption-key-in-secret` that uses the volume

--- a/examples/dynamic_filesystem_encryption_key_in_secret/csi-app-on-fs-encryption-key-in-secret.yaml
+++ b/examples/dynamic_filesystem_encryption_key_in_secret/csi-app-on-fs-encryption-key-in-secret.yaml
@@ -1,0 +1,17 @@
+kind: Pod
+apiVersion: v1
+metadata:
+  name: csi-app-on-fs-encryption-key-in-secret
+spec:
+  containers:
+    - name: my-frontend
+      image: ubuntu
+      volumeMounts:
+      - mountPath: "/data"
+        name: my-csi-volume
+      command: ["/bin/sh"]
+      args: ["-c", "while true; do echo `date` hello >> /data/temp.txt; sleep 10;done"]
+  volumes:
+    - name: my-csi-volume
+      persistentVolumeClaim:
+        claimName: pvc-wekafs-fs-encryption-key-in-secret

--- a/examples/dynamic_filesystem_encryption_key_in_secret/csi-wekafs-api-secret-kms-encryption-key-in-secret.yaml
+++ b/examples/dynamic_filesystem_encryption_key_in_secret/csi-wekafs-api-secret-kms-encryption-key-in-secret.yaml
@@ -1,0 +1,49 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: csi-wekafs-api-secret-kms-encryption-key-in-secret
+  namespace: csi-wekafs
+type: Opaque
+data:
+  # username to connect to the cluster API (base64-encoded)
+  username: YWRtaW4=
+  # password to connect to the cluster API (base64-encoded)
+  password: YWRtaW4=
+  # organization to connect to (default Root, base64-encoded)
+  organization: Um9vdA==
+  # comma-separated list of cluster management endpoints in form of <IP:port> (base64-encoded)
+  # It is recommended to configure at least 2 management endpoints (cluster backend nodes), or a load-balancer if used
+  # e.g. 172.31.15.113:14000,172.31.12.91:14000
+  endpoints: MTcyLjMxLjQxLjU0OjE0MDAwLDE3Mi4zMS40Ny4xNTI6MTQwMDAsMTcyLjMxLjM4LjI1MDoxNDAwMCwxNzIuMzEuNDcuMTU1OjE0MDAwLDE3Mi4zMS4zMy45MToxNDAwMCwxNzIuMzEuMzguMTU1OjE0MDAwCg==
+  # protocol to use for API connection (either http or https, base64-encoded. NOTE: since Weka 4.3.0, HTTPS is mandatory)
+  scheme: aHR0cA==
+  # for multiple clusters setup, set specific container name rather than attempt to identify it automatically
+  localContainerName: ""
+  # for cloud deployments with automatic healing and auto-scaling, set to "true" to enable automatic updates of the endpoints.
+  # The API endpoints will be updated automatically on first connection to the cluster API, as well as on each re-login
+  # maybe either (true/false), base64-encoded
+  # NOTE: if a load balancer is used to access the cluster API, leave this setting as "false"
+  autoUpdateEndpoints: ZmFsc2U=
+  # It is recommended to configure all NFS server IP addresses to better share the load/balance the traffic.
+  # NOTE: this setting is optional and should be used only when the NFS Group IP addresses are not set in the cluster
+  # WARNING: providing a load balancer IP address that uses NFS connection redirects (also known as `referrals`) to other servers is not supported.
+  # e.g. 10.100.100.1,10.100.100.2
+  nfsTargetIps: ""
+  # When using HTTPS connection and self-signed or untrusted certificates, provide a CA certificate in PEM format, base64-encoded
+  # for cloud deployments or other scenarios where setting an NFS Group IP addresses is not possible,
+  # provide a comma-separated list of NFS target IP addresses in form of <IP> (base64-encoded)
+  # caCertificate: <base64-encoded-PEM>
+  caCertificate: ""
+
+  # namespace where the keys for encrypting filesystems are located. If not specified, a default namespace is used.
+  # WARNING: this is not the namespace for the CSI plugin to create new secrets in the KMS, but the place the role and secret for encrypting filesystems are located
+  kmsVaultNamespaceForFilesystemEncryption: ""
+  # key identifier to be used for encrypting filesystems.
+  # WARNING: this is not the key identifier to be used by the CSI plugin to create new secrets in the KMS, but the key identifier for encrypting filesystems
+  kmsVaultKeyIdentifierForFilesystemEncryption: ""
+  # role ID for the filesystems encryption to be passed as is to filesystem create request for encrypted filesystem-backed volumes
+  # WARNING: this is not the role for the CSI plugin to create new secrets in the KMS, but the secret to use for encrypting filesystems
+  kmsVaultRoleIdForFilesystemEncryption: ""
+  # secret ID for the filesystems encryption to be passed as is to filesystem create request for encrypted filesystem-backed volumes
+  # WARNING: this is not the secret for the CSI plugin to create new secrets in the KMS, but the secret to use for encrypting filesystems
+  kmsVaultSecretIdForFilesystemEncryption: ""

--- a/examples/dynamic_filesystem_encryption_key_in_secret/pvc-wekafs-fs-encryption-key-in-secret.yaml
+++ b/examples/dynamic_filesystem_encryption_key_in_secret/pvc-wekafs-fs-encryption-key-in-secret.yaml
@@ -1,0 +1,12 @@
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: pvc-wekafs-fs-encryption-key-in-secret
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: storageclass-wekafs-fs-encryption-key-in-secret
+  volumeMode: Filesystem
+  resources:
+    requests:
+      storage: 1Gi

--- a/examples/dynamic_filesystem_encryption_key_in_secret/storageclass-wekafs-fs-encryption-key-in-secret.yaml
+++ b/examples/dynamic_filesystem_encryption_key_in_secret/storageclass-wekafs-fs-encryption-key-in-secret.yaml
@@ -1,0 +1,30 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: storageclass-wekafs-fs-encryption-key-in-secret
+provisioner: csi.weka.io
+reclaimPolicy: Delete
+volumeBindingMode: Immediate
+allowVolumeExpansion: true
+parameters:
+  volumeType: weka/v2  # this line can be ommitted completely
+  # encrypt the filesystems created by the CSI plugin
+  encryptionEnabled: "true"
+  # name of the filesystem group to create FS in.
+  filesystemGroupName: default
+  # minimum size of filesystem to create (preallocate space for snapshots and derived volumes)
+  initialFilesystemSizeGB: "100"
+  # name of the secret that stores API credentials for a cluster
+  # change the name of secret to match secret of a particular cluster (if you have several Weka clusters)
+  csi.storage.k8s.io/provisioner-secret-name: &secretName csi-wekafs-api-secret-kms-encryption-key-in-secret
+  # change the name of the namespace in which the cluster API credentials
+  csi.storage.k8s.io/provisioner-secret-namespace: &secretNamespace csi-wekafs
+  # do not change anything below this line, or set to same parameters as above
+  csi.storage.k8s.io/controller-publish-secret-name: *secretName
+  csi.storage.k8s.io/controller-publish-secret-namespace: *secretNamespace
+  csi.storage.k8s.io/controller-expand-secret-name: *secretName
+  csi.storage.k8s.io/controller-expand-secret-namespace: *secretNamespace
+  csi.storage.k8s.io/node-stage-secret-name: *secretName
+  csi.storage.k8s.io/node-stage-secret-namespace: *secretNamespace
+  csi.storage.k8s.io/node-publish-secret-name: *secretName
+  csi.storage.k8s.io/node-publish-secret-namespace: *secretNamespace

--- a/pkg/wekafs/apiclient/apiclient.go
+++ b/pkg/wekafs/apiclient/apiclient.go
@@ -171,6 +171,8 @@ func (a *ApiClient) generateHash() uint32 {
 		a.Credentials.NfsTargetIPs,
 		a.Credentials.LocalContainerName,
 		a.Credentials.CaCertificate,
+		a.Credentials.KmsPreexistingCredentialsForVolumeEncryption.InsecureString(),
+		a.Credentials.KmsKeyManagementCredentials.InsecureString(),
 	)
 	_, _ = h.Write([]byte(s))
 	return h.Sum32()

--- a/pkg/wekafs/apiclient/credentials.go
+++ b/pkg/wekafs/apiclient/credentials.go
@@ -2,16 +2,35 @@ package apiclient
 
 import "fmt"
 
+type KmsVaultCredentials struct {
+	KeyIdentifier string
+	Namespace     string
+	RoleId        string
+	SecretId      string
+	Url           string
+}
+
+// InsecureString returns a string representation of the KmsVaultCredentials. Since very unsafe to print the values even by mistake, we do not call it String()
+func (k *KmsVaultCredentials) InsecureString() string {
+	if k == nil {
+		return ""
+	}
+	return fmt.Sprintf("KmsVaultCredentials(KeyIdentifier: %s, Namespace: %s, RoleId: %s, SecretId: %s, Url: %s)",
+		k.KeyIdentifier, k.Namespace, k.RoleId, k.SecretId, k.Url)
+}
+
 type Credentials struct {
-	Username            string
-	Password            string
-	Organization        string
-	HttpScheme          string
-	Endpoints           []string
-	LocalContainerName  string
-	AutoUpdateEndpoints bool
-	CaCertificate       string
-	NfsTargetIPs        []string
+	Username                                     string
+	Password                                     string
+	Organization                                 string
+	HttpScheme                                   string
+	Endpoints                                    []string
+	LocalContainerName                           string
+	AutoUpdateEndpoints                          bool
+	CaCertificate                                string
+	NfsTargetIPs                                 []string
+	KmsPreexistingCredentialsForVolumeEncryption KmsVaultCredentials // those are used as is to pass to filesystem creation
+	KmsKeyManagementCredentials                  KmsVaultCredentials // those are used by the CSI plugin to connect to vault and create new credentials //TODO: not implemented
 }
 
 func (c *Credentials) String() string {

--- a/pkg/wekafs/apiclient/utils.go
+++ b/pkg/wekafs/apiclient/utils.go
@@ -222,6 +222,8 @@ func maskPayload(payload string) string {
 	masker.RegisterMaskField("access_token", "filled4")
 	masker.RegisterMaskField("mount_token", "filled4")
 	masker.RegisterMaskField("refresh_token", "filled4")
+	masker.RegisterMaskField("kms_vault_role_id", "filled4")
+	masker.RegisterMaskField("kms_vault_secret_id", "filled4")
 	var target any
 	err := json.Unmarshal([]byte(payload), &target)
 	if err != nil {

--- a/pkg/wekafs/volumeconstructors.go
+++ b/pkg/wekafs/volumeconstructors.go
@@ -100,6 +100,7 @@ func NewVolumeFromControllerCreateRequest(ctx context.Context, req *csi.CreateVo
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "Could not obtain volume parameters from request")
 	}
+	volume.enrichWithEncryptionParams(ctx)
 
 	volume.pruneUnsupportedMountOptions(ctx)
 

--- a/pkg/wekafs/wekafs.go
+++ b/pkg/wekafs/wekafs.go
@@ -140,6 +140,28 @@ func (api *ApiStore) fromSecrets(ctx context.Context, secrets map[string]string,
 		caCertificate = ""
 	}
 
+	preexistingVaultCreds := apiclient.KmsVaultCredentials{}
+
+	kmsVaultNamespaceForFilesystemEncryption, ok := secrets["kmsVaultNamespaceForFilesystemEncryption"]
+	if ok {
+		preexistingVaultCreds.Namespace = strings.TrimSpace(strings.TrimSuffix(kmsVaultNamespaceForFilesystemEncryption, "\n"))
+	}
+
+	kmsVaultKeyIdentifierForFilesystemEncryption, ok := secrets["kmsVaultKeyIdentifierForFilesystemEncryption"]
+	if ok {
+		preexistingVaultCreds.KeyIdentifier = strings.TrimSpace(strings.TrimSuffix(kmsVaultKeyIdentifierForFilesystemEncryption, "\n"))
+	}
+
+	kmsVaultRoleIdForFilesystemEncryption, ok := secrets["kmsVaultRoleIdForFilesystemEncryption"]
+	if ok {
+		preexistingVaultCreds.RoleId = strings.TrimSpace(strings.TrimSuffix(kmsVaultRoleIdForFilesystemEncryption, "\n"))
+	}
+
+	kmsVaultSecretIdForFilesystemEncryption, ok := secrets["kmsVaultSecretIdForFilesystemEncryption"]
+	if ok {
+		preexistingVaultCreds.SecretId = strings.TrimSpace(strings.TrimSuffix(kmsVaultSecretIdForFilesystemEncryption, "\n"))
+	}
+
 	credentials := apiclient.Credentials{
 		Username:            strings.TrimSpace(strings.TrimSuffix(secrets["username"], "\n")),
 		Password:            strings.TrimSuffix(secrets["password"], "\n"),
@@ -150,6 +172,7 @@ func (api *ApiStore) fromSecrets(ctx context.Context, secrets map[string]string,
 		AutoUpdateEndpoints: autoUpdateEndpoints,
 		CaCertificate:       caCertificate,
 		NfsTargetIPs:        nfsTargetIps,
+		KmsPreexistingCredentialsForVolumeEncryption: preexistingVaultCreds,
 	}
 	return api.fromCredentials(ctx, credentials, hostname)
 }


### PR DESCRIPTION
This feature extends the existing encryption support (CSI-315) by adding the ability to specify custom KMS credentials per filesystem, rather than using only the cluster-wide KMS configuration.

Key changes:
- Added KMS credential fields to Volume struct for per-filesystem encryption key management
- Extended ApiClient to support KMS credentials from secrets
- Added methods to enrich volumes with KMS credentials from API secrets
- Enhanced encryption parameter validation to support custom KMS settings
- Added support for reading KMS credentials (role_id, secret_id, namespace, key_identifier) from CSI secrets
- Improved isEncrypted() method to populate KMS params from existing filesystems
- Added masking for sensitive KMS fields in logs

New examples:
- Added dynamic_filesystem_encryption_key_in_secret example showing how to use per-filesystem encryption

This allows users to:
1. Use different KMS keys for different filesystems
2. Manage KMS credentials per StorageClass via Kubernetes secrets
3. Override cluster-wide KMS settings on a per-volume basis

Requirements:
- Weka cluster must support custom encryption settings
- KMS server must be configured to allow per-filesystem keys
- API secret must include KMS credentials in the expected format