### PR TITLE
fix: remove nil-apiClient legacy mode, error on missing API credentials

### DIFF
--- a/.github/workflows/sanity.yaml
+++ b/.github/workflows/sanity.yaml
@@ -42,19 +42,8 @@ jobs:
           tags: sanity:latest
           load: true
 
-  legacy_sanity:
-    needs: build
-    runs-on: self-hosted
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-      - name: Cleanup any existing containers
-        run: docker-compose -f tests/csi-sanity/docker-compose-nosnapshotcaps.yaml down -v 2>/dev/null || true
-      - run: docker-compose -f tests/csi-sanity/docker-compose-nosnapshotcaps.yaml up $COMPOSE_DEFAULTS
-        env:
-          SANITY_FUNCTION: legacy_sanity
-
   directory_volume_and_snapshots:
-    needs: legacy_sanity
+    needs: build
     runs-on: self-hosted
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4

--- a/pkg/wekafs/controllerserver.go
+++ b/pkg/wekafs/controllerserver.go
@@ -291,8 +291,6 @@ func (cs *ControllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 		return CreateVolumeError(ctx, codes.Internal, "Could not initialize volume representation object from request")
 	}
 
-	// check if with current API client state we can modify this volume or not
-	// (basically only legacy dirVolume with xAttr fallback can be operated without API client)
 	if err := volume.CanBeOperated(); err != nil {
 		return CreateVolumeError(ctx, codes.InvalidArgument, err.Error())
 	}

--- a/pkg/wekafs/volume.go
+++ b/pkg/wekafs/volume.go
@@ -108,9 +108,6 @@ func (v *Volume) pruneUnsupportedMountOptions(ctx context.Context) {
 		if v.apiClient != nil && !v.apiClient.SupportsSyncOnCloseMountOption() {
 			logger.Debug().Str("mount_option", MountOptionSyncOnClose).Msg("Mount option not supported by current Weka cluster version and is dropped.")
 			v.mountOptions = v.mountOptions.RemoveOption(MountOptionSyncOnClose)
-		} else if v.apiClient == nil {
-			logger.Debug().Str("mount_option", MountOptionSyncOnClose).Msg("Cannot determine current Weka cluster version, dropping mount option.")
-			v.mountOptions = v.mountOptions.RemoveOption(MountOptionSyncOnClose)
 		}
 	}
 	if v.mountOptions.hasOption(MountOptionReadOnly) {
@@ -218,6 +215,9 @@ func (v *Volume) isEncrypted(ctx context.Context) (bool, error) {
 				}
 			}
 		}
+	}
+	if v.encrypted == nil {
+		return false, nil
 	}
 	return *v.encrypted, nil
 }
