### PR TITLE
fix: invalidate filesystem cache before deletion to prevent stale UID snapshot listing

### DIFF
--- a/pkg/wekafs/volume.go
+++ b/pkg/wekafs/volume.go
@@ -301,7 +301,10 @@ func (v *Volume) getUnderlyingSnapshots(ctx context.Context) (*[]apiclient.Snaps
 		return nil, errors.New("cannot check for underlying snaphots as volume is not bound to API")
 	}
 
-	fsObj, err := v.getFilesystemObj(ctx, true)
+	// Deliberately not from cache: the answer gates filesystem deletion, and a filesystem object
+	// cached earlier in this request could carry a stale UID, which would list the snapshots of the
+	// wrong filesystem and let one still holding snapshots be deleted.
+	fsObj, err := v.getFilesystemObj(ctx, false)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### TL;DR
Deleting a filesystem could use stale cached data, letting deletion proceed even if the filesystem still had snapshots.

### What changed?
- The snapshot check performed before deleting a filesystem now always reads current data instead of a cached copy.
- The cached record for a filesystem is cleared immediately once its deletion begins.

### How to test?
1. This depends on an internal timing window that isn't practical to reproduce manually.
2. Covered by automated tests added in this change.

### Why make this change?
A cache used to avoid extra lookups wasn't cleared at the right time, so a delete could occasionally act on outdated filesystem information.
