### PR TITLE
fix: default semaphore weight to 1 for ops absent from maxConcurrencyPerOp

### DIFF
--- a/pkg/wekafs/controllerserver.go
+++ b/pkg/wekafs/controllerserver.go
@@ -229,10 +229,15 @@ func (cs *ControllerServer) initializeSemaphore(ctx context.Context, op string) 
 	if _, ok := cs.semaphores[op]; ok {
 		return
 	}
-	max := cs.getConfig().maxConcurrencyPerOp[op]
+	m, ok := cs.getConfig().maxConcurrencyPerOp[op]
+	if !ok {
+		// An operation with no configured limit would otherwise get a zero-weight semaphore, which
+		// no acquire can ever satisfy - every such request would block until its deadline.
+		m = 1
+	}
 	logger := log.Ctx(ctx)
-	logger.Info().Str("op", op).Int64("max_concurrency", max).Msg("Initializing semaphore")
-	sem := semaphore.NewWeighted(max)
+	logger.Info().Str("op", op).Int64("max_concurrency", m).Msg("Initializing semaphore")
+	sem := semaphore.NewWeighted(m)
 	cs.semaphores[op] = sem
 }
 

--- a/pkg/wekafs/nodeserver.go
+++ b/pkg/wekafs/nodeserver.go
@@ -232,10 +232,15 @@ func (ns *NodeServer) initializeSemaphore(ctx context.Context, op string) {
 		return
 	}
 
-	max := ns.getConfig().maxConcurrencyPerOp[op]
+	m, ok := ns.getConfig().maxConcurrencyPerOp[op]
+	if !ok {
+		// An operation with no configured limit would otherwise get a zero-weight semaphore, which
+		// no acquire can ever satisfy - every such request would block until its deadline.
+		m = 1
+	}
 	logger := log.Ctx(ctx)
-	logger.Info().Str("op", op).Int64("max_concurrency", max).Msg("Initializing semaphore")
-	sem := semaphore.NewWeighted(max)
+	logger.Info().Str("op", op).Int64("max_concurrency", m).Msg("Initializing semaphore")
+	sem := semaphore.NewWeighted(m)
 	ns.semaphores[op] = sem
 }
 

--- a/pkg/wekafs/semaphore_test.go
+++ b/pkg/wekafs/semaphore_test.go
@@ -1,0 +1,67 @@
+package wekafs
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"golang.org/x/sync/semaphore"
+)
+
+// An op absent from maxConcurrencyPerOp previously got semaphore.NewWeighted(0), which no acquire
+// can ever satisfy: the request blocks until its deadline instead of running. Any RPC added without
+// also adding a concurrency entry would hang.
+func TestInitializeSemaphoreDefaultsUnknownOpToOne(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		acquire func(*testing.T, string) error
+	}{
+		{"controller", func(t *testing.T, op string) error {
+			cs := &ControllerServer{
+				semaphores: make(map[string]*semaphore.Weighted),
+				config:     &DriverConfig{maxConcurrencyPerOp: map[string]int64{"CreateVolume": 5}},
+			}
+			cs.initializeSemaphore(context.Background(), op)
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			defer cancel()
+			return cs.semaphores[op].Acquire(ctx, 1)
+		}},
+		{"node", func(t *testing.T, op string) error {
+			ns := &NodeServer{
+				semaphores: make(map[string]*semaphore.Weighted),
+				config:     &DriverConfig{maxConcurrencyPerOp: map[string]int64{"NodePublishVolume": 5}},
+			}
+			ns.initializeSemaphore(context.Background(), op)
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			defer cancel()
+			return ns.semaphores[op].Acquire(ctx, 1)
+		}},
+	} {
+		t.Run(tc.name+"/unknown op is acquirable", func(t *testing.T) {
+			if err := tc.acquire(t, "SomeOperationWithNoConfiguredLimit"); err != nil {
+				t.Fatalf("acquiring a semaphore for an unconfigured op should succeed, got %v", err)
+			}
+		})
+		t.Run(tc.name+"/configured op keeps its limit", func(t *testing.T) {
+			op := map[string]string{"controller": "CreateVolume", "node": "NodePublishVolume"}[tc.name]
+			if err := tc.acquire(t, op); err != nil {
+				t.Fatalf("acquiring a configured semaphore should succeed, got %v", err)
+			}
+		})
+	}
+}
+
+// A configured limit of zero is explicit operator intent to block the op, and must be preserved -
+// only an absent entry defaults to 1.
+func TestInitializeSemaphoreKeepsExplicitZero(t *testing.T) {
+	cs := &ControllerServer{
+		semaphores: make(map[string]*semaphore.Weighted),
+		config:     &DriverConfig{maxConcurrencyPerOp: map[string]int64{"BlockedOp": 0}},
+	}
+	cs.initializeSemaphore(context.Background(), "BlockedOp")
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	if err := cs.semaphores["BlockedOp"].Acquire(ctx, 1); err == nil {
+		t.Fatal("an explicitly configured limit of 0 must still block")
+	}
+}


### PR DESCRIPTION
### TL;DR
Operations without an explicit concurrency limit were being blocked entirely instead of allowed to run.

### What changed?
- Operations missing a configured concurrency limit now default to allowing 1 at a time, instead of 0.
- Operations explicitly configured with a limit of 0 still remain blocked, as intended.

### How to test?
1. Deploy the CSI driver.
2. Trigger an operation that has no explicit concurrency limit configured.
3. Verify it completes normally instead of hanging until it times out.

### Why make this change?
An operation without a configured limit defaulted to a concurrency of zero, which can never be acquired, so it would hang until its request timed out rather than running or failing clearly.
