### PR TITLE
fix: prevent controller mount stacking under concurrent provisioning by cloning MountOptions map (CSI-420)

### DIFF
--- a/pkg/wekafs/mountoptions.go
+++ b/pkg/wekafs/mountoptions.go
@@ -62,6 +62,29 @@ type MountOptions struct {
 	excludeOptions []string
 }
 
+// cloneCustomOptions returns a deep copy of the customOptions map. MountOptions
+// methods that derive a new value (AddOption/RemoveOption/MergedWith) MUST clone
+// the map rather than share the reference: a shared map means mutating the
+// "derived" options also mutates the original, which corrupts callers that use
+// MountOptions.String() as a stable identity (e.g. the mount refcount key in
+// getRefcountIdx).
+func (opts MountOptions) cloneCustomOptions() map[string]mountOption {
+	cloned := make(map[string]mountOption, len(opts.customOptions))
+	for k, v := range opts.customOptions {
+		cloned[k] = v
+	}
+	return cloned
+}
+
+// setOption adds/replaces an option in the receiver's map IN PLACE. Only safe on a
+// MountOptions whose map the caller exclusively owns (a freshly constructed value,
+// or an intentional in-place mutation). Derivation that must not touch the receiver
+// uses AddOption instead.
+func (opts MountOptions) setOption(optstring string) {
+	o := newMountOptionFromString(optstring)
+	opts.customOptions[o.option] = o
+}
+
 // Merge merges mount options. The other object always take precedence over the original
 func (opts MountOptions) Merge(other MountOptions, exclusives []mutuallyExclusiveMountOptionSet) {
 	for _, otherOpt := range other.customOptions {
@@ -91,7 +114,7 @@ func (opts MountOptions) Merge(other MountOptions, exclusives []mutuallyExclusiv
 // MergedWith returns a new object merged with other object
 func (opts MountOptions) MergedWith(other MountOptions, exclusives []mutuallyExclusiveMountOptionSet) MountOptions {
 	ret := MountOptions{
-		customOptions:  opts.customOptions,
+		customOptions:  opts.cloneCustomOptions(),
 		excludeOptions: opts.excludeOptions,
 	}
 	ret.Merge(other, exclusives)
@@ -100,7 +123,7 @@ func (opts MountOptions) MergedWith(other MountOptions, exclusives []mutuallyExc
 
 func (opts MountOptions) AddOption(optstring string) MountOptions {
 	ret := MountOptions{
-		customOptions:  opts.customOptions,
+		customOptions:  opts.cloneCustomOptions(),
 		excludeOptions: opts.excludeOptions,
 	}
 	opt := newMountOptionFromString(optstring)
@@ -110,7 +133,7 @@ func (opts MountOptions) AddOption(optstring string) MountOptions {
 
 func (opts MountOptions) RemoveOption(optstring string) MountOptions {
 	ret := MountOptions{
-		customOptions:  opts.customOptions,
+		customOptions:  opts.cloneCustomOptions(),
 		excludeOptions: opts.excludeOptions,
 	}
 	opt := newMountOptionFromString(optstring)
@@ -186,6 +209,8 @@ func (opts MountOptions) AsVolumeContext() string {
 	return ret.String()
 }
 
+// setSelinux mutates the receiver's options in place (it operates directly on the
+// shared customOptions map rather than via AddOption, which now returns a new value).
 func (opts MountOptions) setSelinux(selinuxSupport bool, mountProtocol string) {
 	if selinuxSupport {
 		var o mountOption
@@ -194,8 +219,11 @@ func (opts MountOptions) setSelinux(selinuxSupport bool, mountProtocol string) {
 		} else if mountProtocol == MountProtocolNfs {
 			o = newMountOptionFromString(fmt.Sprintf("context=\"system_u:object_r:%s:s0\"", selinuxContextNfs))
 		}
-		opts.AddOption(o.String())
-		opts.AddOption(MountOptionAcl) // due to STIG and other security requirements we need to enable ACLs otherwise mount might fail, CSI-333
+		if o.option != "" {
+			opts.customOptions[o.option] = o
+		}
+		// due to STIG and other security requirements we need to enable ACLs otherwise mount might fail, CSI-333
+		opts.setOption(MountOptionAcl)
 	} else {
 		if mountProtocol == MountProtocolWekafs {
 			delete(opts.customOptions, "fscontext")
@@ -207,22 +235,24 @@ func (opts MountOptions) setSelinux(selinuxSupport bool, mountProtocol string) {
 }
 
 func (opts MountOptions) AsNfs() MountOptions {
+	// ret owns a freshly constructed map, so we mutate it in place via setOption
+	// rather than AddOption (which would clone the map on every call).
 	ret := NewMountOptionsFromString(DefaultNfsMountOptions)
 	for _, o := range opts.getOpts() {
 		switch o.option {
 		case MountOptionWriteCache:
-			ret.AddOption(MountOptionNfsAsync)
+			ret.setOption(MountOptionNfsAsync)
 		case MountOptionCoherent:
-			ret.AddOption(MountOptionNfsSync)
-			ret.AddOption(MountOptionNfsNoac)
+			ret.setOption(MountOptionNfsSync)
+			ret.setOption(MountOptionNfsNoac)
 		case MountOptionForceDirect:
-			ret.AddOption(MountOptionNfsSync)
-			ret.AddOption(MountOptionNfsNoac)
+			ret.setOption(MountOptionNfsSync)
+			ret.setOption(MountOptionNfsNoac)
 		case MountOptionReadCache:
-			ret.AddOption(MountOptionNfsAc)
+			ret.setOption(MountOptionNfsAc)
 		case "dentry_max_age_positive":
-			ret.AddOption(fmt.Sprintf("acdirmax=%s", o.value))
-			ret.AddOption(fmt.Sprintf("acregmax=%s", o.value))
+			ret.setOption(fmt.Sprintf("acdirmax=%s", o.value))
+			ret.setOption(fmt.Sprintf("acregmax=%s", o.value))
 		default:
 			continue
 		}

--- a/pkg/wekafs/mountoptions_test.go
+++ b/pkg/wekafs/mountoptions_test.go
@@ -33,7 +33,7 @@ func TestMountOptions_Merge(t *testing.T) {
 	}
 
 	opts1.Merge(opts2, exclusives)
-	opts1.AddOption("acl")
+	opts1 = opts1.AddOption("acl")
 
 	if opts1.hasOption("ro") {
 		t.Errorf("Expected option 'ro' to be removed due to exclusivity")
@@ -475,5 +475,91 @@ func TestMountOptionOverride_ApplyToOptions_ComplexScenario(t *testing.T) {
 	}
 	if !result.hasOption("noatime") {
 		t.Errorf("Expected 'noatime' to be added")
+	}
+}
+
+// TestMountOptions_AddOption_DoesNotMutateReceiver guards against the
+// concurrent-provisioning mount-stacking bug: AddOption must NOT mutate the
+// receiver's underlying options map. If it does, callers that use
+// MountOptions.String() as a stable identity (e.g. the mount refcount key in
+// getRefcountIdx) read one key before doMount adds container_name and write a
+// different key after, defeating mount sharing and stacking real mounts.
+func TestMountOptions_AddOption_DoesNotMutateReceiver(t *testing.T) {
+	original := NewMountOptions([]string{"acl", "writecache"})
+	before := original.String()
+
+	derived := original.AddOption("container_name=k8sclient")
+
+	if original.String() != before {
+		t.Errorf("AddOption mutated the receiver: before=%q after=%q", before, original.String())
+	}
+	if original.hasOption("container_name") {
+		t.Errorf("AddOption leaked 'container_name' into the receiver")
+	}
+	if !derived.hasOption("container_name") {
+		t.Errorf("AddOption result is missing the added option")
+	}
+}
+
+// TestMountOptions_RemoveOption_DoesNotMutateReceiver mirrors the AddOption guard.
+func TestMountOptions_RemoveOption_DoesNotMutateReceiver(t *testing.T) {
+	original := NewMountOptions([]string{"acl", "writecache", "ro"})
+	before := original.String()
+
+	derived := original.RemoveOption("ro")
+
+	if original.String() != before {
+		t.Errorf("RemoveOption mutated the receiver: before=%q after=%q", before, original.String())
+	}
+	if !original.hasOption("ro") {
+		t.Errorf("RemoveOption removed 'ro' from the receiver")
+	}
+	if derived.hasOption("ro") {
+		t.Errorf("RemoveOption result still has the removed option")
+	}
+}
+
+// TestMountOptions_RefcountKeyStableAcrossDoMount reproduces the exact refcount-key
+// corruption: doMount adds "container_name=..." while mounting. The options string
+// used to build the refcount key must be identical before and after that addition,
+// so incRef reads and writes the SAME map key and mount sharing works.
+func TestMountOptions_RefcountKeyStableAcrossDoMount(t *testing.T) {
+	mountOpts := NewMountOptions([]string{"acl", "writecache"})
+
+	keyBefore := mountOpts.String() // what incRef reads at refCount lookup
+
+	// emulate doMount: container_name is added to a derived value for the actual mount
+	_ = mountOpts.AddOption("container_name=k8sclient")
+
+	keyAfter := mountOpts.String() // what incRef would write after doMount returns
+
+	if keyBefore != keyAfter {
+		t.Fatalf("refcount key changed across doMount: before=%q after=%q (mounts will stack under concurrency)", keyBefore, keyAfter)
+	}
+}
+
+// TestMountOptions_SetSelinux_StillMutatesInPlace ensures setSelinux keeps its
+// in-place contract after the AddOption clone fix (callers rely on it mutating
+// the passed options before mounting).
+func TestMountOptions_SetSelinux_StillMutatesInPlace(t *testing.T) {
+	opts := NewMountOptions([]string{"writecache"})
+	opts.setSelinux(true, MountProtocolWekafs)
+
+	if !opts.hasOption("fscontext") {
+		t.Errorf("setSelinux did not add fscontext in place")
+	}
+	if !opts.hasOption(MountOptionAcl) {
+		t.Errorf("setSelinux did not add acl in place")
+	}
+}
+
+// TestMountOptions_AsNfs_TranslatesOptions ensures AsNfs still returns the
+// translated NFS options after the AddOption clone fix (it previously relied on
+// AddOption mutating in place).
+func TestMountOptions_AsNfs_TranslatesOptions(t *testing.T) {
+	opts := NewMountOptions([]string{"writecache"})
+	nfs := opts.AsNfs()
+	if !nfs.hasOption(MountOptionNfsAsync) {
+		t.Errorf("AsNfs did not translate writecache -> %s; got %q", MountOptionNfsAsync, nfs.String())
 	}
 }


### PR DESCRIPTION
## Summary

The controller mounts each filesystem onto one shared path and reference-counts it: first request mounts, later concurrent ones just bump the refcount and reuse it, last one unmounts. This is gated by a check: "is there already a mount for this key?"

The bug corrupts that key (AddOption changes the options string mid-incRef when container_name is added), so every request's check says "no existing mount" — and each runs a real mount onto the same path, layering 2nd, 3rd… mounts. That's the stacking (in the repro: refcount never exceeds 1, and repeated "No existing mount → Mounted" on the identical path).

It fails because umount removes only one layer; the path is still mounted, so the driver reports still exists in /proc/mounts (or the kernel says target is busy) → ProvisioningFailed.



Concurrent `CreateVolume` requests targeting the same WekaFS filesystem intermittently failed with `ProvisioningFailed`:

```
rpc error: code = Internal desc = mount point
/run/weka-fs-mounts-controller/<fs>-<hash>-<container> still exists in /proc/mounts after umount
```

```
umount: <path>: target is busy
```

Volumes still bound after external-provisioner retries, but each retry emitted a`Warning` event and bind latency grew with the degree of concurrency. This PR fixes the root cause in `MountOptions`.

## Root cause

`MountOptions` is used as a value type, but `AddOption` / `RemoveOption` / `MergedWith` copied only the **struct** and shared the underlying`customOptions` **map by reference** (maps are reference types in Go). Mutating the "derived" options therefore also mutated the original:

```go
func (opts MountOptions) AddOption(optstring string) MountOptions {
	ret := MountOptions{
		customOptions:  opts.customOptions,   // same map as the receiver
		excludeOptions: opts.excludeOptions,
	}
	ret.customOptions[opt.option] = opt        // mutates the receiver too
	return ret
}
```

The controller mount path is reference-counted, keyed by`getRefcountIdx() = getMountPoint() + "^" + getMountOptions().String()`(`wekafsmount.go`). Inside `incRef`, the refcount is **read** before mounting
and **written** after `doMount` returns — and `doMount` adds `container_name`to the options via `AddOption`:

```go
// wekafsmount.go (doMount)
mountOptions = mountOptions.AddOption(fmt.Sprintf("container_name=%s", m.containerName))
```

Because of the aliasing, that call mutated the mount object's own options, so the options string — and hence the refcount key — **changed mid-`incRef`**:

- refcount **read** key:  `…^acl,fscontext,writecache`
- refcount **write** key: `…^acl,container_name=<c>,fscontext,writecache`

The increment was stored under a key that no subsequent request's initial read ever matched. The "is it already mounted?" check therefore **always missed**, so every concurrent request performed a real `mount` syscall on the same path,
**stacking mounts**. The later `umount` peeled one layer, correctly saw the other still present, and failed — surfacing as `still exists in /proc/mounts` /`target is busy` → `Internal` → `ProvisioningFailed`. External-provisioner
retried (idempotent), so volumes eventually bound, with latency scaling by concurrency.

`doUnmount` is only where the error _surfaces_; it correctly reports a real leftover mount. Simply swallowing that error would mask the symptom and **leak** the stacked mounts — so the fix is upstream, in `MountOptions`.

This was confirmed in controller debug logs: within a single `incRef` the logged`mount_options` lacked `container_name` at the refcount read and contained it at the refcount write, and the mount `refcount` never rose above `1` even under
concurrency (sharing fully defeated).

## Fix

Make `MountOptions` honor value semantics — derived options get an independent
map (`pkg/wekafs/mountoptions.go`):

- `AddOption`, `RemoveOption`, `MergedWith` now **clone** `customOptions`(`cloneCustomOptions`) instead of sharing the reference.
- Added a private in-place `setOption` helper. `setSelinux` (intentional in-place mutator) and `AsNfs` (builds a freshly-owned result) use it directly — they previously relied on `AddOption`'s side effect, and `AsNfs` is on the NFS refcount-key hot path so per-call map clones are avoided.

Effect: `getMountOptions().String()` is now stable across `doMount`, so `incRef`reads and writes the **same** refcount key. Concurrent requests **share** the one mount (refcount 2, 3, …) instead of stacking real mounts; the spurious `umount`failures and `ProvisioningFailed` events disappear.

This is a driver bug, not a WekaFS or CSI limitation. The same fix covers the NFS transport, which shares the `MountOptions` type.

## Validation (live cluster, v2.8.6)

Reproduced and then validated on a real cluster (`dir/v1` StorageClass on a shared filesystem, `concurrency.createVolume=5`), 4 concurrent PVCs:

| Signal | Before (v2.8.6) | After (fixed image) |
| --- | --- | --- |
| `ProvisioningFailed` events | 8 | **0** |
| `Failed to unmount` / `Error creating volume` / `still exists in /proc/mounts` | 10 / 8 / many | **0 / 0 / 0** |
| max mount `refcount` | **1** (sharing defeated) | **4** (sharing restored) |
| bind time | staggered ~19 / 19 / 40 / 75 s | all bound in ~5 s |

