### PR TITLE
feat: implement external volume health monitoring via WEKA REST API

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -24,6 +24,7 @@ csi-wekafs/
 │   ├── wekafs.go                # Driver init, gRPC setup, health probes
 │   ├── volume.go                # Volume abstraction, capacity, xattr metadata
 │   ├── snapshot.go              # Snapshot operations & state
+│   ├── volumehealth.go          # ControllerGetVolume: volume condition & capacity via REST API
 │   ├── wekafsmount.go           # Native Weka mount operations
 │   ├── nfsmount.go              # NFS fallback mount operations
 │   ├── driverconfig.go          # Configuration management
@@ -70,7 +71,7 @@ go test ./pkg/wekafs/apiclient/... # API client tests
 Deploy: `helm install csi-wekafsplugin charts/csi-wekafsplugin/`
 
 Key components deployed:
-- **Controller Deployment** with sidecars: provisioner, attacher, resizer, snapshotter
+- **Controller Deployment** with sidecars: provisioner, attacher, resizer, snapshotter, external-health-monitor
 - **Node DaemonSet** with liveness probe sidecar
 - RBAC roles, CSIDriver resource, optional SELinux policy
 
@@ -80,6 +81,7 @@ Key components deployed:
 - Error types: transient vs non-transient in `apiclient/errors.go`
 - Volume IDs encode filesystem/snapshot/path info - see `utilities.go`
 - Mount operations have separate implementations: native Weka (`wekafsmount.go`) and NFS (`nfsmount.go`)
+- Controller-side Kubernetes access goes through the controller-runtime manager: `manager.GetClient()` for cached PV reads (indexed by `spec.csi.volumeHandle`), `manager.GetAPIReader()` for Secrets, so no Secret informer is started
 - Tests colocated with source files (`*_test.go`)
 
 ## Workflow Rules

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ make build
 | controller.maxConcurrentRequests | int | `5` | Maximum concurrent requests from sidecars (global) |
 | controller.concurrency | object | `{"createSnapshot":5,"createVolume":5,"deleteSnapshot":5,"deleteVolume":5,"expandVolume":5}` | maximum concurrent operations per operation type |
 | controller.grpcRequestTimeoutSeconds | int | `30` | Return GRPC Unavailable if request waits in queue for that long time (seconds) |
-| controller.healthMonitor | object | `{"enabled":true,"monitorInterval":"5m"}` | Volume health monitoring: periodically checks volume condition via the Weka API and reports abnormal volumes as events on the PVC |
+| controller.healthMonitor | object | `{"enabled":true,"monitorInterval":"5m","timeoutSeconds":300}` | Volume health monitoring: periodically checks volume condition via the Weka API and reports abnormal volumes as events on the PVC |
 | controller.nodeSelector | object | `{}` | optional nodeSelector for controller components only |
 | controller.affinity | object | `{}` | optional affinity for controller components only |
 | controller.labels | object | `{}` | optional labels to add to controller deployment |

--- a/README.md
+++ b/README.md
@@ -32,6 +32,25 @@ https://github.com/weka/csi-wekafs
 - [SELinux Support & Installation Notes](selinux/README.md)
 - [Using Weka CSI Plugin with NFS transport](docs/NFS.md)
 
+## Volume Health Monitoring
+The CSI plugin reports the condition and actual capacity of provisioned volumes through the CSI
+`ControllerGetVolume` call, and the bundled `csi-external-health-monitor-controller` sidecar surfaces
+unhealthy volumes as warning events on the corresponding PersistentVolumeClaim.
+
+The condition is determined entirely through the Weka REST API - no volume is mounted for the check.
+A volume is reported abnormal when its filesystem, or the directory backing it, no longer exists on
+the Weka cluster. Credentials are taken from the API secret referenced by the PersistentVolume.
+
+- The check runs every `controller.healthMonitor.monitorInterval` (default `5m`)
+- While enabled, the controller keeps a watch on all PersistentVolumes in the cluster, holding only
+  the few fields it needs for each
+- `controller.healthMonitor.enabled=false` turns the feature off completely - the sidecar is not
+  deployed, the capability is not advertised, and the driver does not watch PersistentVolumes.
+  Outside Helm, the same is done with `--advertisevolumehealthsupport=false`
+- Reporting requires Weka 4.3 or later (4.4.7 or later when the API user has the `CSI` role), since
+  older clusters cannot resolve a path to an inode over the API. On older clusters the volume
+  condition is reported as unknown rather than abnormal, and capacity is taken from the PV
+
 ## Additional Documentation
 - [Official Weka CSI Plugin documentation](https://docs.weka.io/appendices/weka-csi-plugin)
 
@@ -55,6 +74,7 @@ make build
 | images.registrarsidecar | string | `"registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.16.0"` | CSI registrar sidercar |
 | images.resizersidecar | string | `"registry.k8s.io/sig-storage/csi-resizer:v2.1.0"` | CSI resizer sidecar image URL |
 | images.snapshottersidecar | string | `"registry.k8s.io/sig-storage/csi-snapshotter:v8.5.0"` | CSI snapshotter sidecar image URL |
+| images.healthmonitorsidecar | string | `"registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.17.0"` | CSI external health monitor sidecar image URL |
 | images.csidriver | string | `"quay.io/weka.io/csi-wekafs"` | CSI driver main image URL |
 | images.csidriverTag | string | `"2.8.9"` | CSI driver tag |
 | imagePullSecret | string | `""` | image pull secret required for image download. Must have permissions to access all images above.    Should be used in case of private registry that requires authentication |
@@ -69,16 +89,13 @@ make build
 | controller.maxConcurrentRequests | int | `5` | Maximum concurrent requests from sidecars (global) |
 | controller.concurrency | object | `{"createSnapshot":5,"createVolume":5,"deleteSnapshot":5,"deleteVolume":5,"expandVolume":5}` | maximum concurrent operations per operation type |
 | controller.grpcRequestTimeoutSeconds | int | `30` | Return GRPC Unavailable if request waits in queue for that long time (seconds) |
-| controller.configureProvisionerLeaderElection | bool | `true` | Configure provisioner sidecar for leader election |
-| controller.configureResizerLeaderElection | bool | `true` | Configure resizer sidecar for leader election |
-| controller.configureSnapshotterLeaderElection | bool | `true` | Configure snapshotter sidecar for leader election |
-| controller.configureAttacherLeaderElection | bool | `true` | Configure attacher sidecar for leader election |
+| controller.healthMonitor | object | `{"enabled":true,"monitorInterval":"5m"}` | Volume health monitoring: periodically checks volume condition via the Weka API and reports abnormal volumes as events on the PVC |
 | controller.nodeSelector | object | `{}` | optional nodeSelector for controller components only |
 | controller.affinity | object | `{}` | optional affinity for controller components only |
 | controller.labels | object | `{}` | optional labels to add to controller deployment |
 | controller.podLabels | object | `{}` | optional labels to add to controller pods |
 | controller.terminationGracePeriodSeconds | int | `10` | termination grace period for controller pods |
-| controller.resources | object | `{"csiAttacher":{"limits":{"cpu":1,"memory":"1Gi"},"requests":{"cpu":"4m","memory":"48Mi"}},"csiProvisioner":{"limits":{"cpu":1,"memory":"3Gi"},"requests":{"cpu":"128m","memory":"128Mi"}},"csiResizer":{"limits":{"cpu":1,"memory":"2Gi"},"requests":{"cpu":"4m","memory":"48Mi"}},"csiSnapshotter":{"limits":{"cpu":1,"memory":"1Gi"},"requests":{"cpu":"4m","memory":"48Mi"}},"wekafs":{"limits":{"cpu":1,"memory":"3Gi"},"requests":{"cpu":"128m","memory":"128Mi"}}}` | resource requests and limits for controller containers |
+| controller.resources | object | `{"csiAttacher":{"limits":{"cpu":1,"memory":"1Gi"},"requests":{"cpu":"4m","memory":"48Mi"}},"csiHealthMonitor":{"limits":{"cpu":1,"memory":"1Gi"},"requests":{"cpu":"4m","memory":"48Mi"}},"csiProvisioner":{"limits":{"cpu":1,"memory":"3Gi"},"requests":{"cpu":"128m","memory":"128Mi"}},"csiResizer":{"limits":{"cpu":1,"memory":"2Gi"},"requests":{"cpu":"4m","memory":"48Mi"}},"csiSnapshotter":{"limits":{"cpu":1,"memory":"1Gi"},"requests":{"cpu":"4m","memory":"48Mi"}},"wekafs":{"limits":{"cpu":1,"memory":"3Gi"},"requests":{"cpu":"128m","memory":"128Mi"}}}` | resource requests and limits for controller containers |
 | node.concurrency | object | `{"nodePublishVolume":5,"nodeUnpublishVolume":5}` | maximum concurrent operations per operation type (to avoid API starvation) |
 | node.grpcRequestTimeoutSeconds | int | `30` | Return GRPC Unavailable if request waits in queue for that long time (seconds) |
 | node.nodeSelector | object | `{}` | optional nodeSelector for node components only |

--- a/README.md.gotmpl
+++ b/README.md.gotmpl
@@ -28,6 +28,25 @@
 - [SELinux Support & Installation Notes](selinux/README.md)
 - [Using Weka CSI Plugin with NFS transport](docs/NFS.md)
 
+## Volume Health Monitoring
+The CSI plugin reports the condition and actual capacity of provisioned volumes through the CSI
+`ControllerGetVolume` call, and the bundled `csi-external-health-monitor-controller` sidecar surfaces
+unhealthy volumes as warning events on the corresponding PersistentVolumeClaim.
+
+The condition is determined entirely through the Weka REST API - no volume is mounted for the check.
+A volume is reported abnormal when its filesystem, or the directory backing it, no longer exists on
+the Weka cluster. Credentials are taken from the API secret referenced by the PersistentVolume.
+
+- The check runs every `controller.healthMonitor.monitorInterval` (default `5m`)
+- While enabled, the controller keeps a watch on all PersistentVolumes in the cluster, holding only
+  the few fields it needs for each
+- `controller.healthMonitor.enabled=false` turns the feature off completely - the sidecar is not
+  deployed, the capability is not advertised, and the driver does not watch PersistentVolumes.
+  Outside Helm, the same is done with `--advertisevolumehealthsupport=false`
+- Reporting requires Weka 4.3 or later (4.4.7 or later when the API user has the `CSI` role), since
+  older clusters cannot resolve a path to an inode over the API. On older clusters the volume
+  condition is reported as unknown rather than abnormal, and capacity is taken from the PV
+
 ## Additional Documentation
 - [Official Weka CSI Plugin documentation](https://docs.weka.io/appendices/weka-csi-plugin)
 

--- a/charts/csi-wekafsplugin/README.md
+++ b/charts/csi-wekafsplugin/README.md
@@ -87,7 +87,7 @@ helm install csi-wekafsplugin csi-wekafs/csi-wekafsplugin --namespace csi-wekafs
 | controller.maxConcurrentRequests | int | `5` | Maximum concurrent requests from sidecars (global) |
 | controller.concurrency | object | `{"createSnapshot":5,"createVolume":5,"deleteSnapshot":5,"deleteVolume":5,"expandVolume":5}` | maximum concurrent operations per operation type |
 | controller.grpcRequestTimeoutSeconds | int | `30` | Return GRPC Unavailable if request waits in queue for that long time (seconds) |
-| controller.healthMonitor | object | `{"enabled":true,"monitorInterval":"5m"}` | Volume health monitoring: periodically checks volume condition via the Weka API and reports abnormal volumes as events on the PVC |
+| controller.healthMonitor | object | `{"enabled":true,"monitorInterval":"5m","timeoutSeconds":300}` | Volume health monitoring: periodically checks volume condition via the Weka API and reports abnormal volumes as events on the PVC |
 | controller.nodeSelector | object | `{}` | optional nodeSelector for controller components only |
 | controller.affinity | object | `{}` | optional affinity for controller components only |
 | controller.labels | object | `{}` | optional labels to add to controller deployment |

--- a/charts/csi-wekafsplugin/README.md
+++ b/charts/csi-wekafsplugin/README.md
@@ -72,6 +72,7 @@ helm install csi-wekafsplugin csi-wekafs/csi-wekafsplugin --namespace csi-wekafs
 | images.registrarsidecar | string | `"registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.16.0"` | CSI registrar sidercar |
 | images.resizersidecar | string | `"registry.k8s.io/sig-storage/csi-resizer:v2.1.0"` | CSI resizer sidecar image URL |
 | images.snapshottersidecar | string | `"registry.k8s.io/sig-storage/csi-snapshotter:v8.5.0"` | CSI snapshotter sidecar image URL |
+| images.healthmonitorsidecar | string | `"registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.17.0"` | CSI external health monitor sidecar image URL |
 | images.csidriver | string | `"quay.io/weka.io/csi-wekafs"` | CSI driver main image URL |
 | images.csidriverTag | string | `"2.8.9"` | CSI driver tag |
 | imagePullSecret | string | `""` | image pull secret required for image download. Must have permissions to access all images above.    Should be used in case of private registry that requires authentication |
@@ -86,16 +87,13 @@ helm install csi-wekafsplugin csi-wekafs/csi-wekafsplugin --namespace csi-wekafs
 | controller.maxConcurrentRequests | int | `5` | Maximum concurrent requests from sidecars (global) |
 | controller.concurrency | object | `{"createSnapshot":5,"createVolume":5,"deleteSnapshot":5,"deleteVolume":5,"expandVolume":5}` | maximum concurrent operations per operation type |
 | controller.grpcRequestTimeoutSeconds | int | `30` | Return GRPC Unavailable if request waits in queue for that long time (seconds) |
-| controller.configureProvisionerLeaderElection | bool | `true` | Configure provisioner sidecar for leader election |
-| controller.configureResizerLeaderElection | bool | `true` | Configure resizer sidecar for leader election |
-| controller.configureSnapshotterLeaderElection | bool | `true` | Configure snapshotter sidecar for leader election |
-| controller.configureAttacherLeaderElection | bool | `true` | Configure attacher sidecar for leader election |
+| controller.healthMonitor | object | `{"enabled":true,"monitorInterval":"5m"}` | Volume health monitoring: periodically checks volume condition via the Weka API and reports abnormal volumes as events on the PVC |
 | controller.nodeSelector | object | `{}` | optional nodeSelector for controller components only |
 | controller.affinity | object | `{}` | optional affinity for controller components only |
 | controller.labels | object | `{}` | optional labels to add to controller deployment |
 | controller.podLabels | object | `{}` | optional labels to add to controller pods |
 | controller.terminationGracePeriodSeconds | int | `10` | termination grace period for controller pods |
-| controller.resources | object | `{"csiAttacher":{"limits":{"cpu":1,"memory":"1Gi"},"requests":{"cpu":"4m","memory":"48Mi"}},"csiProvisioner":{"limits":{"cpu":1,"memory":"3Gi"},"requests":{"cpu":"128m","memory":"128Mi"}},"csiResizer":{"limits":{"cpu":1,"memory":"2Gi"},"requests":{"cpu":"4m","memory":"48Mi"}},"csiSnapshotter":{"limits":{"cpu":1,"memory":"1Gi"},"requests":{"cpu":"4m","memory":"48Mi"}},"wekafs":{"limits":{"cpu":1,"memory":"3Gi"},"requests":{"cpu":"128m","memory":"128Mi"}}}` | resource requests and limits for controller containers |
+| controller.resources | object | `{"csiAttacher":{"limits":{"cpu":1,"memory":"1Gi"},"requests":{"cpu":"4m","memory":"48Mi"}},"csiHealthMonitor":{"limits":{"cpu":1,"memory":"1Gi"},"requests":{"cpu":"4m","memory":"48Mi"}},"csiProvisioner":{"limits":{"cpu":1,"memory":"3Gi"},"requests":{"cpu":"128m","memory":"128Mi"}},"csiResizer":{"limits":{"cpu":1,"memory":"2Gi"},"requests":{"cpu":"4m","memory":"48Mi"}},"csiSnapshotter":{"limits":{"cpu":1,"memory":"1Gi"},"requests":{"cpu":"4m","memory":"48Mi"}},"wekafs":{"limits":{"cpu":1,"memory":"3Gi"},"requests":{"cpu":"128m","memory":"128Mi"}}}` | resource requests and limits for controller containers |
 | node.concurrency | object | `{"nodePublishVolume":5,"nodeUnpublishVolume":5}` | maximum concurrent operations per operation type (to avoid API starvation) |
 | node.grpcRequestTimeoutSeconds | int | `30` | Return GRPC Unavailable if request waits in queue for that long time (seconds) |
 | node.nodeSelector | object | `{}` | optional nodeSelector for node components only |

--- a/charts/csi-wekafsplugin/templates/controllerserver-clusterrole.yaml
+++ b/charts/csi-wekafsplugin/templates/controllerserver-clusterrole.yaml
@@ -22,9 +22,11 @@ rules:
   - apiGroups: ["storage.k8s.io"]
     resources: ["storageclasses"]
     verbs: ["get", "list", "watch"]
+  # events (get/list/watch/create/update/patch), persistentvolumeclaims (get/list/watch, above) and
+  # nodes (get/list/watch, below) are also required by the external health monitor sidecar
   - apiGroups: [""]
     resources: ["events"]
-    verbs: ["list", "watch", "create", "update", "patch"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
   - apiGroups: ["storage.k8s.io"]
     resources: ["csinodes"]
     verbs: ["get", "list", "watch"]

--- a/charts/csi-wekafsplugin/templates/controllerserver-deployment.yaml
+++ b/charts/csi-wekafsplugin/templates/controllerserver-deployment.yaml
@@ -120,6 +120,9 @@ spec:
             - "--enforcedirvoltotalcapacity"
           {{- end }}
             - "--keepthinprovisioningratioonexpand={{ .Values.pluginConfig.allowedOperations.keepThinProvisioningRatioOnExpand }}"
+            {{/* Tied to the sidecar: with nothing calling ControllerGetVolume, advertising the
+                 capability would only make the driver watch every PV for no consumer. */}}
+            - "--advertisevolumehealthsupport={{ .Values.controller.healthMonitor.enabled }}"
           {{- if .Values.pluginConfig.mountProtocol.useNfs | default false }}
             - "--usenfs"
           {{- end }}
@@ -380,6 +383,36 @@ spec:
           resources:
             {{- toYaml .Values.controller.resources.csiSnapshotter | nindent 12 }}
           {{- end }}
+        {{- if .Values.controller.healthMonitor.enabled }}
+        - name: csi-external-health-monitor-controller
+          {{- if and .Values.hostNetwork (.Capabilities.APIVersions.Has "security.openshift.io/v1/SecurityContextConstraints") }}
+          securityContext:
+            privileged: true
+          {{- end }}
+          image: {{ required "csi external health monitor sidecar image." .Values.images.healthmonitorsidecar }}
+          command: ["/shared/wait-for-leader"]
+          args:
+            - "/csi-external-health-monitor-controller"
+            - "--v={{ .Values.logLevel | default 5 }}"
+            - "--csi-address=$(ADDRESS)"
+            - "--timeout=60s"
+            - "--monitor-interval={{ .Values.controller.healthMonitor.monitorInterval }}"
+          env:
+            - name: ADDRESS
+              value: unix:///csi/csi.sock
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /csi
+            - name: leader-state
+              mountPath: /leader-state
+              readOnly: true
+            - name: shared-bin
+              mountPath: /shared
+          {{- if .Values.controller.resources.csiHealthMonitor }}
+          resources:
+            {{- toYaml .Values.controller.resources.csiHealthMonitor | nindent 12 }}
+          {{- end }}
+        {{- end }}
       {{- with .Values.controllerPluginTolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/charts/csi-wekafsplugin/templates/controllerserver-deployment.yaml
+++ b/charts/csi-wekafsplugin/templates/controllerserver-deployment.yaml
@@ -396,7 +396,11 @@ spec:
             - "--v={{ .Values.logLevel | default 5 }}"
             - "--csi-address=$(ADDRESS)"
             - "--timeout=60s"
+            {{/* The sidecar sweeps the fleet with ListVolumes when the driver advertises
+                 LIST_VOLUMES, and falls back to one ControllerGetVolume per volume otherwise.
+                 Those paths read different flags, so set both from the same value. */}}
             - "--monitor-interval={{ .Values.controller.healthMonitor.monitorInterval }}"
+            - "--list-volumes-interval={{ .Values.controller.healthMonitor.monitorInterval }}"
           env:
             - name: ADDRESS
               value: unix:///csi/csi.sock

--- a/charts/csi-wekafsplugin/templates/controllerserver-deployment.yaml
+++ b/charts/csi-wekafsplugin/templates/controllerserver-deployment.yaml
@@ -395,7 +395,10 @@ spec:
             - "/csi-external-health-monitor-controller"
             - "--v={{ .Values.logLevel | default 5 }}"
             - "--csi-address=$(ADDRESS)"
-            - "--timeout=60s"
+            {{/* This budget covers the WHOLE paginated sweep, not one page, so it has to exceed the
+                 time to walk every volume. Too low and the sweep is cut off mid-fleet and restarts
+                 from the beginning next time, leaving the tail permanently unchecked. */}}
+            - "--timeout={{ .Values.controller.healthMonitor.timeoutSeconds }}s"
             {{/* The sidecar sweeps the fleet with ListVolumes when the driver advertises
                  LIST_VOLUMES, and falls back to one ControllerGetVolume per volume otherwise.
                  Those paths read different flags, so set both from the same value. */}}

--- a/charts/csi-wekafsplugin/values.schema.json
+++ b/charts/csi-wekafsplugin/values.schema.json
@@ -42,6 +42,9 @@
                         },
                         "monitorInterval": {
                             "type": "string"
+                        },
+                        "timeoutSeconds": {
+                            "type": "integer"
                         }
                     }
                 },

--- a/charts/csi-wekafsplugin/values.schema.json
+++ b/charts/csi-wekafsplugin/values.schema.json
@@ -31,20 +31,19 @@
                         }
                     }
                 },
