### PR TITLE
fix: replace Mutex with RWMutex in ApiStore to prevent concurrent map access races

### DIFF
--- a/pkg/wekafs/apistore.go
+++ b/pkg/wekafs/apistore.go
@@ -34,7 +34,7 @@ var ClusterApiNotFoundError = errors.New("could not get API client by cluster gu
 
 // ApiStore hashmap of all APIs defined by credentials + endpoints
 type ApiStore struct {
-	sync.Mutex
+	sync.RWMutex
 	apis          map[uint32]*apiclient.ApiClient
 	legacySecrets *map[string]string
 	config        *DriverConfig
@@ -43,6 +43,15 @@ type ApiStore struct {
 
 // getByHash returns pointer to existing API if found by hash, or nil
 func (api *ApiStore) getByHash(key uint32) *apiclient.ApiClient {
+	api.RLock()
+	defer api.RUnlock()
+	return api.getByHashLocked(key)
+}
+
+// getByHashLocked is getByHash for callers that already hold the lock, since Go's RWMutex is not
+// reentrant and taking it again here would deadlock.
+// REQUIRES: api's read or write lock is held by the caller.
+func (api *ApiStore) getByHashLocked(key uint32) *apiclient.ApiClient {
 	if val, ok := api.apis[key]; ok {
 		return val
 	}
@@ -50,6 +59,8 @@ func (api *ApiStore) getByHash(key uint32) *apiclient.ApiClient {
 }
 
 func (api *ApiStore) getByClusterGuid(guid uuid.UUID) (*apiclient.ApiClient, error) {
+	api.RLock()
+	defer api.RUnlock()
 	for _, val := range api.apis {
 		if val.ClusterGuid == guid {
 			return val, nil
@@ -159,8 +170,8 @@ func (api *ApiStore) fromCredentials(ctx context.Context, credentials apiclient.
 	}
 	api.Lock()
 	defer api.Unlock()
-	if api.getByHash(hash) != nil {
-		return api.getByHash(hash), nil
+	if existingApi := api.getByHashLocked(hash); existingApi != nil {
+		return existingApi, nil
 	}
 	if err := newClient.Init(ctx); err != nil {
 		logger.Error().Err(err).Msg("Failed to initialize API client")
@@ -233,7 +244,6 @@ func (api *ApiStore) GetClientFromSecrets(ctx context.Context, secrets map[strin
 
 func NewApiStore(config *DriverConfig, hostname string) *ApiStore {
 	s := &ApiStore{
-		Mutex:    sync.Mutex{},
 		apis:     make(map[uint32]*apiclient.ApiClient),
 		config:   config,
 		Hostname: hostname,

--- a/pkg/wekafs/apistore_test.go
+++ b/pkg/wekafs/apistore_test.go
@@ -1,0 +1,66 @@
+package wekafs
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/wekafs/csi-wekafs/pkg/wekafs/apiclient"
+)
+
+// ApiStore's map is read on the fast path of fromCredentials without the lock, while a concurrent
+// call writes it under the lock. In Go that is not a benign race but a fatal runtime error
+// ("concurrent map read and map write"), and fromCredentials runs on every request that needs an
+// API client. Run with -race to make this meaningful.
+func TestApiStoreConcurrentAccessIsSafe(t *testing.T) {
+	store := &ApiStore{apis: make(map[uint32]*apiclient.ApiClient)}
+
+	var wg sync.WaitGroup
+	const writers, readers, iterations = 4, 8, 300
+
+	for w := 0; w < writers; w++ {
+		wg.Add(1)
+		go func(base uint32) {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				store.Lock()
+				store.apis[base*uint32(iterations)+uint32(i)] = &apiclient.ApiClient{}
+				store.Unlock()
+			}
+		}(uint32(w))
+	}
+	for r := 0; r < readers; r++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				store.getByHash(uint32(i))
+				_, _ = store.getByClusterGuid(uuid.New())
+			}
+		}()
+	}
+	wg.Wait()
+}
+
+// The write path calls getByHashLocked while already holding the lock; using the locking variant
+// there would deadlock, since Go's RWMutex is not reentrant.
+func TestApiStoreGetByHashLockedDoesNotRelock(t *testing.T) {
+	store := &ApiStore{apis: make(map[uint32]*apiclient.ApiClient)}
+	client := &apiclient.ApiClient{}
+	store.apis[7] = client
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		store.Lock()
+		defer store.Unlock()
+		if got := store.getByHashLocked(7); got != client {
+			t.Errorf("expected the stored client back, got %v", got)
+		}
+		if got := store.getByHashLocked(8); got != nil {
+			t.Errorf("expected nil for an absent hash, got %v", got)
+		}
+	}()
+	<-done
+}


### PR DESCRIPTION
### TL;DR
Fixes a bug that could crash the CSI controller under concurrent use

### What changed?
- Fixed unsafe concurrent access to the driver's internal cache of Weka cluster connections
- Prevents a crash when many requests need cluster credentials at the same time

### How to test?
1. Covered by automated concurrency tests included in this change
2. Before the fix, the symptom was occasional controller pod restarts under heavy simultaneous volume operations; this should no longer occur

### Why make this change?
The controller could crash outright when multiple requests needing storage-cluster credentials were handled at the same time — more likely at scale or with many simultaneous volume operations.

