### PR TITLE
fix: add driver-level container name configuration for multi-client-set deployments

### DIFF
--- a/charts/csi-wekafsplugin/templates/controllerserver-deployment.yaml
+++ b/charts/csi-wekafsplugin/templates/controllerserver-deployment.yaml
@@ -123,6 +123,9 @@ spec:
           {{- if .Values.pluginConfig.mountProtocol.nfsProtocolVersion }}
             - "--nfsprotocolversion={{ .Values.pluginConfig.mountProtocol.nfsProtocolVersion | toString}}"
           {{- end }}
+          {{- if .Values.pluginConfig.mountProtocol.wekafsContainerName }}
+            - "--wekafscontainername=$(WEKAFS_CONTAINER_NAME)"
+          {{- end }}
           {{- if (.Values.pluginConfig.skipGarbageCollection | default false) }}
             - "--skipgarbagecollection"
           {{- end }}
@@ -173,6 +176,10 @@ spec:
             {{- if .Values.tracingDeploymentIdentifier }}
             - name: OTEL_DEPLOYMENT_IDENTIFIER
               value: {{ .Values.tracingDeploymentIdentifier }}
+            {{- end }}
+            {{- if .Values.pluginConfig.mountProtocol.wekafsContainerName }}
+            - name: WEKAFS_CONTAINER_NAME
+              value: {{ .Values.pluginConfig.mountProtocol.wekafsContainerName }}
             {{- end }}
 
           volumeMounts:

--- a/charts/csi-wekafsplugin/templates/nodeserver-daemonset.yaml
+++ b/charts/csi-wekafsplugin/templates/nodeserver-daemonset.yaml
@@ -110,6 +110,9 @@ spec:
           {{- if .Values.pluginConfig.mountProtocol.nfsProtocolVersion }}
             - "--nfsprotocolversion={{ .Values.pluginConfig.mountProtocol.nfsProtocolVersion | toString}}"
           {{- end }}
+          {{- if .Values.pluginConfig.mountProtocol.wekafsContainerName }}
+            - "--wekafscontainername=$(WEKAFS_CONTAINER_NAME)"
+          {{- end }}
           {{- if .Values.pluginConfig.manageNodeTopologyLabels }}
             - "--managenodetopologylabels"
           {{- end }}
@@ -150,6 +153,10 @@ spec:
             {{- if .Values.tracingDeploymentIdentifier }}
             - name: OTEL_DEPLOYMENT_IDENTIFIER
               value: {{ .Values.tracingDeploymentIdentifier }}
+            {{- end }}
+            {{- if .Values.pluginConfig.mountProtocol.wekafsContainerName }}
+            - name: WEKAFS_CONTAINER_NAME
+              value: {{ .Values.pluginConfig.mountProtocol.wekafsContainerName }}
             {{- end }}
           volumeMounts:
             - mountPath: /csi

--- a/charts/csi-wekafsplugin/values.yaml
+++ b/charts/csi-wekafsplugin/values.yaml
@@ -260,6 +260,9 @@ pluginConfig:
     clientGroupName: ""
     # -- Specify NFS protocol version to use for mounting Weka filesystems. Default is "4.1", consult Weka documentation for supported versions
     nfsProtocolVersion: "4.1"
+    # -- Specify name of Weka container to use for mounting filesystems. If not set, container name will be auto-detected.
+    # -- NOTE: for multiple clusters setup, set specific container name rather than attempt to identify it automatically
+    wekafsContainerName: ""
   # -- Skip garbage collection of deleted directory-backed volume contents and only move them to trash. Default false
   skipGarbageCollection: false
   # -- Wait for WEKA filesystem / snapshot deletion before acknowledging the corresponding CSI volume deletion. Default false