-                "configureAttacherLeaderElection": {
-                    "type": "boolean"
-                },
-                "configureProvisionerLeaderElection": {
-                    "type": "boolean"
-                },
-                "configureResizerLeaderElection": {
-                    "type": "boolean"
-                },
-                "configureSnapshotterLeaderElection": {
-                    "type": "boolean"
-                },
                 "grpcRequestTimeoutSeconds": {
                     "type": "integer"
+                },
+                "healthMonitor": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "monitorInterval": {
+                            "type": "string"
+                        }
+                    }
                 },
                 "labels": {
                     "type": "object"
@@ -125,6 +124,9 @@
                     "type": "string"
                 },
                 "csidriverTag": {
+                    "type": "string"
+                },
+                "healthmonitorsidecar": {
                     "type": "string"
                 },
                 "livenessprobesidecar": {

--- a/charts/csi-wekafsplugin/values.yaml
+++ b/charts/csi-wekafsplugin/values.yaml
@@ -19,6 +19,8 @@ images:
   resizersidecar: registry.k8s.io/sig-storage/csi-resizer:v2.1.0
   # -- CSI snapshotter sidecar image URL
   snapshottersidecar: registry.k8s.io/sig-storage/csi-snapshotter:v8.5.0
+  # -- CSI external health monitor sidecar image URL
+  healthmonitorsidecar: registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.17.0
   # -- CSI driver main image URL
   csidriver: quay.io/weka.io/csi-wekafs
   # -- CSI driver tag
@@ -63,14 +65,12 @@ controller:
     deleteSnapshot: 5
   # -- Return GRPC Unavailable if request waits in queue for that long time (seconds)
   grpcRequestTimeoutSeconds: 30
-  # -- Configure provisioner sidecar for leader election
-  configureProvisionerLeaderElection: true
-  # -- Configure resizer sidecar for leader election
-  configureResizerLeaderElection: true
-  # -- Configure snapshotter sidecar for leader election
-  configureSnapshotterLeaderElection: true
-  # -- Configure attacher sidecar for leader election
-  configureAttacherLeaderElection: true
+  # -- Volume health monitoring: periodically checks volume condition via the Weka API and reports abnormal volumes as events on the PVC
+  healthMonitor:
+    # -- Enable the external health monitor sidecar
+    enabled: true
+    # -- How often to check volume health
+    monitorInterval: 5m
   # -- optional nodeSelector for controller components only
   nodeSelector: {}
   # -- optional affinity for controller components only
@@ -112,6 +112,13 @@ controller:
         cpu: 4m
         memory: 48Mi
     csiSnapshotter:
+      limits:
+        cpu: 1
+        memory: 1Gi
+      requests:
+        cpu: 4m
+        memory: 48Mi
+    csiHealthMonitor:
       limits:
         cpu: 1
         memory: 1Gi

--- a/charts/csi-wekafsplugin/values.yaml
+++ b/charts/csi-wekafsplugin/values.yaml
@@ -71,6 +71,12 @@ controller:
     enabled: true
     # -- How often to check volume health
     monitorInterval: 5m
+    # -- Time budget for one full sweep of every volume, in seconds. This is not a per-request
+    #    timeout: the sidecar walks all pages under a single deadline, so a fleet that takes longer
+    #    than this is cut off mid-sweep and restarted from the beginning, leaving later volumes
+    #    permanently unchecked. Measured at roughly 15 seconds per 1000 volumes; raise it for
+    #    larger fleets.
+    timeoutSeconds: 300
   # -- optional nodeSelector for controller components only
   nodeSelector: {}
   # -- optional affinity for controller components only

--- a/cmd/wekafsplugin/ctxlog_test.go
+++ b/cmd/wekafsplugin/ctxlog_test.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+)
+
+// Guards the fix: without DefaultContextLogger, log.Ctx on a bare context is disabled and the line
+// vanishes. Startup paths and background goroutines both hand us such contexts.
+func TestBareContextStillLogs(t *testing.T) {
+	var buf bytes.Buffer
+	prev, prevDefault := log.Logger, zerolog.DefaultContextLogger
+	defer func() { log.Logger, zerolog.DefaultContextLogger = prev, prevDefault }()
+
+	log.Logger = zerolog.New(&buf)
+
+	zerolog.DefaultContextLogger = nil
+	log.Ctx(context.Background()).Info().Msg("swallowed")
+	if buf.Len() != 0 {
+		t.Fatalf("expected the line to be dropped without the fallback, got %q", buf.String())
+	}
+
+	zerolog.DefaultContextLogger = &log.Logger
+	log.Ctx(context.Background()).Info().Msg("survives")
+	if !strings.Contains(buf.String(), "survives") {
+		t.Fatalf("expected the fallback to emit the line, got %q", buf.String())
+	}
+}

