### PR TITLE
fix: mount selinux filesystem in node server daemonset to correctly manage labels in UBI image

### DIFF
--- a/charts/csi-wekafsplugin/templates/nodeserver-daemonset.yaml
+++ b/charts/csi-wekafsplugin/templates/nodeserver-daemonset.yaml
@@ -180,6 +180,8 @@ spec:
             {{- if or (.Capabilities.APIVersions.Has "security.openshift.io/v1/SecurityContextConstraints") (eq .Values.selinuxSupport "enforced") }}
             - mountPath: /etc/selinux/config
               name: selinux-config
+            - mountPath: /sys/fs/selinux
+              name: selinux-fs
             {{- end }}
           {{- if .Values.node.resources.wekafs }}
           resources:
@@ -278,6 +280,10 @@ spec:
             path: /etc/selinux/config
             type: File
           name: selinux-config
+        - hostPath:
+            path: /sys/fs/selinux
+            type: Directory
+          name: selinux-fs
       {{- end }}
 {{- if .Values.legacyVolumeSecretName }}
         - name: legacy-volume-access


### PR DESCRIPTION
Mounts the `/sys/fs/selinux` filesystem from the host into the WekaFS node server container when SELinux support is enabled or running on OpenShift. This provides the container access to the SELinux filesystem alongside the existing `/etc/selinux/config` file mount, which is necessary for proper SELinux enforcement in those environments, and especially when using RedHat UBI image
