### PR TITLE
fix: prevent liveness probe from hanging on unresponsive WekaFS, propagate context (CSI-412)

### DIFF
--- a/charts/csi-wekafsplugin/README.md
+++ b/charts/csi-wekafsplugin/README.md
@@ -83,7 +83,6 @@ helm install csi-wekafsplugin csi-wekafs/csi-wekafsplugin --namespace csi-wekafs
 | controller.podLabels | object | `{}` | optional labels to add to controller pods |
 | controller.terminationGracePeriodSeconds | int | `10` | termination grace period for controller pods |
 | controller.resources | object | `{"csiAttacher":{"limits":{"cpu":1,"memory":"1Gi"},"requests":{"cpu":"4m","memory":"48Mi"}},"csiProvisioner":{"limits":{"cpu":1,"memory":"3Gi"},"requests":{"cpu":"128m","memory":"128Mi"}},"csiResizer":{"limits":{"cpu":1,"memory":"2Gi"},"requests":{"cpu":"4m","memory":"48Mi"}},"csiSnapshotter":{"limits":{"cpu":1,"memory":"1Gi"},"requests":{"cpu":"4m","memory":"48Mi"}},"livenessProbe":{"limits":{"cpu":1,"memory":"1Gi"},"requests":{"cpu":"12m","memory":"48Mi"}},"wekafs":{"limits":{"cpu":1,"memory":"3Gi"},"requests":{"cpu":"128m","memory":"128Mi"}}}` | resource requests and limits for controller containers |
-| node.maxConcurrentRequests | int | `5` | Maximum concurrent requests from sidecars (global) |
 | node.concurrency | object | `{"nodePublishVolume":5,"nodeUnpublishVolume":5}` | maximum concurrent operations per operation type (to avoid API starvation) |
 | node.grpcRequestTimeoutSeconds | int | `30` | Return GRPC Unavailable if request waits in queue for that long time (seconds) |
 | node.nodeSelector | object | `{}` | optional nodeSelector for node components only |

--- a/charts/csi-wekafsplugin/templates/controllerserver-deployment.yaml
+++ b/charts/csi-wekafsplugin/templates/controllerserver-deployment.yaml
@@ -108,6 +108,7 @@ spec:
           {{- if .Values.controller.grpcRequestTimeoutSeconds }}
             - "--grpcrequesttimeoutseconds={{ .Values.controller.grpcRequestTimeoutSeconds | default "5" }}"
           {{- end }}
+            - "--healthprobewekatimeoutseconds=5"
           {{- if .Values.controller.concurrency }}
             - "--concurrency.createVolume={{ .Values.controller.concurrency.createVolume | default "1" }}"
             - "--concurrency.deleteVolume={{ .Values.controller.concurrency.deleteVolume | default "1" }}"
@@ -158,13 +159,13 @@ spec:
               protocol: TCP
           {{- end }}
           livenessProbe:
-            failureThreshold: 5
+            failureThreshold: 10
             httpGet:
               path: /healthz
               port: healthz
             initialDelaySeconds: 10
-            timeoutSeconds: 3
-            periodSeconds: 2
+            timeoutSeconds: 6
+            periodSeconds: 10
           env:
             - name: CSI_ENDPOINT
               value: unix:///csi/csi.sock

--- a/charts/csi-wekafsplugin/templates/nodeserver-daemonset.yaml
+++ b/charts/csi-wekafsplugin/templates/nodeserver-daemonset.yaml
@@ -91,6 +91,7 @@ spec:
           {{- if .Values.node.grpcRequestTimeoutSeconds }}
             - "--grpcrequesttimeoutseconds={{ .Values.node.grpcRequestTimeoutSeconds | default "5" }}"
           {{- end }}
+            - "--healthprobewekatimeoutseconds=5"
           {{- if .Values.node.concurrency }}
             - "--concurrency.nodePublishVolume={{ .Values.node.concurrency.nodePublishVolume | default "1" }}"
             - "--concurrency.nodeUnpublishVolume={{ .Values.node.concurrency.nodeUnpublishVolume | default "1" }}"
