### PR TITLE
fix: remove secret permissions from node-server clusterrole

### DIFF
--- a/charts/csi-wekafsplugin/templates/nodeserver-clusterrole.yaml
+++ b/charts/csi-wekafsplugin/templates/nodeserver-clusterrole.yaml
@@ -8,9 +8,6 @@ metadata:
     release: {{ .Release.Name }}
 rules:
   - apiGroups: [""]
-    resources: ["secrets"]
-    verbs: ["get", "list"]
-  - apiGroups: [""]
     resources: ["persistentvolumes"]
     verbs: ["create", "delete", "get", "list", "watch", "update"]
   - apiGroups: [""]


### PR DESCRIPTION
Removes the `secrets` resource permissions (`get`, `list`) from the node server cluster role, restricting the node server's access to Kubernetes secrets.
