### PR TITLE
feat: make CSI aware of error 403 on getMountToken

### DIFF
--- a/pkg/wekafs/apiclient/apiendpoint.go
+++ b/pkg/wekafs/apiclient/apiendpoint.go
@@ -20,6 +20,7 @@ type ApiEndPoint struct {
 	timeoutCount         int64
 	http400ErrCount      int64
 	http401ErrCount      int64
+	http403ErrCount      int64
 	http404ErrCount      int64
 	http409ErrCount      int64
 	http500ErrCount      int64

--- a/pkg/wekafs/apiclient/errors.go
+++ b/pkg/wekafs/apiclient/errors.go
@@ -21,7 +21,7 @@ type ApiError struct {
 }
 
 func (e ApiError) Error() string {
-	return fmt.Sprintf("%s: %s, status code: %d, original error: %e, raw response: %s, json: %s",
+	return fmt.Sprintf("%s: %s, status code: %d, original error: %v, raw response: %s, json: %s",
 		e.getType(), e.Text, e.StatusCode, e.Err, func() string {
 			if e.RawData != nil {
 				return string(*e.RawData)
@@ -68,7 +68,25 @@ func (e ApiAuthorizationError) getType() string {
 	return "ApiAuthorizationError"
 }
 func (e ApiAuthorizationError) Error() string {
-	return fmt.Sprintf("%s: %s, status code: %d, original error: %e, raw response: %s, json: %s",
+	return fmt.Sprintf("%s: %s, status code: %d, original error: %v, raw response: %s, json: %s",
+		e.getType(),
+		e.Text,
+		e.StatusCode,
+		e.Err,
+		func() string {
+			if e.RawData != nil {
+				return string(*e.RawData)
+			}
+			return ""
+		}(),
+		e.ApiResponse.Data)
+}
+
+type ApiForbiddenError ApiError
+
+func (e ApiForbiddenError) getType() string { return "ApiForbiddenError" }
+func (e ApiForbiddenError) Error() string {
+	return fmt.Sprintf("%s: %s, status code: %d, original error: %v, raw response: %s, json: %s",
 		e.getType(),
 		e.Text,
 		e.StatusCode,
@@ -88,7 +106,7 @@ func (e ApiBadRequestError) getType() string {
 	return "ApiBadRequestError"
 }
 func (e ApiBadRequestError) Error() string {
-	return fmt.Sprintf("%s: %s, status code: %d, original error: %e, raw response: %s, json: %s",
+	return fmt.Sprintf("%s: %s, status code: %d, original error: %v, raw response: %s, json: %s",
 		e.getType(),
 		e.Text,
 		e.StatusCode,
@@ -120,7 +138,7 @@ func (e ApiConflictError) Error() string {
 type ApiInternalError ApiError
 
 func (e ApiInternalError) Error() string {
-	return fmt.Sprintf("%s: %s, status code: %d, original error: %e, raw response: %s, json: %s",
+	return fmt.Sprintf("%s: %s, status code: %d, original error: %v, raw response: %s, json: %s",
 		e.getType(),
 		e.Text,
 		e.StatusCode,
@@ -146,7 +164,7 @@ func (e ApiInternalError) getType() string {
 type ApiNotAvailableError ApiError
 
 func (e ApiNotAvailableError) Error() string {
-	return fmt.Sprintf("%s: %s, status code: %d, original error: %e, raw response: %s, json: %s",
+	return fmt.Sprintf("%s: %s, status code: %d, original error: %v, raw response: %s, json: %s",
 		e.getType(),
 		e.Text,
 		e.StatusCode,
@@ -173,7 +191,7 @@ func (e ApiNotAvailableError) getType() string {
 type ApiNotFoundError ApiError
 
 func (e ApiNotFoundError) Error() string {
-	return fmt.Sprintf("%s: %s, status code: %d, original error: %e, raw response: %s, json: %s",
+	return fmt.Sprintf("%s: %s, status code: %d, original error: %v, raw response: %s, json: %s",
 		e.getType(),
 		e.Text,
 		e.StatusCode,


### PR DESCRIPTION
### TL;DR

Added support for HTTP 403 Forbidden errors in the WekaFS CSI driver, improving error handling for permission-related issues.

### What changed?

- Added tracking for HTTP 403 errors in the `ApiEndPoint` struct
- Created a new `ApiForbiddenError` type to handle permission denied scenarios
- Fixed error formatting in error messages (changed `%e` to `%v` for proper error display)
- Added specific handling for permission denied errors when mounting filesystems
- Introduced a new `MountPermissionDenied` error to properly communicate permission issues
- Updated the controller and node servers to return appropriate CSI error codes when permission is denied

### How to test?

1. Attempt to mount a filesystem with insufficient permissions
2. Verify that a proper permission denied error is returned instead of a generic error
3. Check logs to confirm the error is properly categorized as a permission issue
4. Verify that the CSI driver returns the correct error code (PermissionDenied) to Kubernetes

### Why make this change?

This change improves error handling and reporting when users attempt to access filesystems without proper permissions. Previously, permission issues might have been reported as generic errors, making troubleshooting difficult. With this change, permission denied errors are clearly identified and properly propagated through the CSI interface, allowing for better diagnostics and user feedback.