### PR TITLE
fix: support storageclass quotaGracePeriod

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -55,7 +55,10 @@ Comments:
    As a result, the capacity required by such snapshot would significantly depend on data usage pattern of all CSI directory-backed volumes on same filesystem, and much larger than the volume size.  
    Hence, snapshot creation is prohibited by default, but can be enabled. Refer to Weka CSI Plugin Helm chart documentation for additional information
 4. In Weka versions prior to 4.2, quota is not enforced inside filesystem snapshots. As a result, capacity enforcement is not supported for this type of volume.  
-   If capacity enforcement is crucial for your workload, use directory-backed volumes or upgrade to latest Weka software
+   If capacity enforcement is crucial for your workload, use directory-backed volumes or upgrade to latest Weka software  
+   The `capacityEnforcement` StorageClass parameter accepts `HARD` (default, writes blocked above quota) or `SOFT` (warning issued but writes not blocked).  
+   When using `SOFT` enforcement, the optional `quotaGracePeriod` parameter sets how long a soft-limit breach is tolerated before the soft limit is treated as a hard limit and writes are blocked.  
+   The value is a Go duration string (e.g. `"72h"`, `"30m"`, `"1h30m"`); default is `0`, meaning the soft limit is advisory only and is never enforced (writes are never blocked). This parameter is ignored when `capacityEnforcement` is `HARD`.
 5. Filesystem size and used capacity is not monitoried by CSI plugin. The administrator has to make sure enough capacity is allocated for the filesystem.  
    Filesystems created dynamically (via filesystem-backed volume) can be set with initial size to accomodate future volumes, refer to Weka CSI Plugin Helm chart documentation for additional information
 6. Weka CSI plugin does not support automatic configuration of tiering for filesystem-backed volumes, but those can be set externally.

--- a/examples/dynamic_directory/storageclass-wekafs-dir-api.yaml
+++ b/examples/dynamic_directory/storageclass-wekafs-dir-api.yaml
@@ -24,6 +24,11 @@ parameters:
   # - HARD or unspecified: pod will not be able to write above quota
   # - SOFT: warning will be issued on Weka cluster, but writing will not be blocked
   capacityEnforcement: HARD
+  # optional: grace period for SOFT capacity enforcement, as a Go duration string (e.g. "72h", "30m")
+  # time a soft-limit breach is tolerated before the soft limit is treated as a hard limit and writes are blocked
+  # ignored when capacityEnforcement is HARD
+  # default: 0 (advisory only - soft limit is never enforced, writes are never blocked)
+  #quotaGracePeriod: "168h"
   # name of the secret that stores API credentials for a cluster
   # change the name of secret to match secret of a particular cluster (if you have several Weka clusters)
   csi.storage.k8s.io/provisioner-secret-name: &secretName csi-wekafs-api-secret

--- a/examples/static_volume/static_directory/storageclass-wekafs-dir-static-api.yaml
+++ b/examples/static_volume/static_directory/storageclass-wekafs-dir-static-api.yaml
@@ -23,6 +23,11 @@ parameters:
   # - HARD or unspecified: pod will not be able to write above quota
   # - SOFT: warning will be issued on Weka cluster, but writing will not be blocked
   capacityEnforcement: HARD
+  # optional: grace period for SOFT capacity enforcement, as a Go duration string (e.g. "72h", "30m")
+  # time a soft-limit breach is tolerated before the soft limit is treated as a hard limit and writes are blocked
+  # ignored when capacityEnforcement is HARD
+  # default: 0 (advisory only - soft limit is never enforced, writes are never blocked)
+  #quotaGracePeriod: "168h"
   # name of the secret that stores API credentials for a cluster
   # change the name of secret to match secret of a particular cluster (if you have several Weka clusters)
   csi.storage.k8s.io/provisioner-secret-name: &secretName csi-wekafs-api-secret

--- a/examples/static_volume/static_filesystem/storageclass-wekafs-fs-static-api.yaml
+++ b/examples/static_volume/static_filesystem/storageclass-wekafs-fs-static-api.yaml
@@ -23,6 +23,11 @@ parameters:
   # - HARD or unspecified: pod will not be able to write above quota
   # - SOFT: warning will be issued on Weka cluster, but writing will not be blocked
   capacityEnforcement: HARD
+  # optional: grace period for SOFT capacity enforcement, as a Go duration string (e.g. "72h", "30m")
+  # time a soft-limit breach is tolerated before the soft limit is treated as a hard limit and writes are blocked
+  # ignored when capacityEnforcement is HARD
+  # default: 0 (advisory only - soft limit is never enforced, writes are never blocked)
+  #quotaGracePeriod: "168h"
   # name of the secret that stores API credentials for a cluster
   # change the name of secret to match secret of a particular cluster (if you have several Weka clusters)
   csi.storage.k8s.io/provisioner-secret-name: &secretName csi-wekafs-api-secret

