### PR TITLE
fix: remove semconv schema attributes from otel trace provider

### DIFF
--- a/pkg/wekafs/otel.go
+++ b/pkg/wekafs/otel.go
@@ -2,21 +2,21 @@ package wekafs
 
 import (
 	"context"
+	"os"
+
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
-	"os"
 )
 
 func TracerProvider(version string, url string, csiRole CsiPluginMode) (*sdktrace.TracerProvider, error) {
 	// Ensure default SDK resources and the required service name are set.
 	hostname, _ := os.Hostname()
 	attributes := []attribute.KeyValue{
-		semconv.ServiceNameKey.String("Weka CSI Plugin"),
-		semconv.ServiceVersionKey.String(version),
-		semconv.HostNameKey.String(hostname),
+		attribute.String("service.name", "Weka CSI Plugin"),
+		attribute.String("service.version", version),
+		attribute.String("host.name", hostname),
 		attribute.String("weka.csi.mode", string(csiRole)),
 		attribute.String("weka.csi.version", version),
 	}
@@ -26,10 +26,7 @@ func TracerProvider(version string, url string, csiRole CsiPluginMode) (*sdktrac
 	}
 	r, err := resource.Merge(
 		resource.Default(),
-		resource.NewWithAttributes(
-			semconv.SchemaURL,
-			attributes...,
-		),
+		resource.NewSchemaless(attributes...),
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Plenty of time when otel packages are bumped, the semconv schema is not updated.
As a result, traces are broken and return trace_id and span_id as zeroes.

This PR suggests a way to remove the dependency on semconv schema so version mismatch is not possible