@@ -126,13 +127,13 @@ spec:
               protocol: TCP
           {{- end }}
           livenessProbe:
-            failureThreshold: 5
+            failureThreshold: 10
             httpGet:
               path: /healthz
               port: healthz
             initialDelaySeconds: 10
             timeoutSeconds: 3
-            periodSeconds: 2
+            periodSeconds: 10
           env:
             - name: CSI_DRIVER_NAME
               value: {{ required "Provide CSI Driver Name"  .Values.csiDriverName }}
@@ -193,6 +194,7 @@ spec:
             - "--v={{ .Values.logLevel | default 5 }}"
             - "--csi-address=$(ADDRESS)"
             - "--health-port=$(HEALTH_PORT)"
+            - "--probe-timeout=6s"
           env:
             - name: ADDRESS
               value: unix:///csi/csi.sock

--- a/charts/csi-wekafsplugin/values.schema.json
+++ b/charts/csi-wekafsplugin/values.schema.json
@@ -205,11 +205,14 @@
                 "grpcRequestTimeoutSeconds": {
                     "type": "integer"
                 },
+                "healthProbeWekaTimeoutSeconds": {
+                    "type": "integer"
+                },
                 "labels": {
                     "type": "object"
                 },
-                "maxConcurrentRequests": {
-                    "type": "integer"
+                "livenessProbeTimeout": {
+                    "type": "string"
                 },
                 "nodeSelector": {
                     "type": "object"
@@ -262,6 +265,9 @@
                         },
                         "snapshotVolumesWithoutQuotaEnforcement": {
                             "type": "boolean"
+                        },
+                        "enforceDirVolTotalCapacity": {
+                            "type": "boolean"
                         }
                     }
                 },
@@ -296,6 +302,9 @@
                         },
                         "useNfs": {
                             "type": "boolean"
+                        },
+                        "wekafsContainerName": {
+                            "type": "string"
                         }
                     }
                 },
@@ -318,6 +327,9 @@
                             "type": "string"
                         }
                     }
