### PR TITLE
fix: optimize gc resource consumption and support tenants with same filesystem name 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apk add --no-cache libc6-compat gcc musl-dev
 COPY go.mod /src/go.mod
 COPY go.sum /src/go.sum
 WORKDIR /src
-ARG LOCAR_VERSION=0.4.3
+ARG LOCAR_VERSION=0.5.0
 ADD --chmod=655 https://github.com/weka/locar/releases/download/$LOCAR_VERSION/locar-$LOCAR_VERSION-$TARGETOS-$TARGETARCH locar
 RUN go mod download
 ARG VERSION
@@ -38,9 +38,8 @@ LABEL description="Weka CSI Driver"
 # NOTE: usbutils, nfs-utils, rpcbind removed — unavailable in UBI9-minimal repos.
 # nfs-utils/rpcbind were not used at runtime (app uses kernel NFS client via k8s mount-utils).
 # If USB device discovery is needed, install usbutils from EPEL.
-# findutils provides xargs, required by the locar-based garbage-collection deletion
 RUN microdnf install -y util-linux libselinux-utils pciutils \
-    procps less container-selinux findutils && \
+    procps less container-selinux && \
     microdnf clean all && rm -rf /var/cache/dnf
 RUN mkdir -p /licenses
 COPY LICENSE /licenses

--- a/pkg/wekafs/gc.go
+++ b/pkg/wekafs/gc.go
@@ -179,23 +179,23 @@ func (gc *innerPathVolGc) purgeLeftovers(ctx context.Context, fs string, apiClie
 	}
 	volumeTrashLoc := filepath.Join(path, garbagePath)
 