--- a/examples/static_volume/static_snapshot/storageclass-wekafs-fssnap-static-api.yaml
+++ b/examples/static_volume/static_snapshot/storageclass-wekafs-fssnap-static-api.yaml
@@ -23,6 +23,11 @@ parameters:
   # - HARD or unspecified: pod will not be able to write above quota
   # - SOFT: warning will be issued on Weka cluster, but writing will not be blocked
   capacityEnforcement: HARD
+  # optional: grace period for SOFT capacity enforcement, as a Go duration string (e.g. "72h", "30m")
+  # time a soft-limit breach is tolerated before the soft limit is treated as a hard limit and writes are blocked
+  # ignored when capacityEnforcement is HARD
+  # default: 0 (advisory only - soft limit is never enforced, writes are never blocked)
+  #quotaGracePeriod: "168h"
   # name of the secret that stores API credentials for a cluster
   # change the name of secret to match secret of a particular cluster (if you have several Weka clusters)
   csi.storage.k8s.io/provisioner-secret-name: &secretName csi-wekafs-api-secret

--- a/pkg/wekafs/utilities.go
+++ b/pkg/wekafs/utilities.go
@@ -525,6 +525,28 @@ func getCapacityEnforcementParam(params map[string]string) (bool, error) {
 	return enforceCapacity, nil
 }
 