+                },
+                "setOwnershipOnDynamicFilesystems": {
+                    "type": "boolean"
                 },
                 "skipGarbageCollection": {
                     "type": "boolean"

--- a/charts/csi-wekafsplugin/values.yaml
+++ b/charts/csi-wekafsplugin/values.yaml
@@ -118,17 +118,8 @@ controller:
       requests:
         cpu: 4m
         memory: 48Mi
-    livenessProbe:
-      limits:
-        cpu: 1
-        memory: 1Gi
-      requests:
-        cpu: 12m
-        memory: 48Mi
 # Node-specific parameters, please do not change unless explicitly guided
 node:
-  # -- Maximum concurrent requests from sidecars (global)
-  maxConcurrentRequests: 5
   # -- maximum concurrent operations per operation type (to avoid API starvation)
   concurrency:
     nodePublishVolume: 5

--- a/cmd/wekafsplugin/main.go
+++ b/cmd/wekafsplugin/main.go
@@ -89,8 +89,9 @@ var (
 	maxConcurrentCreateSnapshotReqs      = flag.Int64("concurrency.createSnapshot", 1, "Maximum concurrent CreateSnapshot requests")
 	maxConcurrentDeleteSnapshotReqs      = flag.Int64("concurrency.deleteSnapshot", 1, "Maximum concurrent DeleteSnapshot requests")
 	maxConcurrentNodePublishVolumeReqs   = flag.Int64("concurrency.nodePublishVolume", 1, "Maximum concurrent NodePublishVolume requests")
-	maxConcurrentNodeUnpublishVolumeReqs = flag.Int64("concurrency.nodeUnpublishVolume", 1, "Maximum concurrent NodeUnpublishVolume requests")
+	maxConcurrentNodeUnpublishVolumeReqs = flag.Int64("concurrency.nodeUnpublishVolume", 5, "Maximum concurrent NodeUnpublishVolume requests")
 	grpcRequestTimeoutSeconds            = flag.Int("grpcrequesttimeoutseconds", 30, "Time out requests waiting in queue after X seconds")
+	healthProbeWekaTimeoutSeconds        = flag.Int("healthprobewekatimeoutseconds", 2, "Timeout in seconds for WekaFS health check in liveness probe")
 	allowProtocolContainers              = flag.Bool("allowprotocolcontainers", false, "Allow protocol containers to be used for mounting filesystems")
 	allowNfsFailback                     = flag.Bool("allownfsfailback", false, "Allow NFS failback")
 	useNfs                               = flag.Bool("usenfs", false, "Use NFS for mounting volumes")
@@ -230,6 +231,7 @@ func handle(ctx context.Context) {
 		*maxConcurrentNodePublishVolumeReqs,
 		*maxConcurrentNodeUnpublishVolumeReqs,
 		*grpcRequestTimeoutSeconds,
+		*healthProbeWekaTimeoutSeconds,
 		*allowProtocolContainers,
 		*allowNfsFailback,
 		*useNfs,

--- a/pkg/wekafs/apiclient/cluster.go
+++ b/pkg/wekafs/apiclient/cluster.go
@@ -291,10 +291,9 @@ func GetFrontendsFromDriver(ctx context.Context) ([]ProcFsContainer, error) {
 
 	logger := log.Ctx(ctx)
 
-	ctxWithTimeout, cancel := context.WithTimeout(ctx, time.Second)
-	defer cancel()
-
-	// Use a channel to handle timeout for os.Open
+	// os.Open may block if the WekaFS kernel module is unresponsive.
+	// Run it in a goroutine and abandon it via ctx if it doesn't return in time.
+	// The goroutine itself leaks until the syscall completes, but the caller returns promptly.
 	type openResult struct {
 		file *os.File
 		err  error
@@ -312,11 +311,25 @@ func GetFrontendsFromDriver(ctx context.Context) ([]ProcFsContainer, error) {
 			return nil, result.err
 		}
 		f = result.file
-	case <-ctxWithTimeout.Done():
-		return nil, fmt.Errorf("timeout opening %s: %w", ProcFsPath, ctxWithTimeout.Err())
+	case <-ctx.Done():
+		return nil, fmt.Errorf("timeout opening %s: %w", ProcFsPath, ctx.Err())
 	}
 
 	defer func() { _ = f.Close() }()
+
+	// If the context is cancelled while scanner.Scan() is blocked on a kernel read,
+	// closing the file unblocks the read syscall immediately. The double-close with the
+	// defer above is safe: os.File.Close() on an already-closed file returns an error
+	// we intentionally ignore.
+	scanDone := make(chan struct{})
+	defer close(scanDone)
+	go func() {
+		select {
+		case <-ctx.Done():
+			_ = f.Close()
+		case <-scanDone:
+		}
+	}()
 
 	var frontends []ProcFsContainer
 	scanner := bufio.NewScanner(f)
@@ -376,7 +389,13 @@ func GetFrontendsFromDriver(ctx context.Context) ([]ProcFsContainer, error) {
 			Connected:     true,
 		})
 	}
-	return frontends, scanner.Err()
+	if err := scanner.Err(); err != nil {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		return nil, err
+	}
+	return frontends, nil
 }
 
 func (a *ApiClient) getLocalContainersFromDriver(ctx context.Context) ([]ProcFsContainer, error) {

--- a/pkg/wekafs/driverconfig.go
+++ b/pkg/wekafs/driverconfig.go
@@ -33,6 +33,7 @@ type DriverConfig struct {
 	mutuallyExclusiveOptions         []mutuallyExclusiveMountOptionSet
 	maxConcurrencyPerOp              map[string]int64
 	grpcRequestTimeout               time.Duration
+	healthProbeWekaTimeout           time.Duration
 	allowProtocolContainers          bool
 	allowNfsFailback                 bool
 	useNfs                           bool
@@ -66,6 +67,7 @@ func (dc *DriverConfig) Log() {
 		Int64("max_node_publish_volume_reqs", dc.maxConcurrencyPerOp["NodePublishVolume"]).
 		Int64("max_node_unpublish_volume_reqs", dc.maxConcurrencyPerOp["NodeUnpublishVolume"]).
 		Int("grpc_request_timeout_seconds", int(dc.grpcRequestTimeout.Seconds())).
+		Int("health_probe_weka_timeout_seconds", int(dc.healthProbeWekaTimeout.Seconds())).
 		Bool("allow_protocol_containers", dc.allowProtocolContainers).
 		Bool("allow_nfs_failback", dc.allowNfsFailback).
 		Bool("use_nfs", dc.useNfs).
@@ -87,6 +89,7 @@ func NewDriverConfig(dynamicVolPath, VolumePrefix, SnapshotPrefix, SeedSnapshotP
 	mutuallyExclusiveMountOptions MutuallyExclusiveMountOptsStrings,
 	maxCreateVolumeReqs, maxDeleteVolumeReqs, maxExpandVolumeReqs, maxCreateSnapshotReqs, maxDeleteSnapshotReqs, maxNodePublishVolumeReqs, maxNodeUnpublishVolumeReqs int64,
 	grpcRequestTimeoutSeconds int,
+	healthProbeWekaTimeoutSeconds int,
 	allowProtocolContainers bool,
 	allowNfsFailback, useNfs bool,
 	interfaceGroupName, clientGroupName, nfsProtocolVersion string,
@@ -110,6 +113,7 @@ func NewDriverConfig(dynamicVolPath, VolumePrefix, SnapshotPrefix, SeedSnapshotP
 	}
 
 	grpcRequestTimeout := time.Duration(grpcRequestTimeoutSeconds) * time.Second
+	healthProbeWekaTimeout := time.Duration(healthProbeWekaTimeoutSeconds) * time.Second
 
 	concurrency := make(map[string]int64)
 	concurrency["CreateVolume"] = maxCreateVolumeReqs
@@ -136,6 +140,7 @@ func NewDriverConfig(dynamicVolPath, VolumePrefix, SnapshotPrefix, SeedSnapshotP
 		mutuallyExclusiveOptions:         MutuallyExclusiveMountOptions,
 		maxConcurrencyPerOp:              concurrency,
 		grpcRequestTimeout:               grpcRequestTimeout,
+		healthProbeWekaTimeout:           healthProbeWekaTimeout,
 		allowProtocolContainers:          allowProtocolContainers,
 		allowNfsFailback:                 allowNfsFailback,
 		useNfs:                           useNfs,

--- a/pkg/wekafs/identityserver.go
+++ b/pkg/wekafs/identityserver.go
@@ -82,7 +82,9 @@ func (ids *identityServer) getConfig() *DriverConfig {
 //goland:noinspection GoUnusedParameter
 func (ids *identityServer) Probe(ctx context.Context, req *csi.ProbeRequest) (*csi.ProbeResponse, error) {
 	logger := log.Ctx(ctx)
-	isReady := ids.getConfig().isInDevMode() || isWekaRunning()
+	probeCtx, probeCancel := context.WithTimeout(ctx, ids.config.healthProbeWekaTimeout)
+	defer probeCancel()
+	isReady := ids.getConfig().isInDevMode() || isWekaRunning(probeCtx)
 	if !isReady {
 		if ids.getConfig().useNfs || ids.getConfig().allowNfsFailback {
 			isReady = true

--- a/pkg/wekafs/nfsmount.go
+++ b/pkg/wekafs/nfsmount.go
@@ -114,7 +114,7 @@ func (m *nfsMount) decRef(ctx context.Context) error {
 		}
 	}
 	if refCount > 0 {
-		logger.Trace().Int("refcount", refCount - 1).Strs("mount_options", m.getMountOptions().Strings()).Str("filesystem_name", m.fsName).Msg("RefCount decreased")
+		logger.Trace().Int("refcount", refCount-1).Strs("mount_options", m.getMountOptions().Strings()).Str("filesystem_name", m.fsName).Msg("RefCount decreased")
 		refCount--
 		m.mounter.mountMap[m.getRefcountIdx()] = refCount
 	}

--- a/pkg/wekafs/nodeserver.go
+++ b/pkg/wekafs/nodeserver.go
@@ -491,12 +491,15 @@ func (ns *NodeServer) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpu
 
 FORCEUMOUNT:
 	logger.Trace().Str("target_path", targetPath).Msg("Unmounting")
-	if err := mount.New("").Unmount(targetPath); err != nil {
+	unmountStart := time.Now()
+	unmountErr := mount.New("").Unmount(targetPath)
+	unmountElapsed := time.Since(unmountStart).Seconds()
+	if unmountErr != nil {
+		logger.Warn().Float64("elapsed_seconds", unmountElapsed).Str("target_path", targetPath).Msg("Unmount failed")
 		//it seems that when NodeUnpublishRequest appears, this target path is already not existing, e.g. due to pod being deleted
-		return NodeUnpublishVolumeError(ctx, codes.Internal, err.Error())
-	} else {
-		logger.Trace().Msg("Success")
+		return NodeUnpublishVolumeError(ctx, codes.Internal, unmountErr.Error())
 	}
+	logger.Trace().Float64("elapsed_seconds", unmountElapsed).Msg("Unmount succeeded")
 	logger.Trace().Str("target_path", targetPath).Msg("Removing stale target path")
 	if err := os.Remove(targetPath); err != nil {
 		return NodeUnpublishVolumeError(ctx, codes.Internal, err.Error())

--- a/pkg/wekafs/utilities.go
+++ b/pkg/wekafs/utilities.go
@@ -563,12 +563,12 @@ func isWekaDriverLoaded() bool {
 	return false
 }
 
-func isWekaRunning() bool {
+func isWekaRunning(ctx context.Context) bool {
 	if !isWekaDriverLoaded() {
 		return false
 	}
 
-	frontends, err := apiclient.GetFrontendsFromDriver(context.Background())
+	frontends, err := apiclient.GetFrontendsFromDriver(ctx)
 	if err != nil {
 		log.Err(err).Msg("Failed to read frontend statuses from driver interface")
 		return false

--- a/pkg/wekafs/volume_test.go
+++ b/pkg/wekafs/volume_test.go
@@ -17,7 +17,7 @@ func GetDriverForTest(t *testing.T) *WekaFsDriver {
 	driverConfig := NewDriverConfig("csi-volumes", "csi-vol-", "csi-snap-", "csi-seed-snap-",
 		"", true, true, true, true, true,
 		true, true, mutuallyExclusive,
-		1, 1, 1, 1, 1, 1, 1, 10,
+		1, 1, 1, 1, 1, 1, 1, 10, 5,
 		true, true, true, "", "", "4.1", "v1", false, false, true,
 		"", false, "", false, false)
 	driver, err := NewWekaFsDriver("csi.weka.io", nodeId, "unix://tmp/csi.sock", 10, "v1.0", "", CsiModeAll, false, driverConfig)

--- a/pkg/wekafs/wekafs.go
+++ b/pkg/wekafs/wekafs.go
@@ -614,7 +614,7 @@ func (d *WekaFsDriver) initManager(ctx context.Context) error {
 
 	// - Standby: OK (process is alive)
 	// - Leader: verify gRPC server accepts connections + Weka client running (if needed)
-	if err := mgr.AddHealthzCheck("healthz", func(_ *http.Request) error {
+	if err := mgr.AddHealthzCheck("healthz", func(r *http.Request) error {
 		if d.isLeader.Load() {
 			// Leader: verify gRPC server accepts connections
 			conn, err := net.DialTimeout(socketProto, socketPath, time.Second)
@@ -624,8 +624,10 @@ func (d *WekaFsDriver) initManager(ctx context.Context) error {
 			_ = conn.Close()
 
 			if !d.config.useNfs && !d.config.allowNfsFailback && !d.config.isInDevMode() {
-				if !isWekaRunning() {
-					return fmt.Errorf("weka client not running on leader node")
+				wekaCtx, wekaCancel := context.WithTimeout(r.Context(), d.config.healthProbeWekaTimeout)
+				defer wekaCancel()
+				if !isWekaRunning(wekaCtx) {
+					return fmt.Errorf("weka client not running or unresponsive")
 				}
 			}
 			return nil
@@ -709,7 +711,7 @@ func (d *WekaFsDriver) SetNodeLabels(ctx context.Context) {
 		if d.config.useNfs {
 			return "nfs"
 		}
-		wekaRunning := isWekaRunning()
+		wekaRunning := isWekaRunning(ctx)
 		if d.config.allowNfsFailback && !wekaRunning {
 			return "nfs"
 		}
@@ -829,7 +831,7 @@ func (driver *WekaFsDriver) NewMounter(ctx context.Context) AnyMounter {
 		log.Warn().Msg("Enforcing NFS transport due to configuration")
 		return newNfsMounter(ctx, driver)
 	}
-	if driver.config.allowNfsFailback && !isWekaRunning() {
+	if driver.config.allowNfsFailback && !isWekaRunning(ctx) {
 		if driver.config.isInDevMode() {
 			log.Info().Msg("Not Enforcing NFS transport due to dev mode")
 		} else {

--- a/pkg/wekafs/wekafsmount.go
+++ b/pkg/wekafs/wekafsmount.go
@@ -198,7 +198,7 @@ func (m *wekafsMount) doMount(ctx context.Context, apiClient *apiclient.ApiClien
 		return err
 	}
 	if !m.isInDevMode() {
-		if !isWekaRunning() {
+		if !isWekaRunning(ctx) {
 			logger.Error().Msg("WEKA is not running, cannot mount. Make sure WEKA client software is running on the host")
 			return errors.New("weka is not running, cannot mount")
 		}


### PR DESCRIPTION
# CSI-412: Liveness probe kills node pod when WekaFS kernel module is unresponsive

**Important:** the fix doesn't prevent pod restarts when WekaFS is genuinely stuck — it prevents false restarts when WekaFS is briefly slow.

---

## Symptoms

- CSI node pod enters `CrashLoopBackOff` with repeated restarts under high I/O load
- Observed at customer site with ~700 GB/s read load and many concurrent `NodeUnpublishVolume` calls
- Logs show `"All frontends connected"` printed repeatedly by the periodic liveness probe — then those log lines **stop** as the probe hangs, followed by pod restart
- No application errors precede the restart; the pod is killed by the kubelet liveness probe

---

## Affected probe paths

Two independent probe paths call `isWekaRunning()`:

**Node pod** — liveness probe routes through the `liveness-probe` sidecar via gRPC (see architecture below).

**Controller pod** — there is no `liveness-probe` sidecar; liveness probe is a direct HTTP GET to `/healthz` (port 8081). The handler calls `isWekaRunning()` directly. A hung WekaFS check blocks the HTTP handler, the probe times out, and Kubernetes kills the pod.

Both paths share the same root cause and are fixed by the same mechanism.

---

## Liveness probe architecture (node pod)

```
Kubernetes kubelet
  └─ HTTP GET :9899/healthz  (timeoutSeconds=7, periodSeconds=10, failureThreshold=10)
       └─ liveness-probe sidecar  (sig-storage/livenessprobe:v2.16.0)
            └─ gRPC Probe() RPC  ─── --probe-timeout=6s
                 └─ IdentityServer.Probe()
                      └─ isWekaRunning(ctx)
                           └─ GetFrontendsFromDriver(ctx)
                                ├─ os.Open("/proc/wekafs/interface")  ← can block
                                └─ scanner.Scan() / read()            ← can block
```

The sidecar makes a fresh blocking gRPC `Probe()` call on every HTTP request from kubelet
and waits for it to complete before responding. All three timeouts are binding and must satisfy:

```
healthProbeWekaTimeoutSeconds (5s)  <  --probe-timeout (6s)  <  kubelet timeoutSeconds (7s)
```

---

## Root cause

`/proc/wekafs/interface` is a procfs file served by the WekaFS kernel module.
`cat /proc/wekafs/interface` can hang indefinitely under load.

`GetFrontendsFromDriver()` reads this file: it calls `os.Open()` then reads all lines via
`scanner.Scan()`. Either call can block when the kernel module is unresponsive.
The liveness probe calls this on every probe cycle, so a single blocked read is enough
to start accumulating failures toward the `failureThreshold`.

### Why PR #646 did not fix the issue

PR #646 ("fix: add timeout to frontends check") added a 1-second goroutine timeout around `os.Open()` only:

```go
ctxWithTimeout, cancel := context.WithTimeout(ctx, time.Second)
go func() {
    f, err := os.Open(ProcFsPath)
    openChan <- openResult{f, err}
}()
select {
case result := <-openChan: ...
case <-ctxWithTimeout.Done(): return error  // 1s
}
// scanner.Scan() — completely unprotected
```

Two problems:

**1. `scanner.Scan()` left unprotected.** A hanging read after a successful `os.Open()` would block the probe handler indefinitely.

**2. Timing race with the sidecar.** The sidecar `--probe-timeout` defaults to **1s** in v2.16.0. PR #646's goroutine timeout is also 1s. Both deadlines fire simultaneously — the sidecar's gRPC deadline wins and the caller receives `DeadlineExceeded` instead of a clean `ready:false`, which is counted as a failure.

---

## Fix

Three layered changes, each closing one gap:

```
BEFORE
───────────────────────────────────────────────────────────────────
kubelet timeoutSeconds = 3s
  sidecar --probe-timeout = 1s (v2.16.0 default)
    Probe()  ──────────────────────────────────── no timeout
      └─ isWekaRunning()  ────────────────────── no timeout
           └─ os.Open()  [1s goroutine – PR #646]  ← races with sidecar 1s deadline
           └─ scanner.Scan()                       ← completely unprotected

AFTER
───────────────────────────────────────────────────────────────────
kubelet timeoutSeconds = 7s
  sidecar --probe-timeout = 6s
    Probe()  ──── probeCtx 5s ──────────────── bounded
      └─ isWekaRunning(probeCtx)
           └─ os.Open()  [goroutine, ctx 5s]  ← unblocked at 5s
           └─ scanner.Scan()  [close-on-cancel]  ← f.Close() fires at ctx.Done()
```

**Fix 1 — bound the driver-side check.**
`IdentityServer.Probe()` and the HTTP healthz handler both create a bounded context with
`healthProbeWekaTimeoutSeconds` (default **5s**) before calling `isWekaRunning()`. When
WekaFS is unresponsive, the driver returns `ready:false` within 5 seconds.

**Fix 2 — unblock `scanner.Scan()` on context cancellation.**
A watcher goroutine closes the file descriptor when `ctx` is cancelled. Closing an
`os.File` while another goroutine is blocked in `read()` causes the syscall to return
immediately with an error. The watcher always exits cleanly — via `ctx.Done()` if the
context fires, or via a `scanDone` channel when the scan completes normally — so there is
no goroutine leak.

**Fix 3 — set sidecar `--probe-timeout` > driver timeout.**
`--probe-timeout=6s` (`healthProbeWekaTimeoutSeconds + 1`). With the driver returning at ≤5s
and the sidecar waiting up to 6s, the sidecar always receives a clean `ready:false` response —
never `DeadlineExceeded`. The controller pod's `livenessProbe.timeoutSeconds` is set the same way.

---

## Timeout chain

### Node pod

- `healthProbeWekaTimeoutSeconds` = **5s** — driver waits this long before returning `ready:false`
- `--probe-timeout` = **6s** (= `healthProbeWekaTimeoutSeconds + 1`) — sidecar gRPC deadline; must exceed driver timeout
- `livenessProbe.timeoutSeconds` = **7s** — kubelet HTTP deadline; must exceed sidecar `--probe-timeout`
- `failureThreshold` = **10**, `periodSeconds` = **10s** — survival window ~**100s**

### Controller pod

- `healthProbeWekaTimeoutSeconds` = **5s** — same driver timeout; handler returns HTTP 500 within 5s
- `livenessProbe.timeoutSeconds` = **6s** (= `healthProbeWekaTimeoutSeconds + 1`) — kubelet HTTP deadline; must exceed driver timeout
- `failureThreshold` = **10**, `periodSeconds` = **10s** — survival window ~**100s**

### Single knob

`healthProbeWekaTimeoutSeconds` controls everything. Sidecar `--probe-timeout` and
controller `livenessProbe.timeoutSeconds` are derived as `healthProbeWekaTimeoutSeconds + 1`
automatically.