@@ -474,12 +474,6 @@ func (v *Volume) getFilesystemTotalCapacity(ctx context.Context) (int64, error) 
 }
 
 func (v *Volume) getMaxCapacity(ctx context.Context) (int64, error) {
-
-	if v.apiClient == nil {
-		// this is a legacy, API-unbound volume
-		return v.getFilesystemFreeSpace(ctx)
-	}
-
 	// max size of the volume is the current size of the filesystem (or 0 if not exists) + free space on storage
 	currentFsSize, err := v.getFilesystemTotalCapacity(ctx)
 	if err != nil {
@@ -523,7 +517,6 @@ func (v *Volume) getCapacityFromQuota(ctx context.Context) (capacity int64, retE
 			return int64(size), nil
 		}
 	}
-	logger.Trace().Msg("Volume appears to be a legacy volume, failing back to Xattr")
 	size, err := v.getSizeFromXattr(ctx)
 	if err != nil {
 		return 0, err
@@ -594,12 +587,6 @@ func (v *Volume) ensureSufficientFsSizeOnUpdateCapacity(ctx context.Context, cap
 
 	logger := log.Ctx(ctx).With().Str("volume_id", v.GetId()).Logger()
 
-	if v.apiClient == nil {
-		logger.Trace().Msg("Volume is not bound to API client, expansion is not possible")
-		return nil
-	} else {
-
-	}
 	currentFsCapacity, err := v.getCapacityFromFsSize(ctx)
 	if err != nil {
 		return status.Errorf(codes.FailedPrecondition, "Failed to get current volume capacity for volume %s", v.GetId())
@@ -640,10 +627,6 @@ func (v *Volume) UpdateCapacity(ctx context.Context, enforceCapacity *bool, capa
 	capacityEntity := "quota"
 	if v.server.isInDevMode() {
 		logger.Trace().Msg("Updating quota via API is not possible since running in DEV mode")
-		primaryFunc = fallbackFunc
-		capacityEntity = "xattr"
-	} else if v.apiClient == nil {
-		logger.Trace().Msg("Volume has no API client bound, updating capacity in legacy mode")
 		primaryFunc = fallbackFunc
 		capacityEntity = "xattr"
 	} else if !v.apiClient.SupportsQuotaDirectoryAsVolume() {
@@ -1952,7 +1935,7 @@ func (v *Volume) CreateSnapshot(ctx context.Context, name string) (*Snapshot, er
 	return s, nil
 }
 
-// CanBeOperated returns true if the object can be CRUDed (either a legacy stateless volume or volume with API client bound
+// CanBeOperated returns nil if the volume can be CRUDed, or an error if it cannot
 func (v *Volume) CanBeOperated() error {
 	if v.isOnSnapshot() || v.isFilesystem() {
 		if v.apiClient == nil && !v.server.isInDevMode() {

--- a/pkg/wekafs/volumeconstructors.go
+++ b/pkg/wekafs/volumeconstructors.go
@@ -115,10 +115,9 @@ func NewVolumeFromControllerCreateRequest(ctx context.Context, req *csi.CreateVo
 
 // NewVolumeForBlankVolumeRequest can create a new volume of those types: new raw FS, snapshot of empty FS, directory on predefined filesystem
 func NewVolumeForBlankVolumeRequest(ctx context.Context, req *csi.CreateVolumeRequest, dynamicVolPath string, cs *ControllerServer) (*Volume, error) {
-	// obtain API client (or no client for legacy)
 	client, err := cs.api.GetClientFromSecrets(ctx, req.GetSecrets())
 	if err != nil {
-		return nil, err
+		return nil, status.Errorf(codes.FailedPrecondition, "failed to obtain API client: %v", err)
 	}
 
 	requestedVolumeName := req.GetName()

--- a/pkg/wekafs/wekafs.go
+++ b/pkg/wekafs/wekafs.go
@@ -278,8 +278,9 @@ func (api *ApiStore) GetClientFromSecrets(ctx context.Context, secrets map[strin
 			logger.Trace().Msg("No explicit API service for request, using legacySecrets")
 			secrets = *api.legacySecrets
 		} else {
-			logger.Trace().Msg("No API service for request, switching to legacy mode")
-			return nil, nil
+			logger.Warn().Msg("No API credentials provided for this request and no global API secret is configured")
+			return nil, fmt.Errorf("no API credentials provided for this request and no global API secret is configured; " +
+				"add csi.storage.k8s.io/provisioner-secret-name to the StorageClass or configure a global API secret")
 		}
 	}
 	client, err := api.fromSecrets(ctx, secrets, api.Hostname)
@@ -288,8 +289,8 @@ func (api *ApiStore) GetClientFromSecrets(ctx context.Context, secrets map[strin
 		return nil, err
 	}
 	if client == nil {
-		logger.Trace().Msg("API service was not found for request, switching to legacy mode")
-		return nil, nil
+		logger.Warn().Msg("API client could not be initialized from the provided secret")
+		return nil, fmt.Errorf("API client could not be initialized from the provided secret; check secret contents and cluster reachability")
 	}
 	logger.Trace().Msg("Successfully initialized API backend for request")
 	return client, nil

--- a/pkg/wekafs/wekafsmount.go
+++ b/pkg/wekafs/wekafsmount.go
@@ -170,11 +170,6 @@ func (m *wekafsMount) ensureLocalContainerName(ctx context.Context, apiClient *a
 		return nil
 	}
 
-	// legacy flow
-	if apiClient == nil {
-		return nil
-	}
-
 	// dev mode, no actual wekafs mount happens
 	if m.isInDevMode() {
 		logger.Trace().Msg("In dev mode, skipping container name check")
@@ -202,15 +197,10 @@ func (m *wekafsMount) doMount(ctx context.Context, apiClient *apiclient.ApiClien
 			logger.Error().Msg("WEKA is not running, cannot mount. Make sure WEKA client software is running on the host")
 			return errors.New("weka is not running, cannot mount")
 		}
-		if apiClient == nil {
-			// this flow is relevant only for legacy volumes, will not work with SCMC / authenticated mounts / non-root org
-			logger.Trace().Msg("No API client for mount, not requesting mount token")
+		if mountToken, err := apiClient.GetMountTokenForFilesystemName(ctx, m.fsName); err != nil {
+			return err
 		} else {
-			if mountToken, err := apiClient.GetMountTokenForFilesystemName(ctx, m.fsName); err != nil {
-				return err
-			} else {
-				mountOptionsSensitive = append(mountOptionsSensitive, fmt.Sprintf("token=%s", mountToken))
-			}
+			mountOptionsSensitive = append(mountOptionsSensitive, fmt.Sprintf("token=%s", mountToken))
 		}
 
 		// if needed, add containerName to the mount options


### PR DESCRIPTION
### TL;DR

Removed legacy "API-less" volume operation mode, making an API client mandatory for all volume operations.

### What changed?

- `GetClientFromSecrets` now returns an error instead of `nil, nil` when no API credentials are available, with actionable error messages guiding users to configure a StorageClass secret or global API secret.
- Mount operations now always require an API client to obtain a mount token; the legacy codepath that skipped token retrieval when no client was present has been removed.
- `pruneUnsupportedMountOptions` no longer drops `sync_on_close` when the API client is absent — the option is only dropped when the cluster explicitly reports it as unsupported.
- `getMaxCapacity` and `ensureSufficientFsSizeOnUpdateCapacity` no longer have special-case branches for a missing API client.
- `UpdateCapacity` no longer falls back to xattr-based capacity tracking when no API client is bound.
- `isEncrypted` now safely returns `false, nil` when the encrypted field is unset, preventing a nil pointer dereference.
- `NewVolumeForBlankVolumeRequest` now wraps the API client retrieval error as a proper gRPC `FailedPrecondition` status error.
- The `CanBeOperated` doc comment was corrected to accurately describe its return semantics.

### Why make this change?

The legacy mode allowed volumes to be operated without an API client, relying on xattr-based capacity tracking and unauthenticated mounts. This mode is no longer supported and its presence was masking misconfigurations by silently falling back to degraded behavior. Making the API client mandatory ensures failures are surfaced early with clear, actionable error messages rather than silently producing volumes that behave incorrectly.