### PR TITLE
fix: initialize API metrics once at startup (CSI-398)

### DIFF
--- a/cmd/metricsserver/main.go
+++ b/cmd/metricsserver/main.go
@@ -33,7 +33,6 @@ func init() {
 		file = short
 		return file + ":" + strconv.Itoa(line)
 	}
-
 }
 
 var (

--- a/cmd/wekafsplugin/main.go
+++ b/cmd/wekafsplugin/main.go
@@ -49,7 +49,6 @@ func init() {
 		file = short
 		return file + ":" + strconv.Itoa(line)
 	}
-
 }
 
 var (

--- a/pkg/wekafs/apiclient/apiclient.go
+++ b/pkg/wekafs/apiclient/apiclient.go
@@ -54,7 +54,6 @@ type ApiClient struct {
 	containerName               string
 	NfsInterfaceGroupName       string
 	NfsClientGroupName          string
-	metrics                     *ApiMetrics
 	driverName                  string
 	RotateEndpointOnEachRequest bool // to be used in metrics server only (atm) to increase concurrency of requests across endpoints
 

--- a/pkg/wekafs/apiclient/login.go
+++ b/pkg/wekafs/apiclient/login.go
@@ -66,9 +66,6 @@ func (a *ApiClient) Login(ctx context.Context) error {
 
 // Init checks if API token refresh is required and transparently refreshes or fails back to (re)login
 func (a *ApiClient) Init(ctx context.Context) error {
-	if a.metrics == nil {
-		a.metrics = NewApiMetrics(a)
-	}
 	if a.apiTokenExpiryDate.After(time.Now()) {
 		return nil
 	} else {

--- a/pkg/wekafs/apiclient/metrics.go
+++ b/pkg/wekafs/apiclient/metrics.go
@@ -2,24 +2,25 @@ package apiclient
 
 import (
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/rs/zerolog/log"
 )
 
 type ApiMetrics struct {
-	client           *ApiClient
-	Endpoints        *prometheus.GaugeVec
+	endpoints        *prometheus.GaugeVec
 	requestCounters  *prometheus.CounterVec
 	requestDurations *prometheus.HistogramVec
 }
 
-var GlobalApiMetrics *ApiMetrics
+var apiMetrics *ApiMetrics
 
-func NewApiMetrics(client *ApiClient) *ApiMetrics {
-	if GlobalApiMetrics != nil {
-		return GlobalApiMetrics
-	}
-	ret := &ApiMetrics{
-		client: client,
-		Endpoints: prometheus.NewGaugeVec(
+func init() {
+	InitApiMetrics()
+}
+
+// InitApiMetrics initializes and registers API metrics with Prometheus.
+func InitApiMetrics() {
+	apiMetrics = &ApiMetrics{
+		endpoints: prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
 				Namespace: "weka_csi",
 				Subsystem: "api",
@@ -48,13 +49,8 @@ func NewApiMetrics(client *ApiClient) *ApiMetrics {
 			[]string{"csi_driver_name", "cluster_guid", "endpoint", "method", "url", "status"},
 		),
 	}
-	ret.Init()
-	GlobalApiMetrics = ret
-	return ret
-}
 
-func (m *ApiMetrics) Init() {
-	prometheus.MustRegister(m.Endpoints)
-	prometheus.MustRegister(m.requestCounters)
-	prometheus.MustRegister(m.requestDurations)
+	prometheus.MustRegister(apiMetrics.requestCounters)
+	prometheus.MustRegister(apiMetrics.requestDurations)
+	log.Debug().Msg("API metrics registered with Prometheus")
 }

--- a/pkg/wekafs/apiclient/requests.go
+++ b/pkg/wekafs/apiclient/requests.go
@@ -31,8 +31,8 @@ func (a *ApiClient) do(ctx context.Context, Method string, Path string, Payload 
 		guid := a.ClusterGuid.String()
 		ip := a.getEndpoint(ctx).IpAddress
 		dn := a.driverName
-		a.metrics.requestCounters.WithLabelValues(dn, guid, ip, Method, path, status).Inc()
-		a.metrics.requestDurations.WithLabelValues(dn, guid, ip, Method, path, status).Observe(time.Since(ctx.Value("startTime").(time.Time)).Seconds())
+		apiMetrics.requestCounters.WithLabelValues(dn, guid, ip, Method, path, status).Inc()
+		apiMetrics.requestDurations.WithLabelValues(dn, guid, ip, Method, path, status).Observe(time.Since(ctx.Value("startTime").(time.Time)).Seconds())
 	}()
 	//construct base request and add auth if exists
 	var body *bytes.Reader


### PR DESCRIPTION
### TL;DR

Refactored API metrics collection to use a global singleton pattern with proper initialization.

### What changed?

- Removed the `metrics` field from the `ApiClient` struct
- Replaced instance-based metrics with a global singleton `apiMetrics` variable
- Added an `InitApiMetrics()` function that's called during package initialization
- Removed unnecessary blank lines in initialization functions

### How to test?

1. Run the metrics server or the CSI plugin and verify that API metrics are still being collected and exposed properly
2. Check that the Prometheus endpoint shows the expected API request counters and durations
3. Verify that no errors occur during initialization or when making API requests

### Why make this change?

This change avoids a race condition where multiple API clients for different sets of credentials are agressively initalized in parallel.
This prevents potential issues with multiple metric registrations and ensures metrics are properly initialized before use.