### PR TITLE
fix: csi panic when frontend is not connected

### DIFF
--- a/pkg/wekafs/apiclient/cluster.go
+++ b/pkg/wekafs/apiclient/cluster.go
@@ -302,6 +302,12 @@ func (a *ApiClient) getLocalContainersFromDriver(ctx context.Context) ([]ProcFsC
 		if !strings.Contains(line, "Container=") {
 			continue
 		}
+
+		if strings.Contains(line, "Frontend is not connected") {
+			logger.Warn().Msg("Frontend is not connected, skipping")
+			continue
+		}
+
 		logger.Trace().Str("line", line).Msg("Found line in proc fs")
 		//Container=a88742862af5client FE 1: Connected frontend pid 4081177
 		name := strings.Split(line, "=")[1] // a88742862af5client FE 1: Connected frontend pid 4081177


### PR DESCRIPTION
# Fix
This fixes a panic when parsing `/proc/wekafs/interface`, the panic happens because clients in the disconnected state (`Frontend is not connected`) fails the parsing and leads to a panic when doing `pid := strings.Split(line, "pid ")[1]`.

Clients can get into this state when forcefully killed, which requires a full node reboot to clear the `/proc/wekafs/interface` file.

## Backtrace
```
panic: runtime error: index out of range [1] with length 1 [recovered]
        panic: runtime error: index out of range [1] with length 1 [recovered]
        panic: runtime error: index out of range [1] with length 1 [recovered]
        panic: runtime error: index out of range [1] with length 1

goroutine 408 [running]:
go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).End.deferwrap1()
        /go/pkg/mod/go.opentelemetry.io/otel/sdk@v1.36.0/trace/span.go:467 +0x25
go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).End(0xc00002e960, {0x0, 0x0, 0xc000603880?})
        /go/pkg/mod/go.opentelemetry.io/otel/sdk@v1.36.0/trace/span.go:500 +0xaf2
panic({0x1afbda0?, 0xc000688648?})
        /usr/local/go/src/runtime/panic.go:792 +0x132
go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).End.deferwrap1()
        /go/pkg/mod/go.opentelemetry.io/otel/sdk@v1.36.0/trace/span.go:467 +0x25
go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).End(0xc00002f2c0, {0x0, 0x0, 0xc0006a73c0?})
        /go/pkg/mod/go.opentelemetry.io/otel/sdk@v1.36.0/trace/span.go:500 +0xaf2
panic({0x1afbda0?, 0xc000688648?})
        /usr/local/go/src/runtime/panic.go:792 +0x132
go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).End.deferwrap1()
        /go/pkg/mod/go.opentelemetry.io/otel/sdk@v1.36.0/trace/span.go:467 +0x25
go.opentelemetry.io/otel/sdk/trace.(*recordingSpan).End(0xc00002fc20, {0x0, 0x0, 0xc000a3b0e0?})
        /go/pkg/mod/go.opentelemetry.io/otel/sdk@v1.36.0/trace/span.go:500 +0xaf2
panic({0x1afbda0?, 0xc000688648?})
        /usr/local/go/src/runtime/panic.go:792 +0x132
github.com/wekafs/csi-wekafs/pkg/wekafs/apiclient.(*ApiClient).getLocalContainersFromDriver(0xc000688618?, {0x1f0e378?, 0xc000806ab0?})
        /src/pkg/wekafs/apiclient/cluster.go:322 +0x5e8
github.com/wekafs/csi-wekafs/pkg/wekafs/apiclient.(*ApiClient).EnsureLocalContainer(0xc000030600, {0x1f0e378, 0xc000806ab0}, 0x0)
        /src/pkg/wekafs/apiclient/cluster.go:380 +0x9f
github.com/wekafs/csi-wekafs/pkg/wekafs.(*wekafsMount).ensureLocalContainerName(0xc000a33b80, {0x1f0e378, 0xc000806ab0}, 0xc000030600)
        /src/pkg/wekafs/wekafsmount.go:174 +0x445
github.com/wekafs/csi-wekafs/pkg/wekafs.(*wekafsMounter).mountWithOptions(0xc0006f40a0, {0x1f0e378, 0xc000806ab0}, {0xc000a68007, 0x7}, {0xc000806ae0?, {0xc000d0c610?, 0xc0006eb120?, 0x2?}}, 0xc000030600)
        /src/pkg/wekafs/wekafsmounter.go:75 +0xfa
github.com/wekafs/csi-wekafs/pkg/wekafs.(*Volume).MountUnderlyingFS(0xc00003a100, {0x1f0e420, 0xc00043e230})
        /src/pkg/wekafs/volume.go:923 +0x8d6
github.com/wekafs/csi-wekafs/pkg/wekafs.(*NodeServer).NodePublishVolume(0xc000797440, {0x1f0e378, 0xc000a7b530}, 0xc000d12080)
        /src/pkg/wekafs/nodeserver.go:355 +0x16f9
github.com/container-storage-interface/spec/lib/go/csi._Node_NodePublishVolume_Handler.func1({0x1f0e378?, 0xc000a7b530?}, {0x1b2a0c0?, 0xc000d12080?})
        /go/pkg/mod/github.com/container-storage-interface/spec@v1.11.0/lib/go/csi/csi_grpc.pb.go:1350 +0xcb
github.com/wekafs/csi-wekafs/pkg/wekafs.logGRPC({0x1f0e378, 0xc000d0e060}, {0x1b2a0c0, 0xc000d12080}, 0xc0009084a0, 0xc0009142a0)
        /src/pkg/wekafs/server.go:143 +0x623
github.com/container-storage-interface/spec/lib/go/csi._Node_NodePublishVolume_Handler({0x1ba1180, 0xc000797440}, {0x1f0e378, 0xc000d0e060}, 0xc000d12000, 0x1d3c6b0)
        /go/pkg/mod/github.com/container-storage-interface/spec@v1.11.0/lib/go/csi/csi_grpc.pb.go:1352 +0x143
google.golang.org/grpc.(*Server).processUnaryRPC(0xc000030000, {0x1f0e378, 0xc000960000}, 0xc000a3af00, 0xc000a80330, 0x2db0d50, 0x0)
        /go/pkg/mod/google.golang.org/grpc@v1.72.2/server.go:1405 +0x1036
google.golang.org/grpc.(*Server).handleStream(0xc000030000, {0x1f0ed78, 0xc0003a9520}, 0xc000a3af00)
        /go/pkg/mod/google.golang.org/grpc@v1.72.2/server.go:1815 +0xb88
google.golang.org/grpc.(*Server).serveStreams.func2.1()
        /go/pkg/mod/google.golang.org/grpc@v1.72.2/server.go:1035 +0x7f
created by google.golang.org/grpc.(*Server).serveStreams.func2 in goroutine 407
        /go/pkg/mod/google.golang.org/grpc@v1.72.2/server.go:1046 +0x11d
```