### PR TITLE
feat: unify controller leader election in driver and gate sidecars with wait-for-leader

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,10 @@ RUN true
 
 
 RUN echo Building package
-RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -a -ldflags "-X main.version=$VERSION -extldflags '-static'" -o "/bin/wekafsplugin" /src/cmd/*
+RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -a -ldflags "-X main.version=$VERSION -extldflags '-static'" -o "/bin/wekafsplugin" /src/cmd/wekafsplugin
+
+RUN echo Building wait-for-leader utility
+RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -a -ldflags "-extldflags '-static'" -o "/bin/wait-for-leader" /src/cmd/wait-for-leader
 
 FROM alpine:3.18
 LABEL maintainers="WekaIO, LTD"
@@ -45,6 +48,7 @@ LABEL summary="This image is used by WEKA CSI Plugin and incorporates both Contr
 LABEL description="Container Storage Interface (CSI) plugin for WEKA - the data platform for AI"
 LABEL url="https://www.weka.io"
 COPY --from=go-builder /bin/wekafsplugin /wekafsplugin
+COPY --from=go-builder /bin/wait-for-leader /wait-for-leader
 COPY --from=go-builder /src/locar /locar
 ARG binary=/bin/wekafsplugin
 EXPOSE 2049 111/tcp 111/udp

--- a/charts/csi-wekafsplugin/templates/controllerserver-deployment.yaml
+++ b/charts/csi-wekafsplugin/templates/controllerserver-deployment.yaml
@@ -52,6 +52,13 @@ spec:
       {{- if or .Values.hostNetwork .Values.pluginConfig.mountProtocol.useNfs .Values.pluginConfig.mountProtocol.allowNfsFailback}}
       hostNetwork: true
       {{- end }}
+      initContainers:
+        - name: copy-wait-binary
+          image: {{ .Values.images.csidriver }}:v{{ .Values.images.csidriverTag }}
+          command: ["cp", "/wait-for-leader", "/shared/wait-for-leader"]
+          volumeMounts:
+            - name: shared-bin
+              mountPath: /shared
       containers:
         - name: wekafs
           securityContext:
@@ -139,7 +146,7 @@ spec:
             - "--allowencryptionwithoutkms"
           {{- end}}
           ports:
-            - containerPort: 9898
+            - containerPort: {{ .Values.controller.healthPort | default 8081 }}
               name: healthz
               protocol: TCP
           {{- if .Values.metrics.enabled }}
@@ -176,6 +183,12 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: status.hostIP
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: HEALTH_PORT
+              value: "{{ .Values.controller.healthPort | default 8081 }}"
             {{- if .Values.tracingDeploymentIdentifier }}
             - name: OTEL_DEPLOYMENT_IDENTIFIER
               value: {{ .Values.tracingDeploymentIdentifier }}
@@ -198,6 +211,8 @@ spec:
               name: csi-data-dir
             - mountPath: /dev
               name: dev-dir
+            - mountPath: /leader-state
+              name: leader-state
             {{- if .Values.legacyVolumeSecretName }}
             - mountPath: /legacy-volume-access
               name: legacy-volume-access
@@ -211,16 +226,14 @@ spec:
           image: {{ required "csi attacher sidercar image." .Values.images.attachersidecar }}
           securityContext:
             privileged: true
+          command: ["/shared/wait-for-leader"]
           args:
+            - "/csi-attacher"
             - "--csi-address=$(ADDRESS)"
             - "--v={{ .Values.logLevel | default 5 }}"
             - "--timeout=60s"
-            {{- if .Values.controller.configureAttacherLeaderElection }}
-            - "--leader-election"
-            - "--leader-election-namespace={{ .Release.Namespace }}"
-            {{- end }}
             - "--worker-threads={{ .Values.controller.maxConcurrentRequests }}"
-            {{- if or .Values.metrics.enabled .Values.controller.configureAttacherLeaderElection }}
+            {{- if .Values.metrics.enabled }}
             - "--http-endpoint=:{{ .Values.metrics.attacherPort | default 9095 }}"
             {{- end }}
           env:
@@ -229,11 +242,12 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
-          {{- if .Values.controller.configureAttacherLeaderElection }}
-          livenessProbe:
-            httpGet:
-              port: {{ .Values.metrics.attacherPort | default 9095 }}
-              path: /healthz/leader-election
+            - name: leader-state
+              mountPath: /leader-state
+              readOnly: true
+            - name: shared-bin
+              mountPath: /shared
+          {{- if .Values.metrics.enabled }}
           ports:
             - containerPort: {{ .Values.metrics.attacherPort | default 9095 }}
               name: pr-metrics
@@ -249,26 +263,18 @@ spec:
               privileged: true
           {{- end }}
           image: {{ required "csi provisioner sidecar container image." .Values.images.provisionersidecar }}
+          command: ["/shared/wait-for-leader"]
           args:
+            - "/csi-provisioner"
             - "--v={{ .Values.logLevel | default 5 }}"
             - "--csi-address=$(ADDRESS)"
             - "--feature-gates=Topology=true"
             - "--timeout=60s"
             - "--prevent-volume-mode-conversion"
-          {{- if .Values.controller.configureProvisionerLeaderElection | default true }}
-            - "--leader-election"
-            - "--leader-election-namespace={{ .Release.Namespace }}"
-          {{- end }}
             - "--worker-threads={{ .Values.controller.maxConcurrentRequests }}"
             - "--retry-interval-start=10s"
-          {{- if or .Values.metrics.enabled .Values.controller.configureProvisionerLeaderElection }}
+          {{- if .Values.metrics.enabled }}
             - "--http-endpoint=:{{ .Values.metrics.provisionerPort | default 9091 }}"
-          {{- end }}
-          {{- if .Values.controller.configureProvisionerLeaderElection }}
-          livenessProbe:
-            httpGet:
-              port: {{ .Values.metrics.provisionerPort | default 9091 }}
-              path: /healthz/leader-election
           {{- end }}
           env:
             - name: ADDRESS
@@ -276,10 +282,17 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: "/csi"
+            - name: leader-state
+              mountPath: /leader-state
+              readOnly: true
+            - name: shared-bin
+              mountPath: /shared
+          {{- if .Values.metrics.enabled }}
           ports:
             - containerPort: {{ .Values.metrics.provisionerPort }}
               name: pr-metrics
               protocol: TCP
+          {{- end }}
           {{- if .Values.controller.resources.csiProvisioner }}
           resources:
             {{- toYaml .Values.controller.resources.csiProvisioner | nindent 12 }}
@@ -290,35 +303,34 @@ spec:
             privileged: true
           {{- end }}
           image: {{ required "csi attacher sidercar image." .Values.images.resizersidecar }}
+          command: ["/shared/wait-for-leader"]
           args:
+            - "/csi-resizer"
             - "--v={{ .Values.logLevel | default 5 }}"
             - "--csi-address=$(ADDRESS)"
             - "--timeout=60s"
-          {{- if or .Values.metrics.enabled .Values.controller.configureResizerLeaderElection }}
+          {{- if .Values.metrics.enabled }}
             - "--http-endpoint=:{{ .Values.metrics.resizerPort | default 9092 }}"
-          {{- end }}
-          {{- if .Values.controller.configureResizerLeaderElection | default true }}
-            - "--leader-election"
-            - "--leader-election-namespace={{ .Release.Namespace }}"
           {{- end }}
             - "--workers={{ .Values.controller.maxConcurrentRequests }}"
             - "--retry-interval-start=10s"
-          {{- if .Values.controller.configureResizerLeaderElection }}
-          livenessProbe:
-            httpGet:
-              port: {{ .Values.metrics.resizerPort | default 9092 }}
-              path: /healthz/leader-election
-          {{- end }}
           env:
             - name: ADDRESS
               value: unix:///csi/csi.sock
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+            - name: leader-state
+              mountPath: /leader-state
+              readOnly: true
+            - name: shared-bin
+              mountPath: /shared
+          {{- if .Values.metrics.enabled }}
           ports:
             - containerPort: {{ .Values.metrics.resizerPort }}
               name: rs-metrics
               protocol: TCP
+          {{- end }}
           {{- if .Values.controller.resources.csiResizer }}
           resources:
             {{- toYaml .Values.controller.resources.csiResizer | nindent 12 }}
@@ -329,29 +341,23 @@ spec:
             privileged: true
           {{- end }}
           image: {{ required "csi snapshotter sidecar image." .Values.images.snapshottersidecar }}
+          command: ["/shared/wait-for-leader"]
           args:
+            - "/csi-snapshotter"
             - "--v=5"
             - "--csi-address=$(ADDRESS)"
             - "--timeout=60s"
-          {{- if .Values.controller.configureSnapshotterLeaderElection | default true }}
-            - "--leader-election"
-            - "--leader-election-namespace={{ .Release.Namespace }}"
-          {{- end }}
             - "--worker-threads={{ .Values.controller.maxConcurrentRequests }}"
             - "--retry-interval-start=10s"
-          {{- if or .Values.metrics.enabled .Values.controller.configureSnapshotterLeaderElection }}
+          {{- if .Values.metrics.enabled }}
             - "--http-endpoint=:{{ .Values.metrics.snapshotterPort | default 9093 }}"
           {{- end }}
-          {{- if .Values.controller.configureSnapshotterLeaderElection }}
-          livenessProbe:
-            httpGet:
-              port: {{ .Values.metrics.snapshotterPort | default 9093 }}
-              path: /healthz/leader-election
-          {{- end }}
+          {{- if .Values.metrics.enabled }}
           ports:
             - containerPort: {{ .Values.metrics.snapshotterPort }}
               name: sn-metrics
               protocol: TCP
+          {{- end }}
           env:
             - name: ADDRESS
               value: unix:///csi/csi.sock
@@ -359,27 +365,14 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /csi
+            - name: leader-state
+              mountPath: /leader-state
+              readOnly: true
+            - name: shared-bin
+              mountPath: /shared
           {{- if .Values.controller.resources.csiSnapshotter }}
           resources:
             {{- toYaml .Values.controller.resources.csiSnapshotter | nindent 12 }}
-          {{- end }}
-        - name: liveness-probe
-          volumeMounts:
-            - mountPath: /csi
-              name: socket-dir
-          image: {{ required "Provide Liveness Probe image." .Values.images.livenessprobesidecar }}
-          args:
-            - "--v={{ .Values.logLevel | default 5 }}"
-            - "--csi-address=$(ADDRESS)"
-            - "--health-port=$(HEALTH_PORT)"
-          env:
-            - name: ADDRESS
-              value: unix:///csi/csi.sock
-            - name: HEALTH_PORT
-              value: "9898"
-          {{- if .Values.controller.resources.livenessProbe }}
-          resources:
-            {{- toYaml .Values.controller.resources.livenessProbe | nindent 12 }}
           {{- end }}
       {{- with .Values.controllerPluginTolerations }}
       tolerations:
@@ -413,6 +406,10 @@ spec:
             path: /dev
             type: Directory
           name: dev-dir
+        - name: leader-state
+          emptyDir: {}
+        - name: shared-bin
+          emptyDir: {}
 {{- if .Values.legacyVolumeSecretName }}
         - name: legacy-volume-access
           secret:

--- a/charts/csi-wekafsplugin/values.yaml
+++ b/charts/csi-wekafsplugin/values.yaml
@@ -50,6 +50,8 @@ machineConfigLabels:
 controller:
   # -- Controller number of replicas
   replicas: 2
+  # -- Health probe port for controller pods
+  healthPort: 8081
   # -- Maximum concurrent requests from sidecars (global)
   maxConcurrentRequests: 5
   # -- maximum concurrent operations per operation type

--- a/cmd/wait-for-leader/main.go
+++ b/cmd/wait-for-leader/main.go
@@ -1,0 +1,231 @@
+/*
+A small utility that gates CSI sidecars on controller pods.
+
+It waits for:
+- a leader ready file to exist, and
+- the CSI socket to accept connections,
+
+then starts the real sidecar as a child process. While the sidecar is running, it
+monitors the leader ready file; if leadership is lost, it terminates the sidecar
+and returns to waiting.
+
+Usage: wait-for-leader <command> [args...]
+
+Environment variables:
+
+	LEADER_READY_FILE: Path to the leader ready file (default: /leader-state/leader_ready)
+	WAIT_POLL_INTERVAL: Poll interval in seconds (default: 1)
+	CSI_SOCKET_PATH: Path to the CSI socket (default: /csi/csi.sock)
+	LEADER_LOSS_DEBOUNCE: Seconds to wait before treating leader file disappearance as leadership loss (default: 3)
+	STOP_GRACE_PERIOD: Seconds to wait after SIGTERM before SIGKILLing the child (default: 10)
+*/
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"os/signal"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+)
+
+const (
+	defaultLeaderReadyFile        = "/leader-state/leader_ready"
+	defaultPollIntervalSecs       = 1
+	defaultSocketPath             = "/csi/csi.sock"
+	defaultLeaderLossDebounceSecs = 3
+	defaultStopGracePeriodSecs    = 10
+)
+
+var errLeadershipLost = errors.New("leadership lost")
+
+func parseEnvInt(name string, defaultValue int) int {
+	raw := strings.TrimSpace(os.Getenv(name))
+	if raw == "" {
+		return defaultValue
+	}
+	parsed, err := strconv.Atoi(raw)
+	if err != nil || parsed <= 0 {
+		return defaultValue
+	}
+	return parsed
+}
+
+func fileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+func waitForLeaderFile(ctx context.Context, leaderFile string, pollInterval time.Duration) error {
+	ticker := time.NewTicker(pollInterval)
+	defer ticker.Stop()
+
+	for {
+		if fileExists(leaderFile) {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}
+
+func waitForSocket(ctx context.Context, socketPath, leaderFile string) error {
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		// In case leadership lost, return to waiting for the leader file.
+		if !fileExists(leaderFile) {
+			return errLeadershipLost
+		}
+		conn, err := net.DialTimeout("unix", socketPath, 200*time.Millisecond)
+		if err == nil {
+			_ = conn.Close()
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}
+
+func startChild(binary string, args []string) (*exec.Cmd, <-chan error, error) {
+	cmd := exec.Command(binary, args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Stdin = os.Stdin
+
+	if err := cmd.Start(); err != nil {
+		return nil, nil, err
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- cmd.Wait()
+	}()
+	return cmd, done, nil
+}
+
+func terminateChild(cmd *exec.Cmd, childDone <-chan error, grace time.Duration) {
+	if cmd == nil || cmd.Process == nil {
+		return
+	}
+
+	_ = cmd.Process.Signal(syscall.SIGTERM)
+	select {
+	case <-childDone:
+	case <-time.After(grace):
+		_ = cmd.Process.Kill()
+		<-childDone
+	}
+}
+
+func main() {
+	if len(os.Args) < 2 {
+		fmt.Fprintf(os.Stderr, "Usage: %s <command> [args...]\n", os.Args[0])
+		os.Exit(1)
+	}
+
+	termCtx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
+	defer stop()
+
+	leaderFile := strings.TrimSpace(os.Getenv("LEADER_READY_FILE"))
+	if leaderFile == "" {
+		leaderFile = defaultLeaderReadyFile
+	}
+
+	pollInterval := time.Duration(parseEnvInt("WAIT_POLL_INTERVAL", defaultPollIntervalSecs)) * time.Second
+
+	socketPath := strings.TrimSpace(os.Getenv("CSI_SOCKET_PATH"))
+	if socketPath == "" {
+		socketPath = defaultSocketPath
+	}
+
+	leaderLossDebounce := time.Duration(parseEnvInt("LEADER_LOSS_DEBOUNCE", defaultLeaderLossDebounceSecs)) * time.Second
+	stopGrace := time.Duration(parseEnvInt("STOP_GRACE_PERIOD", defaultStopGracePeriodSecs)) * time.Second
+
+	binary := os.Args[1]
+	args := os.Args[2:]
+
+	fmt.Printf(
+		"wait-for-leader: gating %s (leader file: %s, poll: %s, socket: %s, leader-loss debounce: %s)\n",
+		binary,
+		leaderFile,
+		pollInterval.String(),
+		socketPath,
+		leaderLossDebounce.String(),
+	)
+
+	for {
+		fmt.Printf("wait-for-leader: waiting for leader file: %s\n", leaderFile)
+		if err := waitForLeaderFile(termCtx, leaderFile, pollInterval); err != nil {
+			os.Exit(0)
+		}
+
+		fmt.Printf("wait-for-leader: waiting for socket: %s\n", socketPath)
+		if err := waitForSocket(termCtx, socketPath, leaderFile); err != nil {
+			if errors.Is(err, errLeadershipLost) {
+				continue
+			}
+			os.Exit(0)
+		}
+
+		fmt.Printf("wait-for-leader: leader is ready, starting: %s\n", binary)
+		cmd, childDone, err := startChild(binary, args)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "wait-for-leader: failed to start %s: %v\n", binary, err)
+			os.Exit(1)
+		}
+
+		missingSince := time.Time{}
+		ticker := time.NewTicker(pollInterval)
+
+	monitorLoop:
+		for {
+			select {
+			case <-termCtx.Done():
+				terminateChild(cmd, childDone, stopGrace)
+				os.Exit(0)
+			case err := <-childDone:
+				if err == nil {
+					os.Exit(0)
+				}
+				if exitErr, ok := err.(*exec.ExitError); ok {
+					os.Exit(exitErr.ExitCode())
+				}
+				fmt.Fprintf(os.Stderr, "wait-for-leader: child exited with error: %v\n", err)
+				os.Exit(1)
+			case <-ticker.C:
+				if fileExists(leaderFile) {
+					missingSince = time.Time{}
+					continue
+				}
+
+				if missingSince.IsZero() {
+					missingSince = time.Now()
+					continue
+				}
+
+				if time.Since(missingSince) < leaderLossDebounce {
+					continue
+				}
+
+				fmt.Printf("wait-for-leader: leader file missing, stopping: %s\n", binary)
+				terminateChild(cmd, childDone, stopGrace)
+				break monitorLoop
+			}
+		}
+		ticker.Stop()
+	}
+}

--- a/pkg/wekafs/driverconfig.go
+++ b/pkg/wekafs/driverconfig.go
@@ -47,7 +47,7 @@ type DriverConfig struct {
 	tracingUrl                       string
 	manageNodeTopologyLabels         bool
 	wekafsContainerName              string
-	enforceDirVolTotalCapacity         bool
+	enforceDirVolTotalCapacity       bool
 }
 
 func (dc *DriverConfig) Log() {
@@ -145,7 +145,7 @@ func NewDriverConfig(dynamicVolPath, VolumePrefix, SnapshotPrefix, SeedSnapshotP
 		tracingUrl:                       tracingUrl,
 		manageNodeTopologyLabels:         manageNodeTopologyLabels,
 		wekafsContainerName:              wekafsContainerName,
-		enforceDirVolTotalCapacity:         enforceDirVolTotalCapacity,
+		enforceDirVolTotalCapacity:       enforceDirVolTotalCapacity,
 	}
 }
 

--- a/pkg/wekafs/server.go
+++ b/pkg/wekafs/server.go
@@ -19,14 +19,15 @@ package wekafs
 import (
 	"context"
 	"fmt"
-	"github.com/kubernetes-csi/csi-lib-utils/protosanitizer"
-	"github.com/rs/zerolog/log"
-	"go.opentelemetry.io/otel"
-	"google.golang.org/grpc"
 	"net"
 	"os"
 	"strings"
 	"sync"
+
+	"github.com/kubernetes-csi/csi-lib-utils/protosanitizer"
+	"github.com/rs/zerolog/log"
+	"go.opentelemetry.io/otel"
+	"google.golang.org/grpc"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 )
@@ -64,14 +65,21 @@ func (s *nonBlockingGRPCServer) Wait() {
 }
 
 func (s *nonBlockingGRPCServer) Stop() {
+	if s == nil || s.server == nil {
+		return
+	}
 	s.server.GracefulStop()
 }
 
 func (s *nonBlockingGRPCServer) ForceStop() {
+	if s == nil || s.server == nil {
+		return
+	}
 	s.server.Stop()
 }
 
 func (s *nonBlockingGRPCServer) serve(endpoint string, ids csi.IdentityServer, cs csi.ControllerServer, ns csi.NodeServer) {
+	defer s.wg.Done()
 
 	proto, addr, err := parseEndpoint(endpoint)
 	if err != nil {


### PR DESCRIPTION
### TL;DR

Implemented leader election for CSI controller pods with a new wait-for-leader utility to coordinate sidecar containers (CSI-403).

### What changed?

- Added a new `wait-for-leader` utility that gates CSI sidecar containers, ensuring they only run on the leader pod
- Implemented proper leader election for controller pods using controller-runtime's leader election
- Created a leader signaling mechanism using a shared file that sidecars can monitor
- Added health checks for both leader and standby pods
- Removed individual leader election configurations from each sidecar container
- Updated Helm chart to use the new leader election mechanism
- Added shared volume mounts for leader state and binary sharing between containers

### How to test?

1. Deploy the CSI plugin with multiple controller replicas
2. Verify only one controller pod becomes the leader and runs the sidecars
3. Kill the leader pod and confirm leadership transfers to another pod
4. Check health endpoints on both leader and standby pods
5. Verify the wait-for-leader utility correctly gates sidecars based on leadership status

### Why make this change?

The previous implementation used separate leader election for each sidecar container, which was inefficient and could lead to split-brain scenarios where different pods might be leaders for different operations. This change centralizes leadership to a single controller pod, ensuring all operations are handled by the same leader, improving reliability and resource utilization. It also provides better coordination between the main CSI driver and its sidecars.