--- a/cmd/wekafsplugin/main.go
+++ b/cmd/wekafsplugin/main.go
@@ -96,6 +96,7 @@ var (
 	interfaceGroupName                   = flag.String("interfacegroupname", "", "Name of the NFS interface group to use for mounting volumes")
 	clientGroupName                      = flag.String("clientgroupname", "", "Name of the NFS client group to use for managing NFS permissions")
 	nfsProtocolVersion                   = flag.String("nfsprotocolversion", "4.1", "NFS protocol version to use for mounting volumes")
+	wekafsContainerName                  = flag.String("wekafscontainername", "", "Name of the Weka container to use for mounting filesystems")
 	skipGarbageCollection                = flag.Bool("skipgarbagecollection", false, "Skip garbage collection of directory volumes data, only move to trash")
 	waitForObjectDeletion                = flag.Bool("waitforobjectdeletion", false, "Wait for object deletion before returning from DeleteVolume")
 	allowEncryptionWithoutKms            = flag.Bool("allowencryptionwithoutkms", false, "Allow encryption without KMS, for testing purposes only")
@@ -238,6 +239,7 @@ func handle(ctx context.Context) {
 		*allowEncryptionWithoutKms,
 		*tracingUrl,
 		*manageNodeTopologyLabels,
+		*wekafsContainerName,
 	)
 	driver, err := wekafs.NewWekaFsDriver(*driverName, *nodeID, *endpoint, *maxVolumesPerNode, version, *debugPath, csiMode, *selinuxSupport, config)
 	if err != nil {

--- a/pkg/wekafs/apiclient/cluster.go
+++ b/pkg/wekafs/apiclient/cluster.go
@@ -360,13 +360,18 @@ func GetLocalIpAddresses(ctx context.Context) ([]string, error) {
 	return ips, nil
 }
 
-func (a *ApiClient) EnsureLocalContainer(ctx context.Context, allowProtocolContainers bool) (string, error) {
+func (a *ApiClient) EnsureLocalContainer(ctx context.Context, allowProtocolContainers bool, configuredContainerName string) (string, error) {
 
-	// already have the container name set either via secret or via API call
+	// already have the container name set from previous call
 	if a.containerName != "" {
 		return a.containerName, nil
 	}
-	// if having a local container name set in secrets
+	// Priority 1: container name configured via driver flag (highest priority)
+	if configuredContainerName != "" {
+		a.containerName = configuredContainerName
+		return a.containerName, nil
+	}
+	// Priority 2: container name set in CSI secret (for backward compatibility)
 	if a.Credentials.LocalContainerName != "" {
 		a.containerName = a.Credentials.LocalContainerName
 		return a.containerName, nil

--- a/pkg/wekafs/driverconfig.go
+++ b/pkg/wekafs/driverconfig.go
@@ -45,6 +45,7 @@ type DriverConfig struct {
 	driverRef                        *WekaFsDriver
 	tracingUrl                       string
 	manageNodeTopologyLabels         bool
+	wekafsContainerName              string
 }
 
 func (dc *DriverConfig) Log() {
@@ -71,6 +72,7 @@ func (dc *DriverConfig) Log() {
 		Bool("wait_for_object_deletion", dc.waitForObjectDeletion).
 		Str("tracing_url", dc.tracingUrl).
 		Bool("manage_node_topology_labels", dc.manageNodeTopologyLabels).
+		Str("wekafs_container_name", dc.wekafsContainerName).
 		Msg("Starting driver with the following configuration")
 
 }
@@ -88,6 +90,7 @@ func NewDriverConfig(dynamicVolPath, VolumePrefix, SnapshotPrefix, SeedSnapshotP
 	allowEncryptionWithoutKms bool,
 	tracingUrl string,
 	manageNodeTopologyLabels bool,
+	wekafsContainerName string,
 ) *DriverConfig {
 
 	var MutuallyExclusiveMountOptions []mutuallyExclusiveMountOptionSet
@@ -138,6 +141,7 @@ func NewDriverConfig(dynamicVolPath, VolumePrefix, SnapshotPrefix, SeedSnapshotP
 		allowEncryptionWithoutKms:        allowEncryptionWithoutKms,
 		tracingUrl:                       tracingUrl,
 		manageNodeTopologyLabels:         manageNodeTopologyLabels,
+		wekafsContainerName:              wekafsContainerName,
 	}
 }
 

--- a/pkg/wekafs/volume_test.go
+++ b/pkg/wekafs/volume_test.go
@@ -3,9 +3,11 @@ package wekafs
 import (
 	"context"
 	"flag"
-	"github.com/stretchr/testify/assert"
-	"github.com/wekafs/csi-wekafs/pkg/wekafs/apiclient"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/wekafs/csi-wekafs/pkg/wekafs/apiclient"
 )
 
 func GetDriverForTest(t *testing.T) *WekaFsDriver {
@@ -17,7 +19,7 @@ func GetDriverForTest(t *testing.T) *WekaFsDriver {
 		true, true, mutuallyExclusive,
 		1, 1, 1, 1, 1, 1, 1, 10,
 		true, true, true, "", "", "4.1", "v1", false, false, true,
-		"", false)
+		"", false, "")
 	driver, err := NewWekaFsDriver("csi.weka.io", nodeId, "unix://tmp/csi.sock", 10, "v1.0", "", CsiModeAll, false, driverConfig)
 	if err != nil {
 		t.Fatalf("Failed to create new driver: %v", err)

--- a/pkg/wekafs/wekafsmount.go
+++ b/pkg/wekafs/wekafsmount.go
@@ -171,7 +171,11 @@ func (m *wekafsMount) ensureLocalContainerName(ctx context.Context, apiClient *a
 		return nil
 	}
 	var err error
-	if m.containerName, err = apiClient.EnsureLocalContainer(ctx, m.allowProtocolContainers); err != nil {
+	configuredContainerName := ""
+	if m.mounter.config != nil {
+		configuredContainerName = m.mounter.config.wekafsContainerName
+	}
+	if m.containerName, err = apiClient.EnsureLocalContainer(ctx, m.allowProtocolContainers, configuredContainerName); err != nil {
 		logger.Error().Err(err).Msg("Failed to ensure local container")
 	}
 	return nil

--- a/pkg/wekafs/wekafsmounter.go
+++ b/pkg/wekafs/wekafsmounter.go
@@ -22,6 +22,7 @@ type wekafsMounter struct {
 	selinuxSupport          *bool
 	gc                      *innerPathVolGc
 	allowProtocolContainers bool
+	config                  *DriverConfig
 }
 
 func (m *wekafsMounter) getGarbageCollector() *innerPathVolGc {
@@ -34,7 +35,7 @@ func newWekafsMounter(driver *WekaFsDriver) *wekafsMounter {
 		log.Debug().Msg("SELinux support is forced")
 		selinuxSupport = &[]bool{true}[0]
 	}
-	mounter := &wekafsMounter{mountMap: wekafsMountsMap{}, debugPath: driver.debugPath, selinuxSupport: selinuxSupport}
+	mounter := &wekafsMounter{mountMap: wekafsMountsMap{}, debugPath: driver.debugPath, selinuxSupport: selinuxSupport, config: driver.config}
 	mounter.gc = initInnerPathVolumeGc(mounter)
 	mounter.gc.config = driver.config
 	mounter.schedulePeriodicMountGc()


### PR DESCRIPTION
## Problem

CSI secrets are generated per Weka cluster (in `weka-operator`). However, a single Weka cluster may have multiple client sets, each with its own CSI driver installation. Previously, `localContainerName` could only be configured in the CSI secret, making it impossible to use different container names for different client sets connecting to the same cluster.

## Solution

Add driver-level container name configuration via flags/environment variables, allowing each CSI installation to specify its own container name independently while maintaining backward compatibility with the existing secret-based configuration.

## Changes

- **Added** `--wekafscontainername` flag to CSI driver
- **Added** `wekafsContainerName` field to `DriverConfig`
- **Updated** `EnsureLocalContainer()` to check driver config first, then secret, then auto-detect
- **Updated** Helm templates to pass `WEKAFS_CONTAINER_NAME` env var to driver flag
- **Added** `pluginConfig.mountProtocol.wekafsContainerName` configuration in values.yaml

## Configuration

Set container name per CSI installation in `values.yaml`:

```yaml
pluginConfig:
  mountProtocol:
    # Specify name of Weka container to use for mounting filesystems
    # NOTE: for multiple client sets setup, set specific container name per installation
    wekafsContainerName: "clientset-1"
```

## Priority (highest to lowest)

1. **Driver flag/environment variable** (new) - set via `pluginConfig.mountProtocol.wekafsContainerName` in values.yaml
2. **CSI Secret** **`localContainerName`** **field** (existing) - for backward compatibility
3. **Auto-detection from cluster** (existing) - fallback if nothing configured

## Backward Compatibility

✅ Fully backward compatible. Existing deployments using `localContainerName` in CSI secrets will continue to work unchanged. The new driver-level configuration takes priority when both are set, allowing gradual migration.