-	if fileExists("/locar") {
+	// locar empties the trash far faster than a single-threaded walk, but --delete-all only
+	// removes what it finds inside the directory, never the directory itself. Skip it when there
+	// is no trash yet, since locar treats a missing path as an error.
+	if fileExists("/locar") && PathExists(volumeTrashLoc) {
 		logger.Debug().Msg("Using locar for fast deletion")
-		deleteCmd := exec.CommandContext(opCtx, "bash", "-c",
-			fmt.Sprintf("/locar --type file %s | xargs -P128 -n128 rm -f 2>&1 | wc -l; /locar --type dir %s | /usr/bin/xargs -P128 -n128 rm -rf 2>&1 | wc -l", volumeTrashLoc, volumeTrashLoc),
-		)
-		output, err := deleteCmd.CombinedOutput()
+		output, err := exec.CommandContext(opCtx, "/locar", "--delete-all", volumeTrashLoc).CombinedOutput()
 		if err != nil {
-			logger.Error().Err(err).Msg("Error running locar")
+			logger.Error().Err(err).Str("output", string(output)).Msg("Error running locar")
 			return
 		}
 		logger.Trace().Str("output", string(output)).Msg("Locar output")
-	} else {
-		logger.Debug().Msg("Using default deletion method")
-		if err := os.RemoveAll(volumeTrashLoc); err != nil {
-			logger.Error().Err(err).Str("path", volumeTrashLoc).Msg("Failed to perform garbage collection")
-			return
-		}
+	}
+
+	// Removes just the emptied trash directory after a locar pass, or the whole tree without one.
+	if err := os.RemoveAll(volumeTrashLoc); err != nil {
+		logger.Error().Err(err).Str("path", volumeTrashLoc).Msg("Failed to perform garbage collection")
+		return
 	}
 	succeeded = true
 	logger.Debug().Msg("Garbage collection completed")

--- a/pkg/wekafs/gc.go
+++ b/pkg/wekafs/gc.go
@@ -2,16 +2,16 @@ package wekafs
 
 import (
 	"context"
-	"fmt"
-	"github.com/rs/zerolog/log"
-	"github.com/wekafs/csi-wekafs/pkg/wekafs/apiclient"
-	"go.opentelemetry.io/otel"
 	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"sync"
 	"time"
+
+	"github.com/rs/zerolog/log"
+	"github.com/wekafs/csi-wekafs/pkg/wekafs/apiclient"
+	"go.opentelemetry.io/otel"
 )
 
 const garbagePath = ".__internal__wekafs-async-delete"
@@ -26,9 +26,31 @@ const (
 
 //const garbageCollectionMaxThreads = 32
 
+// gcKey identifies one filesystem's trash on one Weka API client.
+//
+// Filesystem names are only unique within a tenant, so with multitenancy two tenants can each have
+// a filesystem called "default" that are entirely different objects. Keying the GC state by name
+// alone made one tenant's purge look like it covered the other's: the second tenant's request would
+// see the name as already running, mark it deferred, and the chained re-run would then purge the
+// first tenant's filesystem again - leaving the second tenant's trash behind indefinitely.
+type gcKey struct {
+	apiClientHash uint32
+	filesystem    string
+}
+
+// newGcKey scopes a filesystem to its API client. A nil client is legacy, API-unbound mode, where
+// there is only one cluster in play and a zero hash is the right shared scope.
+func newGcKey(fs string, apiClient *apiclient.ApiClient) gcKey {
+	key := gcKey{filesystem: fs}
+	if apiClient != nil {
+		key.apiClientHash = apiClient.Hash()
+	}
+	return key
+}
+
 type innerPathVolGc struct {
-	isRunning  map[string]bool
-	isDeferred map[string]bool
+	isRunning  map[gcKey]bool
+	isDeferred map[gcKey]bool
 	sync.Mutex
 	mounter AnyMounter
 	config  *DriverConfig
@@ -36,8 +58,8 @@ type innerPathVolGc struct {
 
 func initInnerPathVolumeGc(mounter AnyMounter) *innerPathVolGc {
 	gc := innerPathVolGc{mounter: mounter}
-	gc.isRunning = make(map[string]bool)
-	gc.isDeferred = make(map[string]bool)
+	gc.isRunning = make(map[gcKey]bool)
+	gc.isDeferred = make(map[gcKey]bool)
 	return &gc
 }
 
@@ -109,23 +131,29 @@ func (gc *innerPathVolGc) purgeLeftovers(ctx context.Context, fs string, apiClie
 	ctx = log.With().Str("trace_id", span.SpanContext().TraceID().String()).Str("span_id", span.SpanContext().SpanID().String()).Str("op", op).Logger().WithContext(ctx)
 	logger := log.Ctx(ctx)
 
-	gc.Lock()
-	gc.isRunning[fs] = true
-	gc.Unlock()
+	// The caller claimed this key before spawning the goroutine, so only one purge per filesystem
+	// per API client is ever in flight.
+	key := newGcKey(fs, apiClient)
+	// Carry the tenant scope on every line: under multitenancy the filesystem name alone no longer
+	// identifies which trash a message is about.
+	scoped := logger.With().Str("filesystem", fs).Uint32("api_client", key.apiClientHash).Logger()
+	logger = &scoped
 
 	succeeded := false
-	// Always clear the running flag on every exit path. Chain another run if one
-	// was deferred while we ran, or retry (after a backoff) if this run failed, so
-	// failures are retried instead of silently stranding the trash and wedging GC.
+	// Release the claim on every exit path. Chain another run if one was deferred while we ran, or
+	// retry (after a backoff) if this run failed, so failures are retried instead of silently
+	// stranding the trash and wedging GC.
 	defer func() {
 		gc.Lock()
 		defer gc.Unlock()
-		gc.isRunning[fs] = false
-		if gc.isDeferred[fs] {
-			gc.isDeferred[fs] = false
+		if gc.isDeferred[key] {
+			gc.isDeferred[key] = false
+			// Hand the claim straight to the chained run rather than releasing it, so no other
+			// caller can start a competing purge in the gap.
 			go gc.purgeLeftovers(ctx, fs, apiClient)
 			return
 		}
+		gc.isRunning[key] = false
 		if !succeeded {
 			go func() {
 				time.Sleep(garbageCollectionRetryBackoff)
@@ -142,11 +170,11 @@ func (gc *innerPathVolGc) purgeLeftovers(ctx context.Context, fs string, apiClie
 	path, err, unmount := gc.mounter.Mount(opCtx, fs, apiClient)
 	defer func() {
 		if uErr := unmount(); uErr != nil {
-			logger.Error().Err(uErr).Str("filesystem", fs).Str("path", path).Msg("Failed to release filesystem mount after garbage collection")
+			logger.Error().Err(uErr).Str("path", path).Msg("Failed to release filesystem mount after garbage collection")
 		}
 	}()
 	if err != nil {
-		logger.Error().Err(err).Str("filesystem", fs).Str("path", path).Msg("Failed mounting FS for garbage collection")
+		logger.Error().Err(err).Str("path", path).Msg("Failed mounting FS for garbage collection")
 		return
 	}
 	volumeTrashLoc := filepath.Join(path, garbagePath)
@@ -187,15 +215,24 @@ func (gc *innerPathVolGc) initiateGarbageCollection(ctx context.Context, fs stri
 	// its deferred cancel() — does not abort the background purge mid-mount (CSI-422).
 	bgCtx := context.WithoutCancel(ctx)
 
+	// Scope the state to the API client as well as the filesystem name, so that two tenants sharing
+	// a filesystem name do not share GC state.
+	key := newGcKey(fs, apiClient)
+
 	gc.Lock()
 	defer gc.Unlock()
-	if gc.isRunning[fs] {
+	if gc.isRunning[key] {
 		logger.Trace().Msg("Garbage collection already running, deferring next run")
-		gc.isDeferred[fs] = true
+		gc.isDeferred[key] = true
 		return
 	}
-	if !gc.isDeferred[fs] {
+	if !gc.isDeferred[key] {
 		logger.Trace().Msg("Garbage collection not running, starting")
+		// Claim the filesystem before spawning, while still holding the lock. The goroutine cannot
+		// claim it itself: between the go statement and the goroutine acquiring the lock, another
+		// caller would still see the filesystem as idle and start a second, concurrent purge of the
+		// same trash directory.
+		gc.isRunning[key] = true
 		go gc.purgeLeftovers(bgCtx, fs, apiClient)
 	}
 }

--- a/pkg/wekafs/gc_test.go
+++ b/pkg/wekafs/gc_test.go
@@ -1,0 +1,69 @@
+package wekafs
+
+import (
+	"context"
+	"testing"
+
+	"github.com/wekafs/csi-wekafs/pkg/wekafs/apiclient"
+)
+
+func testApiClient(t *testing.T, org string) *apiclient.ApiClient {
+	t.Helper()
+	client, err := apiclient.NewApiClient(context.Background(), apiclient.Credentials{
+		Username:     "csi",
+		Password:     "secret",
+		Organization: org,
+		Endpoints:    []string{"10.0.0.1:14000"},
+		HttpScheme:   "https",
+	}, true, "test-host")
+	if err != nil {
+		t.Fatalf("could not build api client for %s: %v", org, err)
+	}
+	return client
+}
+
+// Two tenants may each own a filesystem called "default". Keying GC state by name alone made one
+// tenant's purge suppress the other's, stranding the second tenant's trash indefinitely.
+func TestGcKeySeparatesTenantsSharingAFilesystemName(t *testing.T) {
+	tenantA := testApiClient(t, "tenant-a")
+	tenantB := testApiClient(t, "tenant-b")
+	if tenantA.Hash() == tenantB.Hash() {
+		t.Fatal("expected different tenants to hash differently")
+	}
+
+	keyA := newGcKey("default", tenantA)
+	keyB := newGcKey("default", tenantB)
+	if keyA == keyB {
+		t.Fatal("same filesystem name on different tenants must not share GC state")
+	}
+
+	// The same filesystem on the same tenant must resolve to one key, or a claim taken by
+	// initiateGarbageCollection would never be released by purgeLeftovers and GC would wedge.
+	if newGcKey("default", tenantA) != keyA {
+		t.Fatal("key must be stable for the same filesystem and client")
+	}
+	if newGcKey("other", tenantA) == keyA {
+		t.Fatal("different filesystems on one tenant must not share GC state")
+	}
+
+	// Simulate the claim/release cycle across both tenants through the real maps.
+	gc := initInnerPathVolumeGc(nil)
+	gc.isRunning[keyA] = true
+	if gc.isRunning[keyB] {
+		t.Fatal("a purge running for tenant A must leave tenant B free to start")
+	}
+}
+
+// Legacy, API-unbound volumes have no client; they must still get a usable, stable key.
+func TestGcKeyWithoutApiClient(t *testing.T) {
+	key := newGcKey("default", nil)
+	if key.apiClientHash != 0 || key.filesystem != "default" {
+		t.Fatalf("unexpected key for API-unbound volume: %+v", key)
+	}
+	if newGcKey("default", nil) != key {
+		t.Fatal("key for API-unbound volumes must be stable")
+	}
+	if newGcKey("default", testApiClient(t, "tenant-a")) == key {
+		t.Fatal("API-bound and API-unbound volumes must not share GC state")
+	}
+}


### PR DESCRIPTION
### TL;DR
Fixes deleted-volume cleanup colliding across tenants sharing a filesystem name

### What changed?
- Cleanup of deleted volumes is now tracked per tenant, not just by filesystem name
- Fixes trash left behind indefinitely when two tenants both use a name like `default`
- Upgraded the deletion tool, lowering cleanup CPU/time cost

### How to test?
1. Create identically-named filesystems under two different tenants
2. Provision and delete volumes on each
3. Confirm both tenants' deleted data is fully cleaned up, without one blocking the other

### Why make this change?
A tenant's deleted volume data could previously be left behind indefinitely if another tenant used the same filesystem name — a real risk in shared, multi-tenant clusters.

