### PR TITLE
fix: update OCP SecurityContextConstraints to allow emptyDir volume type

### DIFF
--- a/charts/csi-wekafsplugin/templates/controllerserver-security-context-constraint.yaml
+++ b/charts/csi-wekafsplugin/templates/controllerserver-security-context-constraint.yaml
@@ -9,9 +9,10 @@ allowHostDirVolumePlugin: true
 {{- if or .Values.hostNetwork .Values.pluginConfig.mountProtocol.allowNfsFailback .Values.pluginConfig.mountProtocol.useNfs }}
 allowHostNetwork: true
 {{- end }}
-allowedVolumeTypes:
+volumes:
   - hostPath
   - secret
+  - emptyDir
 readOnlyRootFilesystem: false
 allowHostPorts: true
 runAsUser:

--- a/charts/csi-wekafsplugin/templates/nodeserver-security-context-constraint.yaml
+++ b/charts/csi-wekafsplugin/templates/nodeserver-security-context-constraint.yaml
@@ -9,9 +9,10 @@ allowHostDirVolumePlugin: true
 {{- if or .Values.hostNetwork .Values.pluginConfig.mountProtocol.allowNfsFailback .Values.pluginConfig.mountProtocol.useNfs }}
 allowHostNetwork: true
 {{- end }}
-allowedVolumeTypes:
+volumes:
   - hostPath
   - secret
+  - emptyDir
 readOnlyRootFilesystem: false
 allowHostPorts: true
 runAsUser:


### PR DESCRIPTION
Ensure that SecurityContextConstraints allow emptyDir volume creation for CSI pods
Also, ensure that SCC templates comply with latest schema