--- a/cmd/wekafsplugin/main.go
+++ b/cmd/wekafsplugin/main.go
@@ -107,6 +107,7 @@ var (
 	setOwnershipOnDynamicFilesystems     = flag.Bool("setownershipondynamicfilesystems", false, "Set ownership on Dynamic Filesystems (only OrgAdmin/CSI user that created the filesystem will be able to mount it")
 	allowMountOptionOverrides            = flag.Bool("allowmountoptionoverrides", false, "Allow mount option overrides via PVC and pod annotations")
 	keepThinProvisioningRatioOnExpand    = flag.Bool("keepthinprovisioningratioonexpand", true, "On filesystem expansion, scale thin-provisioning min-SSD and max-SSD to preserve their ratios to total capacity")
+	advertiseVolumeHealthSupport         = flag.Bool("advertisevolumehealthsupport", true, "Expose GET_VOLUME and VOLUME_CONDITION, allowing the CSI health monitor to report volume condition and capacity")
 	// Set by the build process
 	version = ""
 )
@@ -251,6 +252,7 @@ func handle(ctx context.Context) {
 		*setOwnershipOnDynamicFilesystems,
 		*allowMountOptionOverrides,
 		*keepThinProvisioningRatioOnExpand,
+		*advertiseVolumeHealthSupport,
 	)
 	driver, err := wekafs.NewWekaFsDriver(*driverName, *nodeID, *endpoint, *maxVolumesPerNode, version, *debugPath, csiMode, *selinuxSupport, config)
 	if err != nil {

--- a/cmd/wekafsplugin/main.go
+++ b/cmd/wekafsplugin/main.go
@@ -139,6 +139,11 @@ func main() {
 		log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr, TimeFormat: time.RFC3339Nano}).With().Caller().Logger()
 	}
 	zerolog.SetGlobalLevel(mapVerbosity(*verbosity))
