### PR TITLE
docs: add nodeAffinity configuration to all static PV examples

### DIFF
--- a/examples/static_volume/static_directory/pv-wekafs-dir-static-api.yaml
+++ b/examples/static_volume/static_directory/pv-wekafs-dir-static-api.yaml
@@ -22,3 +22,12 @@ spec:
     controllerExpandSecretRef:
       name: csi-wekafs-api-secret
       namespace: csi-wekafs
+  # make PV schedulable only on nodes with WEKA CSI Plugin and healthy WEKA Client
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: topology.weka-infra.weka.io/accessible
+              operator: In
+              values:
+                - "true"

--- a/examples/static_volume/static_filesystem/pv-wekafs-fs-static-api.yaml
+++ b/examples/static_volume/static_filesystem/pv-wekafs-fs-static-api.yaml
@@ -22,3 +22,12 @@ spec:
     controllerExpandSecretRef:
       name: csi-wekafs-api-secret
       namespace: csi-wekafs
+  # make PV schedulable only on nodes with WEKA CSI Plugin and healthy WEKA Client
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: topology.weka-infra.weka.io/accessible
+              operator: In
+              values:
+                - "true"

--- a/examples/static_volume/static_snapshot/pv-wekafs-fssnap-static-api.yaml
+++ b/examples/static_volume/static_snapshot/pv-wekafs-fssnap-static-api.yaml
@@ -23,3 +23,12 @@ spec:
     controllerExpandSecretRef:
       name: csi-wekafs-api-secret
       namespace: csi-wekafs
+  # make PV schedulable only on nodes with WEKA CSI Plugin and healthy WEKA Client
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: topology.weka-infra.weka.io/accessible
+              operator: In
+              values:
+                - "true"


### PR DESCRIPTION
**TL;DR**
Add a nodeAffinity for all static provisioning examples.

***Purpose:***
Since WEKA CSI Plugin supports topology awareness, the updated configuration will ensure that pods requiring a statically provisioned PersistentVolume on WEKA cluster will only schedule on a node that has a healthy WEKA client