+// getQuotaGracePeriodParam parses the optional quotaGracePeriod storage class parameter.
+// The value is a Go duration string (e.g. "72h", "30m"). It returns the grace period in
+// seconds (0 when unset), and an error if the value is invalid.
+// The grace period only takes effect for SOFT capacity enforcement. A grace period of 0
+// (unset) makes a SOFT quota advisory only: usage is reported as exceeded on the Weka
+// cluster but writes are never blocked. A positive grace period causes the soft limit to
+// be treated as a hard limit once the grace period elapses after a breach.
+func getQuotaGracePeriodParam(params map[string]string) (uint64, error) {
+	val, ok := params["quotaGracePeriod"]
+	if !ok {
+		return 0, nil
+	}
+	d, err := time.ParseDuration(val)
+	if err != nil {
+		return 0, fmt.Errorf("invalid quotaGracePeriod %q: %w", val, err)
+	}
+	if d < 0 {
+		return 0, fmt.Errorf("quotaGracePeriod cannot be negative: %q", val)
+	}
+	return uint64(d.Seconds()), nil
+}
+
 func volumeExistsAndMatchesCapacity(ctx context.Context, v *Volume, capacity int64) (bool, bool, error) {
 	ctx, span := otel.Tracer(TracerName).Start(ctx, "CheckVolumeExistsAndMatchesCapacity")
 	defer span.End()

--- a/pkg/wekafs/utilities_test.go
+++ b/pkg/wekafs/utilities_test.go
@@ -7,6 +7,38 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestGetQuotaGracePeriodParam(t *testing.T) {
+	// param absent → (0, nil)
+	secs, err := getQuotaGracePeriodParam(map[string]string{})
+	assert.NoError(t, err)
+	assert.Equal(t, uint64(0), secs)
+
+	// "72h" → (259200, nil)
+	secs, err = getQuotaGracePeriodParam(map[string]string{"quotaGracePeriod": "72h"})
+	assert.NoError(t, err)
+	assert.Equal(t, uint64(259200), secs)
+
+	// "30m" → (1800, nil)
+	secs, err = getQuotaGracePeriodParam(map[string]string{"quotaGracePeriod": "30m"})
+	assert.NoError(t, err)
+	assert.Equal(t, uint64(1800), secs)
+
+	// "0s" → (0, nil)
+	secs, err = getQuotaGracePeriodParam(map[string]string{"quotaGracePeriod": "0s"})
+	assert.NoError(t, err)
+	assert.Equal(t, uint64(0), secs)
+
+	// "-5m" → error
+	secs, err = getQuotaGracePeriodParam(map[string]string{"quotaGracePeriod": "-5m"})
+	assert.Error(t, err)
+	assert.Equal(t, uint64(0), secs)
+
+	// "garbage" → error
+	secs, err = getQuotaGracePeriodParam(map[string]string{"quotaGracePeriod": "garbage"})
+	assert.Error(t, err)
+	assert.Equal(t, uint64(0), secs)
+}
+
 func TestGetMountContainerNameFromActualMountPoint(t *testing.T) {
 	// Create a temporary file to mock /proc/mounts
 	tmpFile, err := os.CreateTemp("", "mounts")

--- a/pkg/wekafs/volume.go
+++ b/pkg/wekafs/volume.go
@@ -35,24 +35,25 @@ var ErrFilesystemBiggerThanRequested = errors.New("could not resize filesystem s
 
 // Volume is a volume object representation, not necessarily instantiated (e.g. can exist or not exist)
 type Volume struct {
-	id                    string
-	FilesystemName        string
-	filesystemGroupName   string
-	SnapshotName          string
-	SnapshotAccessPoint   string
-	SnapshotUuid          *uuid.UUID
-	innerPath             string
-	apiClient             *apiclient.ApiClient
-	permissions           fs.FileMode
-	ownerUid              int
-	ownerGid              int
-	mountPath             string
-	enforceCapacity       bool
-	initialFilesystemSize int64
-	mountOptions          MountOptions
-	encrypted             *bool // to support also encryption state fetched from actual filesystem when not set
-	manageEncryptionKeys  bool
-	encryptWithoutKms     bool
+	id                      string
+	FilesystemName          string
+	filesystemGroupName     string
+	SnapshotName            string
+	SnapshotAccessPoint     string
+	SnapshotUuid            *uuid.UUID
+	innerPath               string
+	apiClient               *apiclient.ApiClient
+	permissions             fs.FileMode
+	ownerUid                int
+	ownerGid                int
+	mountPath               string
+	enforceCapacity         bool
+	quotaGracePeriodSeconds uint64
+	initialFilesystemSize   int64
+	mountOptions            MountOptions
+	encrypted               *bool // to support also encryption state fetched from actual filesystem when not set
+	manageEncryptionKeys    bool
+	encryptWithoutKms       bool
 
 	kmsVaultNamespace     string
 	kmsVaultKeyIdentifier string
@@ -908,6 +909,9 @@ func (v *Volume) setQuota(ctx context.Context, enforceCapacity *bool, capacityLi
 		return nil, errors.New("cannot set quota, could not find inode ID of the volume")
 	}
 	qr := apiclient.NewQuotaCreateRequest(*fsObj, inodeId, quotaType, capacityLimit)
+	if quotaType == apiclient.QuotaTypeSoft {
+		qr.GraceSeconds = v.quotaGracePeriodSeconds
+	}
 	q := &apiclient.Quota{}
 	if err := v.apiClient.CreateQuota(ctx, qr, q, true); err != nil {
 		return nil, err
@@ -1919,6 +1923,16 @@ func (v *Volume) ObtainRequestParams(ctx context.Context, params map[string]stri
 		return err
 	}
 	v.enforceCapacity = enforceCapacity
+
+	// quotaGracePeriod (applies to SOFT capacity enforcement only)
+	graceSeconds, err := getQuotaGracePeriodParam(params)
+	if err != nil {
+		return err
+	}
+	v.quotaGracePeriodSeconds = graceSeconds
+	if graceSeconds > 0 && v.enforceCapacity {
+		log.Ctx(ctx).Warn().Msg("quotaGracePeriod is set but capacityEnforcement is HARD; grace period only applies to SOFT enforcement and will be ignored")
+	}
 
 	// make sure to set min capacity if comes from request
 	if val, ok := params["initialFilesystemSizeGB"]; ok {


### PR DESCRIPTION
### TL;DR

A new StorageClass parameter, `quotaGracePeriod`, sets how long a soft capacity limit is tolerated before writes are actually blocked.

### What changed?

- New optional StorageClass parameter `quotaGracePeriod`, a duration such as `72h`, `30m` or `1h30m`. It applies only when `capacityEnforcement` is `SOFT`.
- Default is `0`, which keeps the existing behaviour: a soft limit is advisory and writes are never blocked.
- Setting it alongside `capacityEnforcement: HARD` logs a warning and is otherwise ignored.
- A negative or unparseable value is rejected when the volume is provisioned, rather than silently treated as zero.
- The example StorageClasses and the usage guide now document both `capacityEnforcement` and `quotaGracePeriod`.

### How to test?

1. Create a StorageClass with `capacityEnforcement: "SOFT"` and `quotaGracePeriod: "30m"`.
2. Provision a PVC from it and mount it in a pod.
3. Write past the requested size. Writes still succeed, and the volume's quota shows a grace period on the Weka side.
4. Leave it over quota for longer than the grace period; further writes are then blocked.
5. To confirm the guard, set `quotaGracePeriod: "-5m"` and create a PVC — provisioning fails with a clear message instead of accepting it.

### Why make this change?

`SOFT` capacity enforcement previously had only two outcomes: a limit that is never enforced at all, or `HARD`, which blocks writes the moment a volume goes over. There was no way to say "warn now, block if this is still true later", which is what most teams actually want from a soft limit — enough room to react to an over-quota volume without a job failing immediately, and a guarantee that it will not stay over quota indefinitely. Weka's quota API already supports a grace period; this exposes it through the StorageClass.

<!-- CURSOR_SUMMARY -->

<!-- /CURSOR_SUMMARY -->