### PR TITLE
fix: security issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN echo Building package
 RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -a -ldflags "-X main.version=$VERSION -extldflags '-static'" -o "/bin" /src/cmd/*
 
 FROM registry.access.redhat.com/ubi9-minimal:${UBI_HASH} AS ubibuilder
-RUN microdnf install -y util-linux libselinux-utils pciutils binutils jq procps less container-selinux
+RUN microdnf install -y util-linux libselinux-utils pciutils procps less container-selinux
 RUN microdnf clean all && rm -rf /var/cache/dnf
 
 FROM ubibuilder


### PR DESCRIPTION
### TL;DR

Removed `binutils` and `jq` packages from Docker image and added Ginkgo test suite for WekaFS volume operations.

### What changed?

- Removed `binutils` and `jq` from the `microdnf install` command in the Dockerfile
- Added a new test suite using Ginkgo/Gomega framework for the WekaFS package
- Created `volume2_test.go` with a test case that validates CreateVolume request sanity checking
- Added `wekafs_suite_test.go` as the test suite entry point

### How to test?

Run the new test suite using:
```bash
go test ./pkg/wekafs/
```

The test creates a WekaFS driver instance and validates that CreateVolume requests are properly sanitized.

### Why make this change?

The Docker image optimization reduces the container size by removing unused utilities. The test suite addition provides automated validation for volume creation functionality, improving code reliability and enabling regression testing for the WekaFS CSI driver.