+	// log.Ctx returns a *disabled* logger for a context that carries none, so anything written from
+	// a startup path or a background goroutine - neither of which passes through a gRPC handler that
+	// attaches one - is discarded without a trace. Fall back to the global logger instead, so a
+	// missing context logger costs the request fields rather than the whole line.
+	zerolog.DefaultContextLogger = &log.Logger
 
 	csiMode = wekafs.GetCsiPluginMode(csimodetext)
 	if *showVersion {

--- a/pkg/wekafs/apiclient/resolvepath.go
+++ b/pkg/wekafs/apiclient/resolvepath.go
@@ -70,6 +70,9 @@ func (a *ApiClient) ResolvePathToInode(ctx context.Context, fs *FileSystem, path
 			if strings.Contains(t.ApiResponse.Message, "PATH_NOT_FOUND") {
 				return 0, ObjectNotFoundError
 			}
+			// Any other bad request is a real failure and must not be reported as a missing
+			// path - callers act on ObjectNotFoundError as proof the path is gone.
+			return 0, err
 
 		default:
 			return 0, err

--- a/pkg/wekafs/controllerserver.go
+++ b/pkg/wekafs/controllerserver.go
@@ -74,6 +74,7 @@ type ControllerServer struct {
 	semaphores      map[string]*semaphore.Weighted
 	manager         ctrl.Manager     // For listing PVs via K8s client
 	capacityTracker *CapacityTracker // Tracks confirmed + pending capacity
+	secretCache     *secretCache     // Memoizes Secrets read during volume health checks
 	sync.Mutex
 }
 
@@ -122,11 +123,6 @@ func (cs *ControllerServer) GetCapacity(c context.Context, request *csi.GetCapac
 }
 
 //goland:noinspection GoUnusedParameter
-func (cs *ControllerServer) ControllerGetVolume(context.Context, *csi.ControllerGetVolumeRequest) (*csi.ControllerGetVolumeResponse, error) {
-	panic("implement me")
-}
-
-//goland:noinspection GoUnusedParameter
 func (cs *ControllerServer) ControllerModifyVolume(context.Context, *csi.ControllerModifyVolumeRequest) (*csi.ControllerModifyVolumeResponse, error) {
 	panic("implement me")
 }
@@ -143,17 +139,25 @@ func NewControllerServer(nodeID string, api *ApiStore, mounter AnyMounter, confi
 	if config.advertiseVolumeCloneSupport {
 		exposedCapabilities = append(exposedCapabilities, csi.ControllerServiceCapability_RPC_CLONE_VOLUME)
 	}
+	// ControllerGetVolume answers purely over the Weka REST API, but its credentials come from
+	// the PersistentVolume, so serving it needs both a Kubernetes client and a real backend.
+	if config.advertiseVolumeHealthSupport && manager != nil && !config.isInDevMode() {
+		exposedCapabilities = append(exposedCapabilities,
+			csi.ControllerServiceCapability_RPC_GET_VOLUME,
+			csi.ControllerServiceCapability_RPC_VOLUME_CONDITION)
+	}
 
 	capabilities := getControllerServiceCapabilities(exposedCapabilities)
 
 	cs := &ControllerServer{
-		caps:       capabilities,
-		nodeID:     nodeID,
-		mounter:    mounter,
-		api:        api,
-		config:     config,
-		semaphores: make(map[string]*semaphore.Weighted),
-		manager:    manager,
+		caps:        capabilities,
+		nodeID:      nodeID,
+		mounter:     mounter,
+		api:         api,
+		config:      config,
+		semaphores:  make(map[string]*semaphore.Weighted),
+		manager:     manager,
+		secretCache: newSecretCache(volumeSecretCacheTTL),
 	}
 
 	// Initialize capacity tracker if manager available

--- a/pkg/wekafs/controllerserver.go
+++ b/pkg/wekafs/controllerserver.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -76,6 +77,10 @@ type ControllerServer struct {
 	manager         ctrl.Manager     // For listing PVs via K8s client
 	capacityTracker *CapacityTracker // Tracks confirmed + pending capacity
 	secretCache     *secretCache     // Memoizes Secrets read during volume health checks
+	// conditionCache holds volume conditions maintained in the background; ListVolumes answers from
+	// it. Non-nil exactly when the volume health capabilities are advertised.
+	conditionCache   *volumeConditionCache
+	healthReconciler *volumeHealthReconciler
 	sync.Mutex
 }
 
@@ -157,6 +162,13 @@ func NewControllerServer(nodeID string, api *ApiStore, mounter AnyMounter, confi
 		semaphores:  make(map[string]*semaphore.Weighted),
 		manager:     manager,
 		secretCache: newSecretCache(volumeSecretCacheTTL),
+	}
+
+	// Volume health is served from a cache kept warm by a background reconciler, so build both
+	// whenever those capabilities were advertised above.
+	if slices.Contains(exposedCapabilities, csi.ControllerServiceCapability_RPC_LIST_VOLUMES) {
+		cs.conditionCache = newVolumeConditionCache()
+		cs.healthReconciler = newVolumeHealthReconciler(cs, cs.conditionCache)
 	}
 
 	// Initialize capacity tracker if manager available

--- a/pkg/wekafs/controllerserver.go
+++ b/pkg/wekafs/controllerserver.go
@@ -20,11 +20,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/wekafs/csi-wekafs/pkg/wekafs/apiclient"
 	"os"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/wekafs/csi-wekafs/pkg/wekafs/apiclient"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/rs/zerolog"
@@ -113,11 +114,6 @@ func (cs *ControllerServer) ControllerUnpublishVolume(c context.Context, request
 }
 
 //goland:noinspection GoUnusedParameter
-func (cs *ControllerServer) ListVolumes(c context.Context, request *csi.ListVolumesRequest) (*csi.ListVolumesResponse, error) {
-	panic("implement me")
-}
-
-//goland:noinspection GoUnusedParameter
 func (cs *ControllerServer) GetCapacity(c context.Context, request *csi.GetCapacityRequest) (*csi.GetCapacityResponse, error) {
 	panic("implement me")
 }
@@ -139,11 +135,14 @@ func NewControllerServer(nodeID string, api *ApiStore, mounter AnyMounter, confi
 	if config.advertiseVolumeCloneSupport {
 		exposedCapabilities = append(exposedCapabilities, csi.ControllerServiceCapability_RPC_CLONE_VOLUME)
 	}
-	// ControllerGetVolume answers purely over the Weka REST API, but its credentials come from
-	// the PersistentVolume, so serving it needs both a Kubernetes client and a real backend.
+	// These answer purely over the Weka REST API, but their credentials come from the
+	// PersistentVolume, so serving them needs both a Kubernetes client and a real backend.
+	// LIST_VOLUMES matters for scale: it lets a consumer sweep the whole fleet in pages rather
+	// than one ControllerGetVolume per volume.
 	if config.advertiseVolumeHealthSupport && manager != nil && !config.isInDevMode() {
 		exposedCapabilities = append(exposedCapabilities,
 			csi.ControllerServiceCapability_RPC_GET_VOLUME,
+			csi.ControllerServiceCapability_RPC_LIST_VOLUMES,
 			csi.ControllerServiceCapability_RPC_VOLUME_CONDITION)
 	}
 
@@ -543,7 +542,7 @@ func (ct *CapacityTracker) refreshFromKubernetesLocked(ctx context.Context, driv
 	capacityByFS := make(map[string]int64)
 	for _, pv := range pvList.Items {
 		// Filter for our driver
-		if pv.Spec.CSI == nil || pv.Spec.CSI.Driver != driverName {
+		if !isDriverPersistentVolume(&pv, driverName) {
 			continue
 		}
 

--- a/pkg/wekafs/driverconfig.go
+++ b/pkg/wekafs/driverconfig.go
@@ -27,6 +27,7 @@ type DriverConfig struct {
 	allowSnapshotsOfDirectoryVolumes  bool
 	advertiseSnapshotSupport          bool
 	advertiseVolumeCloneSupport       bool
+	advertiseVolumeHealthSupport      bool
 	debugPath                         string
 	allowInsecureHttps                bool
 	alwaysAllowSnapshotVolumes        bool
@@ -59,6 +60,7 @@ func (dc *DriverConfig) Log() {
 		Str("volume_prefix", dc.VolumePrefix).Str("snapshot_prefix", dc.SnapshotPrefix).Str("seed_snapshot_prefix", dc.SnapshotPrefix).
 		Bool("allow_auto_fs_creation", dc.allowAutoFsCreation).Bool("allow_auto_fs_expansion", dc.allowAutoFsExpansion).
 		Bool("advertise_snapshot_support", dc.advertiseSnapshotSupport).Bool("advertise_volume_clone_support", dc.advertiseVolumeCloneSupport).
+		Bool("advertise_volume_health_support", dc.advertiseVolumeHealthSupport).
 		Bool("allow_insecure_https", dc.allowInsecureHttps).Bool("always_allow_snapshot_volumes", dc.alwaysAllowSnapshotVolumes).
 		Interface("mutually_exclusive_mount_options", dc.mutuallyExclusiveOptions).
 		Int64("max_create_volume_reqs", dc.maxConcurrencyPerOp["CreateVolume"]).
@@ -107,6 +109,7 @@ func NewDriverConfig(dynamicVolPath, VolumePrefix, SnapshotPrefix, SeedSnapshotP
 	setOwnershipOnDynamicFilesystems bool,
 	allowMountOptionOverrides bool,
 	keepThinProvisioningRatioOnExpand bool,
+	advertiseVolumeHealthSupport bool,
 ) *DriverConfig {
 
 	var MutuallyExclusiveMountOptions []mutuallyExclusiveMountOptionSet
@@ -140,6 +143,7 @@ func NewDriverConfig(dynamicVolPath, VolumePrefix, SnapshotPrefix, SeedSnapshotP
 		allowSnapshotsOfDirectoryVolumes:  allowSnapshotsOfDirectoryVolumes,
 		advertiseSnapshotSupport:          !suppressnapshotSupport,
 		advertiseVolumeCloneSupport:       !suppressVolumeCloneSupport,
+		advertiseVolumeHealthSupport:      advertiseVolumeHealthSupport,
 		debugPath:                         debugPath,
 		allowInsecureHttps:                allowInsecureHttps,
 		alwaysAllowSnapshotVolumes:        alwaysAllowSnapshotVolumes,
@@ -169,6 +173,14 @@ func NewDriverConfig(dynamicVolPath, VolumePrefix, SnapshotPrefix, SeedSnapshotP
 
 func (dc *DriverConfig) isInDevMode() bool {
 	return dc.debugPath != ""
+}
+
+// requiresPvCaching reports whether any enabled feature reads PersistentVolumes, and hence whether
+// the controller-runtime cache should be set up to hold them. Capacity enforcement lists them to
+// total up provisioned capacity, and volume health reporting resolves a CSI volume handle back to
+// its PersistentVolume. With neither enabled nothing lists PVs and no informer is started.
+func (dc *DriverConfig) requiresPvCaching() bool {
+	return dc.enforceDirVolTotalCapacity || dc.advertiseVolumeHealthSupport
 }
 
 func (dc *DriverConfig) GetVersion() string {

--- a/pkg/wekafs/volume.go
+++ b/pkg/wekafs/volume.go
@@ -1285,7 +1285,7 @@ func (v *Volume) ensureSeedSnapshot(ctx context.Context) (*apiclient.Snapshot, e
 		}
 		if !empty && !v.server.isInDevMode() {
 			logger.Error().Err(err).Msg("Cannot create a seed snapshot, filesystem is not empty")
-			return nil, errors.New("cannot create seed snaspshot on non-empty filesystem")
+			return nil, errors.New("cannot create seed snapshot on non-empty filesystem")
 		}
 
 		if snap, err = v.createSeedSnapshot(ctx); err != nil {

--- a/pkg/wekafs/volume_test.go
+++ b/pkg/wekafs/volume_test.go
@@ -19,7 +19,7 @@ func GetDriverForTest(t *testing.T) *WekaFsDriver {
 		true, true, mutuallyExclusive,
 		1, 1, 1, 1, 1, 1, 1, 10, 5,
 		true, true, true, "", "", "4.1", "v1", false, false, true,
-		"", false, "", false, false, false, true)
+		"", false, "", false, false, false, true, true)
 	driver, err := NewWekaFsDriver("csi.weka.io", nodeId, "unix://tmp/csi.sock", 10, "v1.0", "", CsiModeAll, false, driverConfig)
 	if err != nil {
 		t.Fatalf("Failed to create new driver: %v", err)

--- a/pkg/wekafs/volumehealth.go
+++ b/pkg/wekafs/volumehealth.go
@@ -30,7 +30,6 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/wekafs/csi-wekafs/pkg/wekafs/apiclient"
 	"go.opentelemetry.io/otel"
-	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	v1 "k8s.io/api/core/v1"
@@ -46,12 +45,10 @@ const (
 	volumeSecretCacheTTL = 5 * time.Minute
 	volumeHealthyMessage = "volume exists on the Weka cluster and is reachable via the Weka API"
 
-	// listVolumesPageSize bounds a page when the CO does not set max_entries. Every entry costs a
-	// few Weka API calls, so an unbounded page would not fit inside the gRPC request timeout.
+	// listVolumesPageSize bounds a page when the CO does not set max_entries. Pages are served from
+	// the reconciler's cache, so this is only about response size, not about how much work one call
+	// may do.
 	listVolumesPageSize = 100
-	// listVolumesConcurrency bounds how many volumes of one page are probed at the same time, and
-	// so caps the burst of Weka API calls a single page can produce.
-	listVolumesConcurrency = 10
 	// listVolumesTokenPrefix marks a pagination cursor as this driver's own.
 	listVolumesTokenPrefix = "wekafs:v1:"
 )
@@ -90,9 +87,9 @@ func (v *Volume) ProbeHealth(ctx context.Context) (*VolumeHealth, error) {
 		return nil, ErrVolumeHealthUndetermined
 	}
 
-	// fromCache honours a filesystem object a caller already resolved, which is how ListVolumes
-	// avoids repeating one identical lookup per volume. A single ControllerGetVolume starts with an
-	// empty cache and so still fetches fresh.
+	// fromCache honours a filesystem object a caller already resolved, which is how a reconciler
+	// sweep avoids repeating one identical lookup per volume. A single ControllerGetVolume starts
+	// with an empty cache and so still fetches fresh.
 	fsObj, err := v.getFilesystemObj(ctx, true)
 	if err != nil {
 		return nil, err
@@ -274,33 +271,43 @@ func paginateVolumes(remaining []*v1.PersistentVolume, pageSize int) (page []*v1
 	return page, encodeListVolumesToken(page[len(page)-1].Spec.CSI.VolumeHandle)
 }
 
-// describeVolumes probes a page of volumes concurrently. A volume whose condition cannot be
-// established is still listed, just without a condition - one unreachable volume must not fail
-// the whole page.
+// describeVolumes builds a page of entries from the reconciler's cache, doing no Weka API work at
+// all. That is the point: the health monitor applies its --timeout to an entire paginated sweep
+// rather than to one page, so probing inline here put a hard ceiling on how many volumes could ever
+// be monitored. Volumes the reconciler has not reached yet, or whose result has aged out, are listed
+// without a condition rather than guessed at.
 func (cs *ControllerServer) describeVolumes(ctx context.Context, pvs []*v1.PersistentVolume) []*csi.ListVolumesResponse_Entry {
 	entries := make([]*csi.ListVolumesResponse_Entry, len(pvs))
-	filesystems := newFilesystemCache()
-	var probes errgroup.Group
-	probes.SetLimit(listVolumesConcurrency)
+	uncached := 0
 	for i, pv := range pvs {
-		probes.Go(func() error {
-			volume, condition, err := cs.describeVolume(ctx, pv, filesystems)
-			if err != nil {
-				// describeVolume already returns a nil condition alongside any error, so the entry
-				// is simply listed as unknown rather than failing the whole page.
-				log.Ctx(ctx).Warn().Err(err).Str("volume_id", volume.VolumeId).
-					Msg("Listing volume without a condition")
+		handle := pv.Spec.CSI.VolumeHandle
+		// The PersistentVolume holds the requested size, which stands in until a probe supplies the
+		// size the backend actually reports.
+		volume := &csi.Volume{VolumeId: handle, CapacityBytes: pvCapacityBytes(pv)}
+
+		var condition *csi.VolumeCondition
+		if entry, ok := cs.conditionCache.lookup(handle); ok {
+			if entry.capacity > 0 {
+				volume.CapacityBytes = entry.capacity
 			}
-			// published_node_ids is left unset: this driver has no controller publish step, and it
-			// does not advertise LIST_VOLUMES_PUBLISHED_NODES.
-			entries[i] = &csi.ListVolumesResponse_Entry{
-				Volume: volume,
-				Status: &csi.ListVolumesResponse_VolumeStatus{VolumeCondition: condition},
+			if entry.known {
+				condition = &csi.VolumeCondition{Abnormal: entry.abnormal, Message: entry.message}
 			}
-			return nil
-		})
+		} else {
+			uncached++
+		}
+
+		// published_node_ids is left unset: this driver has no controller publish step, and it does
+		// not advertise LIST_VOLUMES_PUBLISHED_NODES.
+		entries[i] = &csi.ListVolumesResponse_Entry{
+			Volume: volume,
+			Status: &csi.ListVolumesResponse_VolumeStatus{VolumeCondition: condition},
+		}
 	}
-	_ = probes.Wait()
+	if uncached > 0 {
+		log.Ctx(ctx).Debug().Int("uncached", uncached).Int("page", len(pvs)).
+			Msg("Some volumes have no fresh condition yet, listing them as unknown")
+	}
 	return entries
 }
 

--- a/pkg/wekafs/volumehealth.go
+++ b/pkg/wekafs/volumehealth.go
@@ -18,8 +18,11 @@ package wekafs
 
 import (
 	"context"
+	"encoding/base64"
 	"errors"
 	"fmt"
+	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -27,6 +30,7 @@ import (
 	"github.com/rs/zerolog/log"
 	"github.com/wekafs/csi-wekafs/pkg/wekafs/apiclient"
 	"go.opentelemetry.io/otel"
+	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	v1 "k8s.io/api/core/v1"
@@ -41,6 +45,15 @@ const (
 	// about one apiserver read per distinct Secret rather than one per volume.
 	volumeSecretCacheTTL = 5 * time.Minute
 	volumeHealthyMessage = "volume exists on the Weka cluster and is reachable via the Weka API"
+
+	// listVolumesPageSize bounds a page when the CO does not set max_entries. Every entry costs a
+	// few Weka API calls, so an unbounded page would not fit inside the gRPC request timeout.
+	listVolumesPageSize = 100
+	// listVolumesConcurrency bounds how many volumes of one page are probed at the same time, and
+	// so caps the burst of Weka API calls a single page can produce.
+	listVolumesConcurrency = 10
+	// listVolumesTokenPrefix marks a pagination cursor as this driver's own.
+	listVolumesTokenPrefix = "wekafs:v1:"
 )
 
 // ErrVolumeHealthUndetermined is returned when the volume condition cannot be established
@@ -77,7 +90,10 @@ func (v *Volume) ProbeHealth(ctx context.Context) (*VolumeHealth, error) {
 		return nil, ErrVolumeHealthUndetermined
 	}
 
-	fsObj, err := v.getFilesystemObj(ctx, false)
+	// fromCache honours a filesystem object a caller already resolved, which is how ListVolumes
+	// avoids repeating one identical lookup per volume. A single ControllerGetVolume starts with an
+	// empty cache and so still fetches fresh.
+	fsObj, err := v.getFilesystemObj(ctx, true)
 	if err != nil {
 		return nil, err
 	}
@@ -141,54 +157,208 @@ func (cs *ControllerServer) ControllerGetVolume(ctx context.Context, req *csi.Co
 	defer cancel()
 
 	// ControllerGetVolumeRequest carries no secrets, so the PersistentVolume is the only place
-	// left to recover the Weka API credentials from. It also holds the requested size, which is
-	// the fallback answer whenever the backend cannot supply one.
+	// left to recover the Weka API credentials from.
 	pv, err := cs.getPersistentVolumeByHandle(ctx, volumeID)
 	if err != nil {
 		return nil, err
 	}
-	response := &csi.ControllerGetVolumeResponse{
-		Volume: &csi.Volume{
-			VolumeId:      volumeID,
-			CapacityBytes: pvCapacityBytes(pv),
-		},
-		Status: &csi.ControllerGetVolumeResponse_VolumeStatus{},
-	}
 
-	client, err := cs.apiClientFromPersistentVolume(ctx, pv)
-	if err != nil {
-		return nil, status.Errorf(codes.Unavailable, "could not reach the Weka API for volume %s: %v", volumeID, err)
-	}
-	if client == nil {
-		logger.Warn().Str("pv", pv.Name).Msg("No Weka API credentials available for volume, reporting condition as unknown")
-		return response, nil
-	}
-
-	volume, err := NewVolumeFromId(ctx, volumeID, client, cs)
+	volume, condition, err := cs.describeVolume(ctx, pv, nil)
 	if err != nil {
 		return nil, err
 	}
+	return &csi.ControllerGetVolumeResponse{
+		Volume: volume,
+		Status: &csi.ControllerGetVolumeResponse_VolumeStatus{VolumeCondition: condition},
+	}, nil
+}
 
-	health, err := volume.ProbeHealth(ctx)
+// describeVolume resolves a PersistentVolume into the capacity and condition reported by both
+// ControllerGetVolume and ListVolumes. A nil condition with a nil error means the condition could
+// not be established, which callers must report as unknown rather than as abnormal.
+// The filesystems cache may be nil, in which case every lookup goes to the Weka API.
+func (cs *ControllerServer) describeVolume(ctx context.Context, pv *v1.PersistentVolume, filesystems *filesystemCache) (*csi.Volume, *csi.VolumeCondition, error) {
+	volumeID := pv.Spec.CSI.VolumeHandle
+	logger := log.Ctx(ctx).With().Str("volume_id", volumeID).Logger()
+
+	// The PersistentVolume holds the requested size, which stands in whenever the backend cannot
+	// supply one of its own.
+	volume := &csi.Volume{VolumeId: volumeID, CapacityBytes: pvCapacityBytes(pv)}
+
+	client, err := cs.apiClientFromPersistentVolume(ctx, pv)
+	if err != nil {
+		return volume, nil, status.Errorf(codes.Unavailable, "could not reach the Weka API for volume %s: %v", volumeID, err)
+	}
+	if client == nil {
+		logger.Warn().Str("pv", pv.Name).Msg("No Weka API credentials available for volume, reporting condition as unknown")
+		return volume, nil, nil
+	}
+
+	vol, err := NewVolumeFromId(ctx, volumeID, client, cs)
+	if err != nil {
+		return volume, nil, err
+	}
+	// Seed the volume with an already-resolved filesystem, and publish whatever it resolved so the
+	// next volume on the same filesystem can skip the lookup.
+	vol.fileSystemObject = filesystems.get(vol.FilesystemName)
+	defer func() { filesystems.put(vol.FilesystemName, vol.fileSystemObject) }()
+
+	health, err := vol.ProbeHealth(ctx)
 	if err != nil {
 		if errors.Is(err, ErrVolumeHealthUndetermined) {
 			logger.Warn().Err(err).Msg("Reporting volume condition as unknown")
-			return response, nil
+			return volume, nil, nil
 		}
-		return nil, status.Errorf(codes.Internal, "failed to determine condition of volume %s: %v", volumeID, err)
+		return volume, nil, status.Errorf(codes.Internal, "failed to determine condition of volume %s: %v", volumeID, err)
 	}
 
 	if health.Capacity > 0 {
-		response.Volume.CapacityBytes = health.Capacity
-	}
-	response.Status.VolumeCondition = &csi.VolumeCondition{
-		Abnormal: health.Abnormal,
-		Message:  health.Message,
+		volume.CapacityBytes = health.Capacity
 	}
 	if health.Abnormal {
 		logger.Warn().Str("condition", health.Message).Msg("Volume is abnormal")
 	}
+	return volume, &csi.VolumeCondition{Abnormal: health.Abnormal, Message: health.Message}, nil
+}
+
+func (cs *ControllerServer) ListVolumes(ctx context.Context, req *csi.ListVolumesRequest) (*csi.ListVolumesResponse, error) {
+	op := "ListVolumes"
+	ctx, span := otel.Tracer(TracerName).Start(ctx, op)
+	defer span.End()
+	ctx = log.With().Str("trace_id", span.SpanContext().TraceID().String()).Str("span_id", span.SpanContext().SpanID().String()).Str("op", op).Logger().WithContext(ctx)
+
+	logger := log.Ctx(ctx)
+	logger.Debug().Int32("max_entries", req.GetMaxEntries()).Msg(">>>> Received request")
+	defer logger.Debug().Msg("<<<< Completed processing request")
+
+	if err := cs.validateControllerServiceRequest(csi.ControllerServiceCapability_RPC_LIST_VOLUMES); err != nil {
+		logger.Err(err).Msg("Volume listing is not enabled")
+		return nil, err
+	}
+	if req.GetMaxEntries() < 0 {
+		return nil, status.Error(codes.InvalidArgument, "max_entries cannot be negative")
+	}
+	after, err := decodeListVolumesToken(req.GetStartingToken())
+	if err != nil {
+		// The spec mandates ABORTED here specifically, so the CO knows to restart the listing
+		// from the beginning rather than treating this as a transient failure.
+		return nil, status.Errorf(codes.Aborted, "invalid starting_token: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, cs.getConfig().grpcRequestTimeout)
+	defer cancel()
+
+	remaining, err := cs.listDriverPersistentVolumes(ctx, after)
+	if err != nil {
+		return nil, err
+	}
+
+	page, nextToken := paginateVolumes(remaining, int(req.GetMaxEntries()))
+
+	response := &csi.ListVolumesResponse{Entries: cs.describeVolumes(ctx, page), NextToken: nextToken}
+	logger.Debug().Int("entries", len(response.Entries)).Bool("more_pages", nextToken != "").Msg("Listed volumes")
 	return response, nil
+}
+
+// paginateVolumes cuts one page out of the remaining volumes and mints the cursor to resume from,
+// which is empty once the page is the last one. A pageSize of zero or less means the CO left
+// max_entries unset and the driver picks the page size.
+func paginateVolumes(remaining []*v1.PersistentVolume, pageSize int) (page []*v1.PersistentVolume, nextToken string) {
+	if pageSize <= 0 {
+		pageSize = listVolumesPageSize
+	}
+	if len(remaining) <= pageSize {
+		return remaining, ""
+	}
+	page = remaining[:pageSize]
+	return page, encodeListVolumesToken(page[len(page)-1].Spec.CSI.VolumeHandle)
+}
+
+// describeVolumes probes a page of volumes concurrently. A volume whose condition cannot be
+// established is still listed, just without a condition - one unreachable volume must not fail
+// the whole page.
+func (cs *ControllerServer) describeVolumes(ctx context.Context, pvs []*v1.PersistentVolume) []*csi.ListVolumesResponse_Entry {
+	entries := make([]*csi.ListVolumesResponse_Entry, len(pvs))
+	filesystems := newFilesystemCache()
+	var probes errgroup.Group
+	probes.SetLimit(listVolumesConcurrency)
+	for i, pv := range pvs {
+		probes.Go(func() error {
+			volume, condition, err := cs.describeVolume(ctx, pv, filesystems)
+			if err != nil {
+				// describeVolume already returns a nil condition alongside any error, so the entry
+				// is simply listed as unknown rather than failing the whole page.
+				log.Ctx(ctx).Warn().Err(err).Str("volume_id", volume.VolumeId).
+					Msg("Listing volume without a condition")
+			}
+			// published_node_ids is left unset: this driver has no controller publish step, and it
+			// does not advertise LIST_VOLUMES_PUBLISHED_NODES.
+			entries[i] = &csi.ListVolumesResponse_Entry{
+				Volume: volume,
+				Status: &csi.ListVolumesResponse_VolumeStatus{VolumeCondition: condition},
+			}
+			return nil
+		})
+	}
+	_ = probes.Wait()
+	return entries
+}
+
+// listDriverPersistentVolumes returns this driver's PersistentVolumes ordered by volume handle,
+// starting after the given handle. The stable ordering is what makes the pagination token a
+// cursor rather than an offset, so volumes appearing or disappearing between pages cannot shift
+// the remaining pages and cause one to be skipped.
+func (cs *ControllerServer) listDriverPersistentVolumes(ctx context.Context, after string) ([]*v1.PersistentVolume, error) {
+	if cs.manager == nil {
+		return nil, status.Error(codes.Unavailable, "kubernetes client is unavailable, cannot list volumes")
+	}
+	pvList := &v1.PersistentVolumeList{}
+	// A sweep pages through the whole fleet, so every page would otherwise deep-copy every cached
+	// PV out of the informer. These objects are only ever read here, never mutated.
+	if err := cs.manager.GetClient().List(ctx, pvList, runtimeclient.UnsafeDisableDeepCopy); err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to list persistent volumes: %v", err)
+	}
+	return volumesAfterHandle(pvList.Items, cs.getConfig().GetDriver().name, after), nil
+}
+
+// volumesAfterHandle keeps this driver's PersistentVolumes whose handle sorts after the cursor,
+// ordered by handle.
+func volumesAfterHandle(items []v1.PersistentVolume, driverName, after string) []*v1.PersistentVolume {
+	matching := make([]*v1.PersistentVolume, 0, len(items))
+	for i := range items {
+		pv := &items[i]
+		if !isDriverPersistentVolume(pv, driverName) || pv.Spec.CSI.VolumeHandle <= after {
+			continue
+		}
+		matching = append(matching, pv)
+	}
+	sort.Slice(matching, func(i, j int) bool {
+		return matching[i].Spec.CSI.VolumeHandle < matching[j].Spec.CSI.VolumeHandle
+	})
+	return matching
+}
+
+// encodeListVolumesToken mints a pagination cursor pointing at the last handle of a page.
+func encodeListVolumesToken(handle string) string {
+	return base64.RawURLEncoding.EncodeToString([]byte(listVolumesTokenPrefix + handle))
+}
+
+// decodeListVolumesToken recovers the handle a previous page ended at. The prefix makes tokens
+// this driver did not mint detectable, so they can be rejected with ABORTED instead of being
+// silently misread as a starting position.
+func decodeListVolumesToken(token string) (string, error) {
+	if token == "" {
+		return "", nil
+	}
+	raw, err := base64.RawURLEncoding.DecodeString(token)
+	if err != nil {
+		return "", errors.New("token is not a valid cursor")
+	}
+	cursor, found := strings.CutPrefix(string(raw), listVolumesTokenPrefix)
+	if !found {
+		return "", errors.New("token was not issued by this driver")
+	}
+	return cursor, nil
 }
 
 // getPersistentVolumeByHandle finds the PersistentVolume carrying the given CSI volume handle.
@@ -204,11 +374,16 @@ func (cs *ControllerServer) getPersistentVolumeByHandle(ctx context.Context, vol
 	driverName := cs.getConfig().GetDriver().name
 	for i := range pvList.Items {
 		pv := &pvList.Items[i]
-		if pv.Spec.CSI != nil && pv.Spec.CSI.Driver == driverName {
+		if isDriverPersistentVolume(pv, driverName) {
 			return pv, nil
 		}
 	}
 	return nil, status.Errorf(codes.NotFound, "no persistent volume of driver %s exists for volume %s", driverName, volumeID)
+}
+
+// isDriverPersistentVolume reports whether a PersistentVolume is backed by this CSI driver.
+func isDriverPersistentVolume(pv *v1.PersistentVolume, driverName string) bool {
+	return pv.Spec.CSI != nil && pv.Spec.CSI.Driver == driverName
 }
 
 // apiClientFromPersistentVolume builds an API client from the Secret the PersistentVolume points
@@ -272,6 +447,45 @@ func pvCapacityBytes(pv *v1.PersistentVolume) int64 {
 		return capacity.Value()
 	}
 	return 0
+}
+
+// filesystemCache memoizes filesystem lookups for the span of a single ListVolumes call.
+//
+// Of the API calls a health probe makes, the filesystem lookup is identical for every volume that
+// shares a filesystem, so without this a page repeats it once per volume. It pays off for
+// directory-backed volumes, and equally for snapshot-backed ones, since a storage class pins all of
+// its volumes to one filesystem. Filesystem-backed volumes each own their filesystem, so they get
+// one cache entry apiece and no benefit - but no penalty either.
+//
+// Scoping this to one call bounds the staleness it can introduce: a filesystem removed while a page
+// is in flight is still reported as present until the next page.
+type filesystemCache struct {
+	sync.Mutex
+	byName map[string]*apiclient.FileSystem
+}
+
+func newFilesystemCache() *filesystemCache {
+	return &filesystemCache{byName: make(map[string]*apiclient.FileSystem)}
+}
+
+// get returns a previously resolved filesystem, or nil to mean "look it up". A nil cache always
+// misses, which is how single-volume callers opt out.
+func (fc *filesystemCache) get(name string) *apiclient.FileSystem {
+	if fc == nil {
+		return nil
+	}
+	fc.Lock()
+	defer fc.Unlock()
+	return fc.byName[name]
+}
+
+func (fc *filesystemCache) put(name string, fs *apiclient.FileSystem) {
+	if fc == nil || fs == nil {
+		return
+	}
+	fc.Lock()
+	defer fc.Unlock()
+	fc.byName[name] = fs
 }
 
 // secretCache memoizes Secrets read while answering ControllerGetVolume. The health monitor

--- a/pkg/wekafs/volumehealth.go
+++ b/pkg/wekafs/volumehealth.go
@@ -1,0 +1,312 @@
+/*
+Copyright 2019-2025 Weka.io LTD and The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package wekafs
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	"github.com/rs/zerolog/log"
+	"github.com/wekafs/csi-wekafs/pkg/wekafs/apiclient"
+	"go.opentelemetry.io/otel"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	v1 "k8s.io/api/core/v1"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	// pvIndexVolumeHandle names the field index that maps a CSI volume handle to its PersistentVolume.
+	pvIndexVolumeHandle = "spec.csi.volumeHandle"
+	// volumeSecretCacheTTL bounds how long a Secret read for a volume health check is reused. It
+	// matches the chart's default health monitor interval, so a full sweep of the cluster costs
+	// about one apiserver read per distinct Secret rather than one per volume.
+	volumeSecretCacheTTL = 5 * time.Minute
+	volumeHealthyMessage = "volume exists on the Weka cluster and is reachable via the Weka API"
+)
+
+// ErrVolumeHealthUndetermined is returned when the volume condition cannot be established
+// over the API alone, so the caller must report it as unknown rather than guess.
+var ErrVolumeHealthUndetermined = errors.New("volume condition cannot be determined without mounting the filesystem")
+
+// VolumeHealth is the outcome of a mount-free, API-only inspection of a volume.
+type VolumeHealth struct {
+	Abnormal bool
+	Message  string
+	// Capacity is the volume size in bytes as reported by the backend, or 0 when the backend
+	// does not track it (legacy volumes that keep their size in an extended attribute).
+	Capacity int64
+}
+
+func abnormalVolumeHealth(format string, args ...interface{}) *VolumeHealth {
+	return &VolumeHealth{Abnormal: true, Message: fmt.Sprintf(format, args...)}
+}
+
+// ProbeHealth inspects the volume using the Weka REST API only, never mounting the filesystem,
+// and reports whether the volume is usable along with its backend-tracked size.
+//
+// It returns ErrVolumeHealthUndetermined when the answer would require a mount - the volume is
+// then neither healthy nor abnormal as far as this driver can tell.
+func (v *Volume) ProbeHealth(ctx context.Context) (*VolumeHealth, error) {
+	op := "ProbeVolumeHealth"
+	ctx, span := otel.Tracer(TracerName).Start(ctx, op)
+	defer span.End()
+	ctx = log.With().Str("trace_id", span.SpanContext().TraceID().String()).Str("span_id", span.SpanContext().SpanID().String()).Str("op", op).Logger().WithContext(ctx)
+
+	logger := log.Ctx(ctx).With().Str("volume_id", v.GetId()).Logger()
+
+	if v.apiClient == nil {
+		return nil, ErrVolumeHealthUndetermined
+	}
+
+	fsObj, err := v.getFilesystemObj(ctx, false)
+	if err != nil {
+		return nil, err
+	}
+	if fsObj == nil {
+		return abnormalVolumeHealth("filesystem %s does not exist on the Weka cluster", v.FilesystemName), nil
+	}
+	if fsObj.IsRemoving {
+		return abnormalVolumeHealth("filesystem %s is being removed", v.FilesystemName), nil
+	}
+
+	// Every volume type is a path inside the filesystem - the filesystem root for filesystem-backed
+	// volumes, and a path through the snapshot's access point for snapshot-backed ones, so resolving
+	// it also proves the snapshot is still there. Resolving to an inode is the only way to prove
+	// existence without mounting, and the inode is what the quota is keyed by. Capacity always comes
+	// from that quota, including for filesystem-backed volumes, which carry one on their root inode.
+	if !v.apiClient.SupportsResolvePathToInode() {
+		return nil, ErrVolumeHealthUndetermined
+	}
+	relativePath := v.GetRelativePath(ctx)
+	inodeId, err := v.apiClient.ResolvePathToInode(ctx, fsObj, relativePath)
+	if err != nil {
+		if errors.Is(err, apiclient.ObjectNotFoundError) {
+			return abnormalVolumeHealth("path %s does not exist on filesystem %s", relativePath, v.FilesystemName), nil
+		}
+		return nil, err
+	}
+
+	quota, err := v.apiClient.GetQuotaByFileSystemAndInode(ctx, fsObj, inodeId)
+	if err != nil {
+		if errors.Is(err, apiclient.ObjectNotFoundError) {
+			// A volume without a quota is not broken - legacy volumes never had one. The inode
+			// resolved, so the volume is there; its size just cannot come from the API.
+			logger.Debug().Str("path", relativePath).Msg("Volume has no quota, capacity is not known from API")
+			return &VolumeHealth{Message: volumeHealthyMessage}, nil
+		}
+		return nil, err
+	}
+	return &VolumeHealth{Message: volumeHealthyMessage, Capacity: int64(quota.GetCapacityLimit())}, nil
+}
+
+func (cs *ControllerServer) ControllerGetVolume(ctx context.Context, req *csi.ControllerGetVolumeRequest) (*csi.ControllerGetVolumeResponse, error) {
+	op := "ControllerGetVolume"
+	ctx, span := otel.Tracer(TracerName).Start(ctx, op)
+	defer span.End()
+	ctx = log.With().Str("trace_id", span.SpanContext().TraceID().String()).Str("span_id", span.SpanContext().SpanID().String()).Str("op", op).Logger().WithContext(ctx)
+
+	volumeID := req.GetVolumeId()
+	logger := log.Ctx(ctx).With().Str("volume_id", volumeID).Logger()
+	logger.Debug().Msg(">>>> Received request")
+	defer logger.Debug().Msg("<<<< Completed processing request")
+
+	if err := cs.validateControllerServiceRequest(csi.ControllerServiceCapability_RPC_GET_VOLUME); err != nil {
+		logger.Err(err).Msg("Volume health reporting is not enabled")
+		return nil, err
+	}
+	if err := validateVolumeId(volumeID); err != nil {
+		return nil, err
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, cs.getConfig().grpcRequestTimeout)
+	defer cancel()
+
+	// ControllerGetVolumeRequest carries no secrets, so the PersistentVolume is the only place
+	// left to recover the Weka API credentials from. It also holds the requested size, which is
+	// the fallback answer whenever the backend cannot supply one.
+	pv, err := cs.getPersistentVolumeByHandle(ctx, volumeID)
+	if err != nil {
+		return nil, err
+	}
+	response := &csi.ControllerGetVolumeResponse{
+		Volume: &csi.Volume{
+			VolumeId:      volumeID,
+			CapacityBytes: pvCapacityBytes(pv),
+		},
+		Status: &csi.ControllerGetVolumeResponse_VolumeStatus{},
+	}
+
+	client, err := cs.apiClientFromPersistentVolume(ctx, pv)
+	if err != nil {
+		return nil, status.Errorf(codes.Unavailable, "could not reach the Weka API for volume %s: %v", volumeID, err)
+	}
+	if client == nil {
+		logger.Warn().Str("pv", pv.Name).Msg("No Weka API credentials available for volume, reporting condition as unknown")
+		return response, nil
+	}
+
+	volume, err := NewVolumeFromId(ctx, volumeID, client, cs)
+	if err != nil {
+		return nil, err
+	}
+
+	health, err := volume.ProbeHealth(ctx)
+	if err != nil {
+		if errors.Is(err, ErrVolumeHealthUndetermined) {
+			logger.Warn().Err(err).Msg("Reporting volume condition as unknown")
+			return response, nil
+		}
+		return nil, status.Errorf(codes.Internal, "failed to determine condition of volume %s: %v", volumeID, err)
+	}
+
+	if health.Capacity > 0 {
+		response.Volume.CapacityBytes = health.Capacity
+	}
+	response.Status.VolumeCondition = &csi.VolumeCondition{
+		Abnormal: health.Abnormal,
+		Message:  health.Message,
+	}
+	if health.Abnormal {
+		logger.Warn().Str("condition", health.Message).Msg("Volume is abnormal")
+	}
+	return response, nil
+}
+
+// getPersistentVolumeByHandle finds the PersistentVolume carrying the given CSI volume handle.
+// It is served from the manager's PV informer through a field index, so it costs no API call.
+func (cs *ControllerServer) getPersistentVolumeByHandle(ctx context.Context, volumeID string) (*v1.PersistentVolume, error) {
+	if cs.manager == nil {
+		return nil, status.Error(codes.Unavailable, "kubernetes client is unavailable, cannot look up volume")
+	}
+	pvList := &v1.PersistentVolumeList{}
+	if err := cs.manager.GetClient().List(ctx, pvList, runtimeclient.MatchingFields{pvIndexVolumeHandle: volumeID}); err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to look up persistent volume for volume %s: %v", volumeID, err)
+	}
+	driverName := cs.getConfig().GetDriver().name
+	for i := range pvList.Items {
+		pv := &pvList.Items[i]
+		if pv.Spec.CSI != nil && pv.Spec.CSI.Driver == driverName {
+			return pv, nil
+		}
+	}
+	return nil, status.Errorf(codes.NotFound, "no persistent volume of driver %s exists for volume %s", driverName, volumeID)
+}
+
+// apiClientFromPersistentVolume builds an API client from the Secret the PersistentVolume points
+// at. A nil client with no error means no credentials are available and the caller must treat the
+// volume condition as unknown.
+func (cs *ControllerServer) apiClientFromPersistentVolume(ctx context.Context, pv *v1.PersistentVolume) (*apiclient.ApiClient, error) {
+	ref := preferredSecretRef(pv)
+	if ref == nil {
+		// Statically provisioned volumes may reference no Secret at all - fall back to the
+		// cluster-wide legacy secret if the driver was started with one.
+		return cs.getApiStore().GetClientFromSecrets(ctx, nil)
+	}
+	key := ref.Namespace + "/" + ref.Name
+	secrets, cached := cs.secretCache.lookup(key)
+	if !cached {
+		var err error
+		if secrets, err = cs.readSecret(ctx, ref); err != nil {
+			return nil, err
+		}
+		cs.secretCache.store(key, secrets)
+	}
+	return cs.getApiStore().GetClientFromSecrets(ctx, secrets)
+}
+
+// preferredSecretRef picks the Secret to authenticate with, preferring the refs meant for
+// controller-side calls. The provisioner secret is never recorded on the PersistentVolume.
+func preferredSecretRef(pv *v1.PersistentVolume) *v1.SecretReference {
+	if pv.Spec.CSI == nil {
+		return nil
+	}
+	for _, ref := range []*v1.SecretReference{
+		pv.Spec.CSI.ControllerExpandSecretRef,
+		pv.Spec.CSI.ControllerPublishSecretRef,
+		pv.Spec.CSI.NodeStageSecretRef,
+		pv.Spec.CSI.NodePublishSecretRef,
+	} {
+		if ref != nil && ref.Name != "" && ref.Namespace != "" {
+			return ref
+		}
+	}
+	return nil
+}
+
+func (cs *ControllerServer) readSecret(ctx context.Context, ref *v1.SecretReference) (map[string]string, error) {
+	secret := &v1.Secret{}
+	// Deliberately an uncached read: going through the manager's client would start an informer
+	// that mirrors every Secret in the cluster into this pod's memory.
+	key := runtimeclient.ObjectKey{Namespace: ref.Namespace, Name: ref.Name}
+	if err := cs.manager.GetAPIReader().Get(ctx, key, secret); err != nil {
+		return nil, err
+	}
+	secrets := make(map[string]string, len(secret.Data))
+	for k, val := range secret.Data {
+		secrets[k] = string(val)
+	}
+	return secrets, nil
+}
+
+func pvCapacityBytes(pv *v1.PersistentVolume) int64 {
+	if capacity, ok := pv.Spec.Capacity[v1.ResourceStorage]; ok {
+		return capacity.Value()
+	}
+	return 0
+}
+
+// secretCache memoizes Secrets read while answering ControllerGetVolume. The health monitor
+// sweeps every volume on a fixed interval and in practice all volumes of a cluster share a
+// single API Secret, so without this each sweep would issue one apiserver read per volume.
+type secretCache struct {
+	sync.Mutex
+	ttl     time.Duration
+	entries map[string]secretCacheEntry
+}
+
+type secretCacheEntry struct {
+	secrets   map[string]string
+	fetchedAt time.Time
+}
+
+func newSecretCache(ttl time.Duration) *secretCache {
+	return &secretCache{ttl: ttl, entries: make(map[string]secretCacheEntry)}
+}
+
+// lookup returns the cached Secret contents, if they are present and still fresh. The lock is
+// never held across the apiserver read, so one slow read cannot stall health checks of volumes
+// that use a different Secret.
+func (sc *secretCache) lookup(key string) (map[string]string, bool) {
+	sc.Lock()
+	defer sc.Unlock()
+	entry, ok := sc.entries[key]
+	if !ok || time.Since(entry.fetchedAt) >= sc.ttl {
+		return nil, false
+	}
+	return entry.secrets, true
+}
+
+func (sc *secretCache) store(key string, secrets map[string]string) {
+	sc.Lock()
+	defer sc.Unlock()
+	sc.entries[key] = secretCacheEntry{secrets: secrets, fetchedAt: time.Now()}
+}

--- a/pkg/wekafs/volumehealth_test.go
+++ b/pkg/wekafs/volumehealth_test.go
@@ -1,0 +1,129 @@
+package wekafs
+
+import (
+	"testing"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+func TestPreferredSecretRef(t *testing.T) {
+	ref := func(name string) *v1.SecretReference {
+		return &v1.SecretReference{Name: name, Namespace: "csi-wekafs"}
+	}
+
+	for _, tc := range []struct {
+		name     string
+		source   *v1.CSIPersistentVolumeSource
+		expected string
+	}{
+		{
+			name:   "no CSI source",
+			source: nil,
+		},
+		{
+			name:   "no refs at all",
+			source: &v1.CSIPersistentVolumeSource{Driver: "csi.weka.io"},
+		},
+		{
+			name: "controller expand ref wins over node refs",
+			source: &v1.CSIPersistentVolumeSource{
+				ControllerExpandSecretRef:  ref("expand"),
+				ControllerPublishSecretRef: ref("publish"),
+				NodeStageSecretRef:         ref("stage"),
+			},
+			expected: "expand",
+		},
+		{
+			name: "falls back to node stage ref",
+			source: &v1.CSIPersistentVolumeSource{
+				NodeStageSecretRef:   ref("stage"),
+				NodePublishSecretRef: ref("node-publish"),
+			},
+			expected: "stage",
+		},
+		{
+			name: "ref without namespace is unusable",
+			source: &v1.CSIPersistentVolumeSource{
+				ControllerExpandSecretRef: &v1.SecretReference{Name: "expand"},
+				NodeStageSecretRef:        ref("stage"),
+			},
+			expected: "stage",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			pv := &v1.PersistentVolume{
+				Spec: v1.PersistentVolumeSpec{
+					PersistentVolumeSource: v1.PersistentVolumeSource{CSI: tc.source},
+				},
+			}
+			got := preferredSecretRef(pv)
+			if tc.expected == "" {
+				if got != nil {
+					t.Fatalf("expected no secret ref, got %s/%s", got.Namespace, got.Name)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("expected secret ref %s, got none", tc.expected)
+			}
+			if got.Name != tc.expected {
+				t.Fatalf("expected secret ref %s, got %s", tc.expected, got.Name)
+			}
+		})
+	}
+}
+
+func TestPvCapacityBytes(t *testing.T) {
+	if got := pvCapacityBytes(&v1.PersistentVolume{}); got != 0 {
+		t.Fatalf("expected 0 for PV without capacity, got %d", got)
+	}
+	pv := &v1.PersistentVolume{
+		Spec: v1.PersistentVolumeSpec{
+			Capacity: v1.ResourceList{v1.ResourceStorage: resource.MustParse("1Gi")},
+		},
+	}
+	if got := pvCapacityBytes(pv); got != 1024*1024*1024 {
+		t.Fatalf("expected 1Gi in bytes, got %d", got)
+	}
+}
+
+func TestSecretCache(t *testing.T) {
+	sc := newSecretCache(time.Hour)
+	if _, ok := sc.lookup("csi-wekafs/api"); ok {
+		t.Fatal("expected a miss on an empty cache")
+	}
+
+	sc.store("csi-wekafs/api", map[string]string{"username": "admin"})
+	secrets, ok := sc.lookup("csi-wekafs/api")
+	if !ok {
+		t.Fatal("expected a hit for a freshly stored key")
+	}
+	if secrets["username"] != "admin" {
+		t.Fatalf("unexpected secret contents: %v", secrets)
+	}
+	if _, ok := sc.lookup("csi-wekafs/other"); ok {
+		t.Fatal("expected a miss for a key that was never stored")
+	}
+
+	// A zero TTL makes every entry stale on arrival, so every lookup is a miss.
+	expired := newSecretCache(0)
+	expired.store("csi-wekafs/api", map[string]string{"username": "admin"})
+	if _, ok := expired.lookup("csi-wekafs/api"); ok {
+		t.Fatal("expected a miss for a stale entry")
+	}
+}
+
+func TestAbnormalVolumeHealth(t *testing.T) {
+	health := abnormalVolumeHealth("filesystem %s does not exist", "myfs")
+	if !health.Abnormal {
+		t.Fatal("expected health to be abnormal")
+	}
+	if health.Message != "filesystem myfs does not exist" {
+		t.Fatalf("unexpected message: %s", health.Message)
+	}
+	if health.Capacity != 0 {
+		t.Fatalf("expected no capacity on an abnormal volume, got %d", health.Capacity)
+	}
+}

--- a/pkg/wekafs/volumehealth_test.go
+++ b/pkg/wekafs/volumehealth_test.go
@@ -1,11 +1,15 @@
 package wekafs
 
 import (
+	"encoding/base64"
+	"fmt"
 	"testing"
 	"time"
 
+	"github.com/wekafs/csi-wekafs/pkg/wekafs/apiclient"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestPreferredSecretRef(t *testing.T) {
@@ -125,5 +129,156 @@ func TestAbnormalVolumeHealth(t *testing.T) {
 	}
 	if health.Capacity != 0 {
 		t.Fatalf("expected no capacity on an abnormal volume, got %d", health.Capacity)
+	}
+}
+
+func TestListVolumesTokenRoundTrip(t *testing.T) {
+	handle := "dir/v1/default/csi-volumes/pvc-abc-0123456789"
+	got, err := decodeListVolumesToken(encodeListVolumesToken(handle))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != handle {
+		t.Fatalf("expected %q, got %q", handle, got)
+	}
+
+	// An empty token means "start from the beginning", not an error.
+	if cursor, err := decodeListVolumesToken(""); err != nil || cursor != "" {
+		t.Fatalf("expected empty cursor with no error, got %q / %v", cursor, err)
+	}
+}
+
+func TestListVolumesTokenRejectsForeignTokens(t *testing.T) {
+	// The CSI spec requires an unrecognized starting_token to be reported as ABORTED, so every
+	// token this driver did not mint must be detectable rather than read as a position.
+	for _, token := range []string{
+		"not base64 at all!!",
+		"!!!!",
+		base64.RawURLEncoding.EncodeToString([]byte("someoneelse:v1:handle")),
+		base64.RawURLEncoding.EncodeToString([]byte("42")),
+		base64.RawURLEncoding.EncodeToString([]byte("wekafs:v2:handle")),
+	} {
+		if _, err := decodeListVolumesToken(token); err == nil {
+			t.Fatalf("expected token %q to be rejected", token)
+		}
+	}
+}
+
+func pvWithHandle(name, driver, handle string) v1.PersistentVolume {
+	return v1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: v1.PersistentVolumeSpec{
+			PersistentVolumeSource: v1.PersistentVolumeSource{
+				CSI: &v1.CSIPersistentVolumeSource{Driver: driver, VolumeHandle: handle},
+			},
+		},
+	}
+}
+
+func TestVolumesAfterHandleFiltersAndOrders(t *testing.T) {
+	items := []v1.PersistentVolume{
+		pvWithHandle("c", "csi.weka.io", "dir/v1/fs/c"),
+		pvWithHandle("a", "csi.weka.io", "dir/v1/fs/a"),
+		pvWithHandle("other", "csi.other.io", "dir/v1/fs/b"),
+		pvWithHandle("nocsi", "", ""),
+		pvWithHandle("b", "csi.weka.io", "dir/v1/fs/b"),
+	}
+	items[3].Spec.CSI = nil
+
+	got := volumesAfterHandle(items, "csi.weka.io", "")
+	if len(got) != 3 {
+		t.Fatalf("expected 3 volumes of our driver, got %d", len(got))
+	}
+	for i, want := range []string{"dir/v1/fs/a", "dir/v1/fs/b", "dir/v1/fs/c"} {
+		if got[i].Spec.CSI.VolumeHandle != want {
+			t.Fatalf("position %d: expected %s, got %s", i, want, got[i].Spec.CSI.VolumeHandle)
+		}
+	}
+
+	// The cursor is exclusive.
+	got = volumesAfterHandle(items, "csi.weka.io", "dir/v1/fs/a")
+	if len(got) != 2 || got[0].Spec.CSI.VolumeHandle != "dir/v1/fs/b" {
+		t.Fatalf("expected to resume after the cursor, got %d entries starting at %s", len(got), got[0].Spec.CSI.VolumeHandle)
+	}
+	if len(volumesAfterHandle(items, "csi.weka.io", "dir/v1/fs/z")) != 0 {
+		t.Fatal("expected no entries past the last handle")
+	}
+}
+
+// TestListVolumesPaginationCoversEverything is the property that matters: paging with a keyset
+// cursor must visit every volume exactly once even while volumes are deleted mid-listing, which
+// is exactly where an offset-based token silently skips entries.
+func TestListVolumesPaginationCoversEverything(t *testing.T) {
+	var items []v1.PersistentVolume
+	for i := 0; i < 25; i++ {
+		h := fmt.Sprintf("dir/v1/fs/vol-%02d", i)
+		items = append(items, pvWithHandle(h, "csi.weka.io", h))
+	}
+
+	const pageSize = 4
+	seen := map[string]int{}
+	cursor := ""
+	for pages := 0; ; pages++ {
+		if pages > 50 {
+			t.Fatal("pagination did not terminate")
+		}
+		// Drive the same two functions ListVolumes itself uses, so this exercises the real paging
+		// logic rather than a copy of it.
+		remaining := volumesAfterHandle(items, "csi.weka.io", cursor)
+		if len(remaining) == 0 {
+			break
+		}
+		page, nextToken := paginateVolumes(remaining, pageSize)
+		for _, pv := range page {
+			seen[pv.Spec.CSI.VolumeHandle]++
+		}
+		if nextToken == "" {
+			break
+		}
+		var err error
+		if cursor, err = decodeListVolumesToken(nextToken); err != nil {
+			t.Fatalf("driver minted a token it cannot decode: %v", err)
+		}
+
+		// Delete an already-listed volume between pages. With an offset token this shifts the
+		// remaining entries and one volume is never returned; with a cursor it cannot.
+		if len(items) > 1 {
+			items = items[1:]
+		}
+	}
+
+	for i := 0; i < 25; i++ {
+		h := fmt.Sprintf("dir/v1/fs/vol-%02d", i)
+		if seen[h] != 1 {
+			t.Fatalf("volume %s was returned %d times, expected exactly 1", h, seen[h])
+		}
+	}
+}
+
+func TestFilesystemCache(t *testing.T) {
+	// A nil cache must always miss and must tolerate writes, so single-volume callers can pass nil.
+	var absent *filesystemCache
+	if absent.get("default") != nil {
+		t.Fatal("expected a nil cache to miss")
+	}
+	absent.put("default", &apiclient.FileSystem{Name: "default"})
+
+	fc := newFilesystemCache()
+	if fc.get("default") != nil {
+		t.Fatal("expected a miss on an empty cache")
+	}
+	fs := &apiclient.FileSystem{Name: "default"}
+	fc.put("default", fs)
+	if got := fc.get("default"); got != fs {
+		t.Fatalf("expected the cached filesystem back, got %v", got)
+	}
+	if fc.get("other") != nil {
+		t.Fatal("expected a miss for a filesystem that was never cached")
+	}
+
+	// Storing nil must not create an entry that would later be mistaken for a hit.
+	fc.put("nilfs", nil)
+	if _, ok := fc.byName["nilfs"]; ok {
+		t.Fatal("expected a nil filesystem not to be cached")
 	}
 }

--- a/pkg/wekafs/volumehealthreconciler.go
+++ b/pkg/wekafs/volumehealthreconciler.go
@@ -115,14 +115,19 @@ func newVolumeHealthReconciler(cs *ControllerServer, cache *volumeConditionCache
 // runnable, so exactly one controller replica probes the fleet and the loop stops when leadership is
 // lost or the process shuts down.
 func (r *volumeHealthReconciler) Start(ctx context.Context) error {
-	logger := log.Ctx(ctx).With().Str("component", "volume-health-reconciler").Logger()
+	// The manager hands runnables a bare context. zerolog's log.Ctx returns a *disabled* logger when
+	// the context carries none, so deriving from it here would silently swallow every line this loop
+	// writes. Build from the global logger instead, and attach it so log.Ctx works downstream.
+	logger := log.With().Str("component", "volume-health-reconciler").Logger()
+	ctx = logger.WithContext(ctx)
+
 	logger.Info().
 		Dur("interval", volumeHealthReconcileInterval).
 		Int("concurrency", volumeHealthProbeConcurrency).
 		Msg("Starting volume health reconciler")
 
 	for {
-		r.reconcileOnce(logger.WithContext(ctx))
+		r.reconcileOnce(ctx)
 
 		select {
 		case <-ctx.Done():

--- a/pkg/wekafs/volumehealthreconciler.go
+++ b/pkg/wekafs/volumehealthreconciler.go
@@ -1,0 +1,207 @@
+/*
+Copyright 2019-2025 Weka.io LTD and The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package wekafs
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/rs/zerolog/log"
+	"go.opentelemetry.io/otel"
+	"golang.org/x/sync/errgroup"
+)
+
+const (
+	// volumeHealthReconcileInterval is how long the reconciler waits between finishing one sweep of
+	// every volume and starting the next. A sweep that overruns simply delays the next one.
+	volumeHealthReconcileInterval = 5 * time.Minute
+	// volumeHealthProbeConcurrency bounds how many volumes the reconciler probes at once, and so
+	// caps the sustained Weka API call rate it can produce.
+	volumeHealthProbeConcurrency = 10
+	// volumeHealthMaxAge is how long a probe result may be served before it is reported as unknown
+	// instead. Generous relative to the interval, so a slow or partially failing sweep degrades to
+	// stale-but-useful rather than blanking every condition at once.
+	volumeHealthMaxAge = 30 * time.Minute
+)
+
+// volumeConditionEntry is one volume's last probe result, in domain terms rather than CSI protos so
+// nothing shared is mutable.
+type volumeConditionEntry struct {
+	// known is false when the volume was probed but its condition could not be established, which
+	// callers must report as unknown rather than as healthy.
+	known    bool
+	abnormal bool
+	message  string
+	capacity int64
+	probedAt time.Time
+}
+
+// volumeConditionCache holds the reconciler's most recent result per volume handle. ListVolumes
+// answers from it, which is what keeps that RPC free of Weka API calls.
+type volumeConditionCache struct {
+	sync.RWMutex
+	entries map[string]volumeConditionEntry
+}
+
+func newVolumeConditionCache() *volumeConditionCache {
+	return &volumeConditionCache{entries: make(map[string]volumeConditionEntry)}
+}
+
+// lookup returns the entry for a volume handle if one exists and is still fresh enough to serve.
+func (c *volumeConditionCache) lookup(handle string) (volumeConditionEntry, bool) {
+	c.RLock()
+	defer c.RUnlock()
+	entry, ok := c.entries[handle]
+	if !ok || time.Since(entry.probedAt) > volumeHealthMaxAge {
+		return volumeConditionEntry{}, false
+	}
+	return entry, true
+}
+
+func (c *volumeConditionCache) store(handle string, entry volumeConditionEntry) {
+	c.Lock()
+	defer c.Unlock()
+	c.entries[handle] = entry
+}
+
+// retainOnly drops entries for volumes that no longer exist, so the cache tracks the fleet rather
+// than growing forever with deleted volumes.
+func (c *volumeConditionCache) retainOnly(handles map[string]struct{}) int {
+	c.Lock()
+	defer c.Unlock()
+	for handle := range c.entries {
+		if _, live := handles[handle]; !live {
+			delete(c.entries, handle)
+		}
+	}
+	return len(c.entries)
+}
+
+// volumeHealthReconciler keeps volume conditions up to date in the background.
+//
+// Probing a volume costs a couple of Weka API calls and cannot be avoided - resolving the path to an
+// inode is the only proof the volume still exists, so it can never be served from a cache. What this
+// moves is *when* that work happens. Doing it inside ListVolumes made the whole fleet's probe cost
+// fall inside one RPC, and the health monitor sidecar applies its --timeout to an entire paginated
+// sweep rather than to a single page: a fleet too large to walk inside that budget was cut off
+// mid-sweep and restarted from the beginning next time, so its tail was never checked at all.
+// Reconciling separately makes ListVolumes a pure cache read, so the sidecar's deadline stops being
+// a limit on how many volumes can be monitored.
+type volumeHealthReconciler struct {
+	cs    *ControllerServer
+	cache *volumeConditionCache
+}
+
+func newVolumeHealthReconciler(cs *ControllerServer, cache *volumeConditionCache) *volumeHealthReconciler {
+	return &volumeHealthReconciler{cs: cs, cache: cache}
+}
+
+// Start satisfies controller-runtime's manager.Runnable. It is registered as a leader-election
+// runnable, so exactly one controller replica probes the fleet and the loop stops when leadership is
+// lost or the process shuts down.
+func (r *volumeHealthReconciler) Start(ctx context.Context) error {
+	logger := log.Ctx(ctx).With().Str("component", "volume-health-reconciler").Logger()
+	logger.Info().
+		Dur("interval", volumeHealthReconcileInterval).
+		Int("concurrency", volumeHealthProbeConcurrency).
+		Msg("Starting volume health reconciler")
+
+	for {
+		r.reconcileOnce(logger.WithContext(ctx))
+
+		select {
+		case <-ctx.Done():
+			logger.Info().Msg("Volume health reconciler stopped")
+			return nil
+		case <-time.After(volumeHealthReconcileInterval):
+		}
+	}
+}
+
+// reconcileOnce probes every volume of this driver once and refreshes the cache. It never returns an
+// error: a sweep is best-effort background work, and one unreachable volume must not stop the rest.
+func (r *volumeHealthReconciler) reconcileOnce(ctx context.Context) {
+	op := "ReconcileVolumeHealth"
+	ctx, span := otel.Tracer(TracerName).Start(ctx, op)
+	defer span.End()
+	logger := log.Ctx(ctx)
+
+	started := time.Now()
+	pvs, err := r.cs.listDriverPersistentVolumes(ctx, "")
+	if err != nil {
+		logger.Error().Err(err).Msg("Failed to list volumes for health reconciliation")
+		return
+	}
+
+	// One filesystem lookup per filesystem for the whole sweep, rather than per volume. Bounds the
+	// staleness to a single sweep: a filesystem removed mid-sweep is still reported as present until
+	// the next one.
+	filesystems := newFilesystemCache()
+	live := make(map[string]struct{}, len(pvs))
+
+	var abnormal, unknown, failed int64
+	var counters sync.Mutex
+
+	var probes errgroup.Group
+	probes.SetLimit(volumeHealthProbeConcurrency)
+	for _, pv := range pvs {
+		handle := pv.Spec.CSI.VolumeHandle
+		live[handle] = struct{}{}
+		probes.Go(func() error {
+			if ctx.Err() != nil {
+				return nil
+			}
+			volume, condition, err := r.cs.describeVolume(ctx, pv, filesystems)
+
+			counters.Lock()
+			defer counters.Unlock()
+			if err != nil {
+				// Keep the previous entry rather than overwriting it with "unknown", so a transient
+				// API failure does not erase a condition that was good a moment ago. It ages out
+				// through volumeHealthMaxAge if the failure persists.
+				logger.Warn().Err(err).Str("volume_id", handle).Msg("Failed to probe volume health")
+				failed++
+				return nil
+			}
+			entry := volumeConditionEntry{capacity: volume.CapacityBytes, probedAt: time.Now()}
+			if condition != nil {
+				entry.known = true
+				entry.abnormal = condition.Abnormal
+				entry.message = condition.Message
+				if condition.Abnormal {
+					abnormal++
+				}
+			} else {
+				unknown++
+			}
+			r.cache.store(handle, entry)
+			return nil
+		})
+	}
+	_ = probes.Wait()
+
+	cached := r.cache.retainOnly(live)
+	logger.Info().
+		Int("volumes", len(pvs)).
+		Int("cached", cached).
+		Int64("abnormal", abnormal).
+		Int64("unknown", unknown).
+		Int64("failed", failed).
+		Dur("duration", time.Since(started)).
+		Msg("Volume health reconciliation completed")
+}

--- a/pkg/wekafs/volumehealthreconciler_test.go
+++ b/pkg/wekafs/volumehealthreconciler_test.go
@@ -1,0 +1,96 @@
+package wekafs
+
+import (
+	"testing"
+	"time"
+)
+
+func TestVolumeConditionCacheStoreAndLookup(t *testing.T) {
+	c := newVolumeConditionCache()
+
+	if _, ok := c.lookup("dir/v1/fs/a"); ok {
+		t.Fatal("expected a miss on an empty cache")
+	}
+
+	c.store("dir/v1/fs/a", volumeConditionEntry{
+		known: true, abnormal: true, message: "path is gone", capacity: 1 << 30, probedAt: time.Now(),
+	})
+	entry, ok := c.lookup("dir/v1/fs/a")
+	if !ok {
+		t.Fatal("expected a hit for a freshly stored entry")
+	}
+	if !entry.known || !entry.abnormal || entry.message != "path is gone" || entry.capacity != 1<<30 {
+		t.Fatalf("entry did not round-trip: %+v", entry)
+	}
+
+	// A probed-but-undeterminable volume is cached as known=false, which callers must report as
+	// unknown rather than as healthy.
+	c.store("dir/v1/fs/b", volumeConditionEntry{known: false, probedAt: time.Now()})
+	if entry, ok := c.lookup("dir/v1/fs/b"); !ok || entry.known {
+		t.Fatalf("expected a cached but unknown condition, got ok=%v entry=%+v", ok, entry)
+	}
+}
+
+// A result older than volumeHealthMaxAge must not be served: reporting a stale condition as current
+// is worse than reporting nothing, because the CO cannot tell the difference.
+func TestVolumeConditionCacheExpiresStaleEntries(t *testing.T) {
+	c := newVolumeConditionCache()
+	c.store("dir/v1/fs/a", volumeConditionEntry{
+		known: true, message: "healthy", probedAt: time.Now().Add(-volumeHealthMaxAge - time.Minute),
+	})
+	if _, ok := c.lookup("dir/v1/fs/a"); ok {
+		t.Fatal("expected an entry older than volumeHealthMaxAge to be treated as a miss")
+	}
+
+	// Just inside the window is still served.
+	c.store("dir/v1/fs/b", volumeConditionEntry{
+		known: true, message: "healthy", probedAt: time.Now().Add(-volumeHealthMaxAge + time.Minute),
+	})
+	if _, ok := c.lookup("dir/v1/fs/b"); !ok {
+		t.Fatal("expected an entry inside volumeHealthMaxAge to be served")
+	}
+}
+
+// Without eviction the cache would grow forever as volumes are deleted, and a recreated handle
+// could inherit a previous volume's condition.
+func TestVolumeConditionCacheRetainOnlyDropsDeletedVolumes(t *testing.T) {
+	c := newVolumeConditionCache()
+	for _, h := range []string{"a", "b", "c"} {
+		c.store(h, volumeConditionEntry{known: true, probedAt: time.Now()})
+	}
+
+	remaining := c.retainOnly(map[string]struct{}{"a": {}, "c": {}})
+	if remaining != 2 {
+		t.Fatalf("expected 2 entries to remain, got %d", remaining)
+	}
+	if _, ok := c.lookup("b"); ok {
+		t.Fatal("expected the deleted volume to be evicted")
+	}
+	for _, h := range []string{"a", "c"} {
+		if _, ok := c.lookup(h); !ok {
+			t.Fatalf("expected %s to be retained", h)
+		}
+	}
+
+	if c.retainOnly(map[string]struct{}{}) != 0 {
+		t.Fatal("expected an empty live set to clear the cache")
+	}
+}
+
+// The reconciler probes concurrently, so the cache is written from many goroutines while
+// ListVolumes reads it. Run with -race to make this meaningful.
+func TestVolumeConditionCacheConcurrentAccess(t *testing.T) {
+	c := newVolumeConditionCache()
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for i := 0; i < 500; i++ {
+			c.store("dir/v1/fs/a", volumeConditionEntry{known: true, probedAt: time.Now()})
+			c.retainOnly(map[string]struct{}{"dir/v1/fs/a": {}})
+		}
+	}()
+	for i := 0; i < 500; i++ {
+		c.lookup("dir/v1/fs/a")
+	}
+	<-done
+}

--- a/pkg/wekafs/wekafs.go
+++ b/pkg/wekafs/wekafs.go
@@ -429,6 +429,15 @@ func (driver *WekaFsDriver) runWithLeaderElection(ctx context.Context, termConte
 	runCtx, cancelRun := context.WithCancel(ctx)
 	var shutdownOnce sync.Once
 
+	// Keep volume conditions fresh in the background so ListVolumes stays a pure cache read.
+	// Registered as an ordinary runnable, which controller-runtime gates on leadership, so exactly
+	// one replica probes the fleet and the loop stops when leadership is lost.
+	if driver.cs != nil && driver.cs.healthReconciler != nil {
+		if err := driver.manager.Add(manager.RunnableFunc(driver.cs.healthReconciler.Start)); err != nil {
+			log.Error().Err(err).Msg("Failed to register volume health reconciler, conditions will not be reported")
+		}
+	}
+
 	// Add runnable that starts gRPC server when we become leader
 	err := driver.manager.Add(manager.RunnableFunc(func(ctx context.Context) error {
 		// This only runs when we are the leader

--- a/pkg/wekafs/wekafs.go
+++ b/pkg/wekafs/wekafs.go
@@ -596,9 +596,10 @@ func (d *WekaFsDriver) initManager(ctx context.Context, leaderElection bool) err
 	zapLogger := zap.New(zap.UseDevMode(false))
 	clog.SetLogger(zapLogger)
 
-	// Configure cache options (only if enforceDirVolTotalCapacity is enabled)
+	// When PVs are cached at all, keep only the fields the driver reads, so a large cluster's PV
+	// list stays cheap in memory.
 	cacheOpts := cache.Options{}
-	if d.config.enforceDirVolTotalCapacity {
+	if d.config.requiresPvCaching() {
 		cacheOpts = cache.Options{
 			ByObject: map[runtimeclient.Object]cache.ByObject{
 				&v1.PersistentVolume{}: {
@@ -643,6 +644,25 @@ func (d *WekaFsDriver) initManager(ctx context.Context, leaderElection bool) err
 		return fmt.Errorf("failed to create manager: %w", err)
 	}
 
+	// ControllerGetVolume resolves a CSI volume handle back to its PersistentVolume on every
+	// health check. Index the handle so that is a cache lookup rather than a full PV scan.
+	// Registering the index starts a PV informer, so only do it where it is actually used - keyed
+	// on the csiMode that serves the controller service, which is also what gates advertising the
+	// capability, rather than on leaderElection which merely happens to correlate today.
+	servesControllerService := d.csiMode == CsiModeController || d.csiMode == CsiModeAll
+	if servesControllerService && d.config.advertiseVolumeHealthSupport {
+		if err := mgr.GetFieldIndexer().IndexField(ctx, &v1.PersistentVolume{}, pvIndexVolumeHandle,
+			func(obj runtimeclient.Object) []string {
+				pv, ok := obj.(*v1.PersistentVolume)
+				if !ok || pv.Spec.CSI == nil {
+					return nil
+				}
+				return []string{pv.Spec.CSI.VolumeHandle}
+			}); err != nil {
+			return fmt.Errorf("failed to index persistent volumes by CSI volume handle: %w", err)
+		}
+	}
+
 	if leaderElection {
 		// Parse socket path from endpoint (format: "unix:///path/to/socket")
 		socketProto, socketPath, err := parseEndpoint(d.endpoint)
@@ -684,6 +704,8 @@ func (d *WekaFsDriver) initManager(ctx context.Context, leaderElection bool) err
 	logger.Info().
 		Bool("leader_election", leaderElection).
 		Bool("enforce_capacity", d.config.enforceDirVolTotalCapacity).
+		Bool("advertise_volume_health_support", d.config.advertiseVolumeHealthSupport).
+		Bool("cache_persistent_volumes", d.config.requiresPvCaching()).
 		Str("leader_election_id", mgrOpts.LeaderElectionID).
 		Str("namespace", mgrOpts.LeaderElectionNamespace).
 		Msg("Kubernetes manager initialized")
@@ -717,6 +739,12 @@ func stripUnnecessaryPVFields(obj interface{}) (interface{}, error) {
 		minimal.Spec.PersistentVolumeSource.CSI = &v1.CSIPersistentVolumeSource{
 			Driver:       pv.Spec.CSI.Driver,       // Need to filter by driver
 			VolumeHandle: pv.Spec.CSI.VolumeHandle, // Need to extract filesystem path
+			// ControllerGetVolume recovers the Weka API credentials from these refs, since the
+			// RPC itself carries no secrets. Refs only, the Secret contents are not cached here.
+			ControllerExpandSecretRef:  pv.Spec.CSI.ControllerExpandSecretRef,
+			ControllerPublishSecretRef: pv.Spec.CSI.ControllerPublishSecretRef,
+			NodeStageSecretRef:         pv.Spec.CSI.NodeStageSecretRef,
+			NodePublishSecretRef:       pv.Spec.CSI.NodePublishSecretRef,
 		}
 	}
 


### PR DESCRIPTION
### TL;DR
Kubernetes can now detect and report when a volume's storage becomes unhealthy

### What changed?
- Periodic health checks for each volume against the Weka cluster
- Unhealthy volumes surface as abnormal conditions on the PVC
- Reports actual used capacity alongside health status
- On by default, checks every 5 minutes; requires Weka 4.3+

### How to test?
1. Deploy the CSI driver and create a PVC
2. Remove the volume's backing filesystem on the Weka cluster
3. Run `kubectl describe pvc <name>` and confirm an abnormal condition appears within 5 minutes

### Why make this change?
Previously Kubernetes couldn't tell if a volume's storage was still intact; problems went unnoticed until an application failed. This gives ongoing visibility into real volume health.

