### PR TITLE
feat: add paginated API response support for quota fetching

### DIFF
--- a/pkg/wekafs/apiclient/apiclient_test.go
+++ b/pkg/wekafs/apiclient/apiclient_test.go
@@ -277,7 +277,7 @@ func TestApiClientRequest(t *testing.T) {
 			responseData := &LoginResponse{}
 
 			// Perform the request
-			err = apiClient.request(context.Background(), "GET", ApiPathClusterInfo, jb, nil, responseData)
+			_, err = apiClient.request(context.Background(), "GET", ApiPathClusterInfo, jb, nil, responseData)
 
 			// Assert the error type
 			if tt.expectedError != nil {

--- a/pkg/wekafs/apiclient/apiobject.go
+++ b/pkg/wekafs/apiclient/apiobject.go
@@ -2,8 +2,6 @@ package apiclient
 
 import (
 	"encoding/json"
-
-	"github.com/google/uuid"
 )
 
 // ApiObject generic interface of API object of any type (FileSystem, Quota, etc.)
@@ -21,8 +19,19 @@ type ApiResponse struct {
 	Data           json.RawMessage `json:"data"` // Data, may be either object, dict or list
 	ErrorCodes     []string        `json:"data.exceptionClass,omitempty"`
 	Message        string          `json:"message,omitempty"`    // Optional, can have error message
-	NextToken      uuid.UUID       `json:"next_token,omitempty"` // For paginated objects
+	NextToken      string          `json:"next_token,omitempty"` // For paginated objects
 	HttpStatusCode int
+}
+
+// ApiObjectResponse is implemented by response types the backend may return across several pages.
+//
+// Implementing it is what opts a type into pagination, so there is no separate boolean to keep in
+// step with the method. A response type that does not implement it is fetched in a single request,
+// exactly as before.
+type ApiObjectResponse interface {
+	// CombinePartialResponse folds one fetched page into the accumulated response. Implementations
+	// append, since the accumulated value is the caller's own object.
+	CombinePartialResponse(page ApiObjectResponse) error
 }
 
 // ApiObjectRequest interface that describes a request for an ApiObject CRUD operation

--- a/pkg/wekafs/apiclient/constants.go
+++ b/pkg/wekafs/apiclient/constants.go
@@ -1,9 +1,12 @@
 package apiclient
 
 const (
-	ApiHttpTimeOutSeconds                     = 60
-	ApiRetryIntervalSeconds                   = 1
-	ApiRetryMaxCount                          = 5
+	ApiHttpTimeOutSeconds   = 60
+	ApiRetryIntervalSeconds = 1
+	ApiRetryMaxCount        = 5
+	// ApiMaxPagesPerRequest bounds a paginated fetch, so a backend that keeps returning a next
+	// token cannot spin forever.
+	ApiMaxPagesPerRequest                     = 1000
 	RetryBackoffExponentialFactor             = 1
 	RootOrganizationName                      = "Root"
 	TracerName                                = "weka-csi"

--- a/pkg/wekafs/apiclient/login.go
+++ b/pkg/wekafs/apiclient/login.go
@@ -26,7 +26,7 @@ func (a *ApiClient) Login(ctx context.Context) error {
 		return err
 	}
 	responseData := &LoginResponse{}
-	if err := a.request(ctx, "POST", ApiPathLogin, jb, nil, responseData); err != nil {
+	if _, err := a.request(ctx, "POST", ApiPathLogin, jb, nil, responseData); err != nil {
 		if err.getType() == "ApiAuthorizationError" {
 			logger.Error().Err(err).Str("endpoint", a.getEndpoint(ctx).String()).Msg("Could not log in to endpoint")
 		}
@@ -80,7 +80,7 @@ func (a *ApiClient) Init(ctx context.Context) error {
 	r := RefreshRequest{RefreshToken: a.refreshToken}
 	responseData := &RefreshResponse{}
 	payload, _ := marshalRequest(r)
-	if err := a.request(ctx, "POST", ApiPathRefresh, payload, nil, responseData); err != nil {
+	if _, err := a.request(ctx, "POST", ApiPathRefresh, payload, nil, responseData); err != nil {
 		log.Ctx(ctx).Trace().Msg("Failed to refresh auth token, logging in...")
 		return a.Login(ctx)
 	}

--- a/pkg/wekafs/apiclient/pagination_test.go
+++ b/pkg/wekafs/apiclient/pagination_test.go
@@ -1,6 +1,7 @@
 package apiclient
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -126,5 +127,207 @@ func TestNonPaginatedResponseFetchesOnce(t *testing.T) {
 	}
 	if len(seen) != 1 {
 		t.Fatalf("a non-paginated response must be fetched once, saw %d requests", len(seen))
+	}
+}
+
+// Finding 1: a cluster that can't accept URL query params (old cluster, or an unparseable version
+// string) silently drops next_token. Looping in that state re-sends the same request and gets
+// page 1 back every time; the fix is to fetch exactly one page and warn, matching what this call
+// did before pagination existed. Revert the SupportsUrlQueryParams check in Request and this test
+// fails by asserting more than one request went out (in fact it would hang looping to 1000).
+func TestPaginationWithoutUrlQuerySupportMakesExactlyOneRequest(t *testing.T) {
+	pages := [][]Quota{
+		{{InodeId: 1}, {InodeId: 2}},
+		{{InodeId: 3}},
+	}
+	var seen []string
+	srv := pagedServer(t, pages, &seen)
+	defer srv.Close()
+
+	c := testClient(t, srv)
+	c.CompatibilityMap = &WekaCompatibilityMap{UrlQueryParams: false}
+
+	got := &Quotas{}
+	if err := c.Get(t.Context(), "/quotas", url.Values{"filter": []string{"x"}}, got); err != nil {
+		t.Fatalf("Get must not fail just because the cluster can't accept a pagination token: %v", err)
+	}
+	if len(seen) != 1 {
+		t.Fatalf("expected exactly one request when the cluster cannot accept next_token, saw %d: %v", len(seen), seen)
+	}
+	if len(*got) != 2 {
+		t.Fatalf("expected only page 1's data (truncated), got %d entries: %+v", len(*got), *got)
+	}
+}
+
+// Finding 2: a backend that hands back the same token it was just given must not be followed
+// forever. Revert the currentToken check in Request and this test fails because no error comes
+// back (the loop would instead run until ApiMaxPagesPerRequest).
+func TestPaginationStopsOnNonAdvancingToken(t *testing.T) {
+	var seen []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "quotas") {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data": map[string]any{"access_token": "t", "refresh_token": "r", "expires_in": 3600},
+			})
+			return
+		}
+		seen = append(seen, r.URL.Query().Get("next_token"))
+		// Always hands back the same token, regardless of what was sent - a backend contract
+		// violation that must not be looped on indefinitely.
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data":       []Quota{{InodeId: 1}},
+			"next_token": "stuck",
+		})
+	}))
+	defer srv.Close()
+
+	got := &Quotas{}
+	err := testClient(t, srv).Get(t.Context(), "/quotas", nil, got)
+	if err == nil {
+		t.Fatalf("expected an error when the backend never advances the pagination token")
+	}
+	if len(seen) == 0 || len(seen) > 5 {
+		t.Fatalf("expected only a handful of requests before giving up on a stuck token, saw %d: %v", len(seen), seen)
+	}
+}
+
+// Finding 3: a page whose data fails to unmarshal must surface as an error from Request, not be
+// folded in as an empty page. Revert the unmarshalErr check in request() and this test fails
+// because Get returns nil with a truncated (empty) result instead of an error.
+func TestPaginationDataUnmarshalErrorIsReturned(t *testing.T) {
+	var seen []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "quotas") {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data": map[string]any{"access_token": "t", "refresh_token": "r", "expires_in": 3600},
+			})
+			return
+		}
+		seen = append(seen, r.URL.Query().Get("next_token"))
+		// "data" is a string here, never a valid []Quota - unmarshalling it always fails.
+		_ = json.NewEncoder(w).Encode(map[string]any{"data": "not-a-quota-list"})
+	}))
+	defer srv.Close()
+
+	got := &Quotas{}
+	err := testClient(t, srv).Get(t.Context(), "/quotas", nil, got)
+	if err == nil {
+		t.Fatalf("expected an error when a page's data fails to unmarshal, got nil (result: %+v)", *got)
+	}
+	if len(seen) != 1 {
+		t.Fatalf("expected exactly one request before the unmarshal failure was surfaced, saw %d", len(seen))
+	}
+}
+
+// Finding 4: do() cannot abort an in-flight request (it uses http.NewRequest, not
+// NewRequestWithContext), so the pagination loop itself must notice a cancelled ctx and stop
+// before issuing the next page's request. Revert the ctx.Err() check in Request's loop and this
+// test fails because a 3rd request goes out and no error is returned.
+func TestPaginationStopsOnCancelledContext(t *testing.T) {
+	pages := [][]Quota{
+		{{InodeId: 1}},
+		{{InodeId: 2}},
+		{{InodeId: 3}},
+	}
+	var seen []string
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	srv := pagedServer(t, pages, &seen)
+	defer srv.Close()
+	inner := srv.Config.Handler
+	srv.Config.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		inner.ServeHTTP(w, r)
+		if strings.Contains(r.URL.Path, "quotas") {
+			// Cancel once the first page has been served. The HTTP transport never observes
+			// this (that's finding 4's premise), so only the loop's own ctx.Err() check can
+			// stop the second request from going out.
+			cancel()
+		}
+	})
+
+	got := &Quotas{}
+	err := testClient(t, srv).Get(ctx, "/quotas", nil, got)
+	if err == nil {
+		t.Fatalf("expected the cancelled context's error to be returned")
+	}
+	if len(seen) != 1 {
+		t.Fatalf("expected pagination to stop right after the context was cancelled, saw %d requests: %v", len(seen), seen)
+	}
+}
+
+// Finding 5: CombinePartialResponse appends, so a caller-supplied accumulator that already has
+// entries must be reset before the first page is fetched, or the pre-existing entries survive
+// alongside the freshly fetched ones. Revert the reflect.Zero reset in Request and this test fails
+// because the accumulator ends up with 3 pre-existing + 2 fetched entries instead of just the 2.
+func TestPaginationReplacesPrepopulatedAccumulator(t *testing.T) {
+	pages := [][]Quota{
+		{{InodeId: 1}},
+		{{InodeId: 2}},
+	}
+	var seen []string
+	srv := pagedServer(t, pages, &seen)
+	defer srv.Close()
+
+	got := &Quotas{{InodeId: 997}, {InodeId: 998}, {InodeId: 999}}
+	if err := testClient(t, srv).Get(t.Context(), "/quotas", nil, got); err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if len(*got) != 2 {
+		t.Fatalf("expected the pre-populated accumulator to be replaced, not appended to; got %d entries: %+v", len(*got), *got)
+	}
+}
+
+// Finding 8: Request decides whether to paginate purely from the response type, so a mutating
+// method (POST/PUT/DELETE) whose response type happens to implement ApiObjectResponse must still
+// take the single-request path - otherwise the same payload would be re-sent once per page. Revert
+// the Method == http.MethodGet check and this test fails because a 2nd POST goes out carrying
+// next_token.
+func TestNonGetMethodWithPaginatedResponseTypeMakesOneRequest(t *testing.T) {
+	pages := [][]Quota{
+		{{InodeId: 1}},
+		{{InodeId: 2}},
+	}
+	var seen []string
+	srv := pagedServer(t, pages, &seen)
+	defer srv.Close()
+
+	got := &Quotas{}
+	payload := []byte("{}")
+	if err := testClient(t, srv).Post(t.Context(), "/quotas", &payload, nil, got); err != nil {
+		t.Fatalf("Post: %v", err)
+	}
+	if len(seen) != 1 {
+		t.Fatalf("expected exactly one request for a non-GET method, saw %d: %v", len(seen), seen)
+	}
+	if seen[0] != "" {
+		t.Fatalf("expected no next_token to be sent for a non-GET method, saw next_token=%q", seen[0])
+	}
+}
+
+// Finding 6: a nil *Quotas still satisfies ApiObjectResponse (the interface value carries a type
+// even though the pointer is nil), so it takes the paginated path. Without an explicit nil check,
+// CombinePartialResponse's `*q = append(*q, ...)` dereferences that nil pointer and panics. Revert
+// the IsNil check in Request and this test fails via the recover() catching a panic instead of
+// seeing a plain error.
+func TestPaginationNilTypedPointerErrorsWithoutPanic(t *testing.T) {
+	var seen []string
+	srv := pagedServer(t, [][]Quota{{{InodeId: 1}}}, &seen)
+	defer srv.Close()
+
+	var got *Quotas // typed nil, still satisfies ApiObjectResponse via its pointer-receiver method
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("a nil typed pointer must return an error, not panic: %v", r)
+			}
+		}()
+		err := testClient(t, srv).Get(t.Context(), "/quotas", nil, got)
+		if err == nil {
+			t.Fatalf("expected an error for a nil *Quotas response, got nil")
+		}
+	}()
+	if len(seen) != 0 {
+		t.Fatalf("expected the nil check to reject the call before any request went out, saw %d", len(seen))
 	}
 }

--- a/pkg/wekafs/apiclient/pagination_test.go
+++ b/pkg/wekafs/apiclient/pagination_test.go
@@ -1,0 +1,130 @@
+package apiclient
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+// pagedServer serves a fixed number of pages, echoing back which next_token it was asked for so a
+// test can assert the client actually followed the chain.
+func pagedServer(t *testing.T, pages [][]Quota, seen *[]string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "quotas") {
+			// login / token refresh - not part of what these tests count
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data": map[string]any{"access_token": "t", "refresh_token": "r", "expires_in": 3600},
+			})
+			return
+		}
+		token := r.URL.Query().Get("next_token")
+		*seen = append(*seen, token)
+		idx := 0
+		if token != "" {
+			_, _ = fmt.Sscanf(token, "page-%d", &idx)
+		}
+		body := map[string]any{"data": pages[idx]}
+		if idx+1 < len(pages) {
+			body["next_token"] = fmt.Sprintf("page-%d", idx+1)
+		}
+		_ = json.NewEncoder(w).Encode(body)
+	}))
+}
+
+func testClient(t *testing.T, srv *httptest.Server) *ApiClient {
+	t.Helper()
+	u, _ := url.Parse(srv.URL)
+	c, err := NewApiClient(t.Context(), Credentials{
+		Username: "u", Password: "p", Organization: "Root",
+		Endpoints: []string{u.Host}, HttpScheme: "http",
+	}, true, "test")
+	if err != nil {
+		t.Fatalf("client: %v", err)
+	}
+	c.apiToken = "t"
+	c.CompatibilityMap = &WekaCompatibilityMap{UrlQueryParams: true}
+	return c
+}
+
+// Every page must reach the caller's object. The original implementation reassigned its local
+// Response to an accumulator, so the caller kept only page 1.
+func TestPaginationReturnsEveryPageToTheCaller(t *testing.T) {
+	pages := [][]Quota{
+		{{InodeId: 1}, {InodeId: 2}},
+		{{InodeId: 3}, {InodeId: 4}},
+		{{InodeId: 5}},
+	}
+	var seen []string
+	srv := pagedServer(t, pages, &seen)
+	defer srv.Close()
+
+	got := &Quotas{}
+	if err := testClient(t, srv).Get(t.Context(), "/quotas", url.Values{"filter": []string{"x"}}, got); err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if len(*got) != 5 {
+		t.Fatalf("expected all 5 quotas across 3 pages, got %d: %+v", len(*got), *got)
+	}
+	for i, q := range *got {
+		if q.InodeId != uint64(i+1) {
+			t.Fatalf("page contents out of order at %d: %+v", i, *got)
+		}
+	}
+	if len(seen) != 3 || seen[0] != "" || seen[1] != "page-1" || seen[2] != "page-2" {
+		t.Fatalf("expected the client to follow the token chain, saw %v", seen)
+	}
+}
+
+// FindQuotaByFilter passes a nil Query. Setting next_token on a nil url.Values panics, so the
+// second page used to take the process down.
+func TestPaginationWithNilQuery(t *testing.T) {
+	pages := [][]Quota{{{InodeId: 1}}, {{InodeId: 2}}}
+	var seen []string
+	srv := pagedServer(t, pages, &seen)
+	defer srv.Close()
+
+	got := &Quotas{}
+	if err := testClient(t, srv).Get(t.Context(), "/quotas", nil, got); err != nil {
+		t.Fatalf("a nil query must be usable for a paginated response, got %v", err)
+	}
+	if len(*got) != 2 {
+		t.Fatalf("expected 2 quotas, got %d", len(*got))
+	}
+}
+
+// Pagination must not mutate the query the caller handed in.
+func TestPaginationDoesNotMutateCallerQuery(t *testing.T) {
+	pages := [][]Quota{{{InodeId: 1}}, {{InodeId: 2}}}
+	var seen []string
+	srv := pagedServer(t, pages, &seen)
+	defer srv.Close()
+
+	caller := url.Values{"filter": []string{"x"}}
+	if err := testClient(t, srv).Get(t.Context(), "/quotas", caller, &Quotas{}); err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if _, polluted := caller["next_token"]; polluted {
+		t.Fatalf("pagination leaked next_token into the caller's query: %v", caller)
+	}
+}
+
+// A response type that does not implement ApiObjectResponse is fetched exactly once, as before.
+func TestNonPaginatedResponseFetchesOnce(t *testing.T) {
+	pages := [][]Quota{{{InodeId: 1}}, {{InodeId: 2}}}
+	var seen []string
+	srv := pagedServer(t, pages, &seen)
+	defer srv.Close()
+
+	got := &[]Quota{}
+	if err := testClient(t, srv).Get(t.Context(), "/quotas", nil, got); err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if len(seen) != 1 {
+		t.Fatalf("a non-paginated response must be fetched once, saw %d requests", len(seen))
+	}
+}

--- a/pkg/wekafs/apiclient/pagination_test.go
+++ b/pkg/wekafs/apiclient/pagination_test.go
@@ -331,3 +331,64 @@ func TestPaginationNilTypedPointerErrorsWithoutPanic(t *testing.T) {
 		t.Fatalf("expected the nil check to reject the call before any request went out, saw %d", len(seen))
 	}
 }
+
+// A 200 whose body carries no "data" key at all is not a decode failure: every DELETE passes
+// &ApiResponse{} and gets exactly that shape back, and a paginated fetch may legitimately return
+// an empty page. Unmarshalling a nil data field fails with "unexpected end of JSON input", so
+// without the len(rawResponse.Data) == 0 guard this turns every successful delete into a
+// permanent ApiNonTransientError - and the CSI sidecar retries a delete that already succeeded.
+// Remove that guard and this test fails.
+func TestBodylessSuccessIsNotAnUnmarshalFailure(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "quotas") {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data": map[string]any{"access_token": "t", "refresh_token": "r", "expires_in": 3600},
+			})
+			return
+		}
+		// Exactly what a Weka DELETE returns: a success envelope with no data key.
+		_, _ = w.Write([]byte(`{"status":"OK"}`))
+	}))
+	defer srv.Close()
+
+	resp := &ApiResponse{}
+	if err := testClient(t, srv).Delete(t.Context(), "/quotas/x", nil, nil, resp); err != nil {
+		t.Fatalf("a body-less 200 must not be reported as an unmarshal failure: %v", err)
+	}
+}
+
+// The same guard must not resurrect the truncation bug for paginated fetches: an empty page ends
+// the fetch cleanly rather than erroring, and the caller gets the pages that did arrive.
+func TestPaginationEmptyPageEndsFetchWithoutError(t *testing.T) {
+	var seen int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "quotas") {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data": map[string]any{"access_token": "t", "refresh_token": "r", "expires_in": 3600},
+			})
+			return
+		}
+		seen++
+		if seen == 1 {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data":       []Quota{{InodeId: 1}},
+				"next_token": "page-2",
+			})
+			return
+		}
+		// Second page carries no data key and no token - a legitimate empty tail.
+		_, _ = w.Write([]byte(`{"status":"OK"}`))
+	}))
+	defer srv.Close()
+
+	got := &Quotas{}
+	if err := testClient(t, srv).Get(t.Context(), "/quotas", nil, got); err != nil {
+		t.Fatalf("an empty final page must end the fetch, not fail it: %v", err)
+	}
+	if len(*got) != 1 {
+		t.Fatalf("expected the 1 quota from page 1, got %d", len(*got))
+	}
+	if seen != 2 {
+		t.Fatalf("expected 2 requests (page 1 + empty tail), saw %d", seen)
+	}
+}

--- a/pkg/wekafs/apiclient/quota.go
+++ b/pkg/wekafs/apiclient/quota.go
@@ -89,6 +89,19 @@ func (q *Quota) GetCapacityLimit() uint64 {
 	return q.SoftLimitBytes
 }
 
+// Quotas is a paginated list of quotas. A filesystem can hold far more quotas than the backend
+// returns in one response, so this is the type to fetch into rather than a plain slice.
+type Quotas []Quota
+
+func (q *Quotas) CombinePartialResponse(page ApiObjectResponse) error {
+	partial, ok := page.(*Quotas)
+	if !ok {
+		return fmt.Errorf("cannot combine a %T into a quota list", page)
+	}
+	*q = append(*q, *partial...)
+	return nil
+}
+
 type QuotaCreateRequest struct {
 	filesystemUid  uuid.UUID
 	inodeId        uint64
@@ -272,7 +285,7 @@ func (a *ApiClient) FindQuotaByFilter(ctx context.Context, query *Quota, resultS
 	if query.FilesystemUid == uuid.Nil {
 		return RequestMissingParams
 	}
-	ret := &[]Quota{}
+	ret := &Quotas{}
 	err := a.Get(ctx, query.GetBasePath(a), nil, ret)
 	if err != nil {
 		return err

--- a/pkg/wekafs/apiclient/requests.go
+++ b/pkg/wekafs/apiclient/requests.go
@@ -239,12 +239,24 @@ func (a *ApiClient) request(ctx context.Context, Method string, Path string, Pay
 				apiError: reqErr,
 			}
 		}
-		err := json.Unmarshal(rawResponse.Data, v)
-		if err != nil {
-			logger.Error().Err(err).Interface("object_type", reflect.TypeOf(v)).Msg("Failed to marshal JSON request into a valid interface")
+		unmarshalErr := json.Unmarshal(rawResponse.Data, v)
+		if unmarshalErr != nil {
+			logger.Error().Err(unmarshalErr).Interface("object_type", reflect.TypeOf(v)).Msg("Failed to marshal JSON request into a valid interface")
 		}
 		switch s {
 		case http.StatusOK:
+			if unmarshalErr != nil {
+				// A page whose data fails to decode must not be folded in as an empty page -
+				// that would silently truncate a paginated result. Only the success path can
+				// reach here relying on unmarshalErr; non-200 paths return their own reqErr
+				// below and never look at it.
+				return ApiNonTransientError{apiError: ApiError{
+					Err:         unmarshalErr,
+					Text:        "Failed to unmarshal JSON response body",
+					StatusCode:  s,
+					ApiResponse: rawResponse,
+				}}
+			}
 			nextToken = rawResponse.NextToken
 			return nil
 		case http.StatusUnauthorized:
@@ -280,7 +292,11 @@ func (a *ApiClient) Request(ctx context.Context, Method string, Path string, Pay
 		return err
 	}
 
+	// Only a GET can safely be repeated per page: a POST/PUT/DELETE whose response type happens
+	// to implement ApiObjectResponse would otherwise re-send the same mutating payload once per
+	// page.
 	accumulated, paginated := Response.(ApiObjectResponse)
+	paginated = paginated && Method == http.MethodGet
 	if !paginated {
 		_, err := a.request(ctx, Method, Path, Payload, Query, Response)
 		if err != nil {
@@ -293,12 +309,45 @@ func (a *ApiClient) Request(ctx context.Context, Method string, Path string, Pay
 	if responseType.Kind() != reflect.Ptr {
 		return errors.New("a paginated response must be passed as a pointer")
 	}
+	responseValue := reflect.ValueOf(Response)
+	if responseValue.IsNil() {
+		// accumulated wraps a nil *T here: the interface value itself is non-nil (it carries a
+		// type), so the type assertion above succeeds, but CombinePartialResponse would
+		// dereference a nil receiver and panic. Fail cleanly instead.
+		return fmt.Errorf("a paginated response must not be a nil %s pointer", responseType.Elem())
+	}
+	logger := log.Ctx(ctx)
+
+	if !a.SupportsUrlQueryParams() {
+		// The cluster can't accept next_token at all, so pagination cannot happen: every
+		// request would come back as page 1 again (see the non-advancing-token check below,
+		// which exists for exactly this shape of backend misbehaviour). Do a single request and
+		// return it, matching the pre-pagination behaviour, rather than looping or failing a
+		// call that used to succeed.
+		logger.Warn().Str("path", Path).Msg("Cluster does not support URL query parameters; fetching a single page, result may be truncated")
+		_, err := a.request(ctx, Method, Path, Payload, Query, Response)
+		return err
+	}
+
 	// Work on a copy: Query belongs to the caller, and it is legitimately nil, which Set would
 	// panic on.
 	query := cloneQuery(Query)
-	logger := log.Ctx(ctx)
+
+	// Zero the caller's accumulator before fetching the first page. CombinePartialResponse
+	// appends, so a caller that passes in a non-empty accumulator (or reuses one across calls)
+	// would otherwise get duplicates alongside the freshly fetched pages. This restores the
+	// replace-semantics of the pre-pagination code path, which unmarshalled straight into
+	// Response.
+	responseValue.Elem().Set(reflect.Zero(responseType.Elem()))
+
+	// currentToken is the next_token that produced the page just received - used to detect a
+	// backend that echoes the same token back forever instead of advancing it.
+	currentToken := ""
 
 	for page := 1; ; page++ {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		// Every page is unmarshalled into a fresh object and then folded into the caller's
 		// Response. Unmarshalling straight into Response would let each page overwrite the last.
 		pageValue := reflect.New(responseType.Elem()).Interface()
@@ -316,10 +365,14 @@ func (a *ApiClient) Request(ctx context.Context, Method string, Path string, Pay
 			}
 			return nil
 		}
+		if nextToken == currentToken {
+			return fmt.Errorf("backend returned pagination token %q unchanged after it was already used for %s; refusing to loop indefinitely since the backend is not advancing the token", nextToken, Path)
+		}
 		if page >= ApiMaxPagesPerRequest {
 			return fmt.Errorf("paginated response exceeded %d pages, giving up", ApiMaxPagesPerRequest)
 		}
 		query.Set("next_token", nextToken)
+		currentToken = nextToken
 	}
 }
 

--- a/pkg/wekafs/apiclient/requests.go
+++ b/pkg/wekafs/apiclient/requests.go
@@ -205,14 +205,18 @@ func (a *ApiClient) do(ctx context.Context, Method string, Path string, Payload 
 	}
 }
 
-// request wraps do with retries and some more error handling
-func (a *ApiClient) request(ctx context.Context, Method string, Path string, Payload *[]byte, Query url.Values, v interface{}) apiError {
+// request wraps do with retries and some more error handling. It returns the token of the next
+// page when the backend indicates the result was truncated, or an empty string when it was not.
+func (a *ApiClient) request(ctx context.Context, Method string, Path string, Payload *[]byte, Query url.Values, v interface{}) (string, apiError) {
 	op := "ApiClientRequest"
 	ctx, span := otel.Tracer(TracerName).Start(ctx, op)
 	defer span.End()
 	ctx = log.With().Str("span_id", span.SpanContext().SpanID().String()).Logger().WithContext(ctx)
 	logger := log.Ctx(ctx)
+	var nextToken string
 	f := func() apiError {
+		// Reset per attempt: a retry must not inherit the token of an attempt that later failed.
+		nextToken = ""
 		rawResponse, reqErr := a.do(ctx, Method, Path, Payload, Query)
 		if a.handleTransientErrors(ctx, reqErr) != nil { // transient network errors
 			a.rotateEndpoint(ctx)
@@ -241,6 +245,7 @@ func (a *ApiClient) request(ctx context.Context, Method string, Path string, Pay
 		}
 		switch s {
 		case http.StatusOK:
+			nextToken = rawResponse.NextToken
 			return nil
 		case http.StatusUnauthorized:
 			logger.Warn().Msg("Got Authorization failure on request, trying to re-login")
@@ -260,22 +265,72 @@ func (a *ApiClient) request(ctx context.Context, Method string, Path string, Pay
 	}
 	err := a.retryBackoff(ctx, ApiRetryMaxCount, time.Second*time.Duration(ApiRetryIntervalSeconds), f)
 	if err != nil {
-		return err.(apiError)
+		return "", err.(apiError)
 	}
-	return nil
+	return nextToken, nil
 }
 
-// Request makes sure that client is logged in and has a non-expired token
+// Request makes sure that client is logged in and has a non-expired token.
+//
+// When Response implements ApiObjectResponse the backend may return it across several pages, and
+// every page is fetched and folded into Response before returning.
 func (a *ApiClient) Request(ctx context.Context, Method string, Path string, Payload *[]byte, Query url.Values, Response interface{}) error {
 	if err := a.Init(ctx); err != nil {
 		log.Ctx(ctx).Error().Err(err).Msg("Failed to re-authenticate on repeating request")
 		return err
 	}
-	err := a.request(ctx, Method, Path, Payload, Query, Response)
-	if err != nil {
-		return err
+
+	accumulated, paginated := Response.(ApiObjectResponse)
+	if !paginated {
+		_, err := a.request(ctx, Method, Path, Payload, Query, Response)
+		if err != nil {
+			return err
+		}
+		return nil
 	}
-	return nil
+
+	responseType := reflect.TypeOf(Response)
+	if responseType.Kind() != reflect.Ptr {
+		return errors.New("a paginated response must be passed as a pointer")
+	}
+	// Work on a copy: Query belongs to the caller, and it is legitimately nil, which Set would
+	// panic on.
+	query := cloneQuery(Query)
+	logger := log.Ctx(ctx)
+
+	for page := 1; ; page++ {
+		// Every page is unmarshalled into a fresh object and then folded into the caller's
+		// Response. Unmarshalling straight into Response would let each page overwrite the last.
+		pageValue := reflect.New(responseType.Elem()).Interface()
+		nextToken, err := a.request(ctx, Method, Path, Payload, query, pageValue)
+		if err != nil {
+			return err
+		}
+		if err := accumulated.CombinePartialResponse(pageValue.(ApiObjectResponse)); err != nil {
+			logger.Error().Err(err).Msg("Failed to combine a partial response")
+			return err
+		}
+		if nextToken == "" {
+			if page > 1 {
+				logger.Debug().Int("pages", page).Msg("Fetched a paginated response")
+			}
+			return nil
+		}
+		if page >= ApiMaxPagesPerRequest {
+			return fmt.Errorf("paginated response exceeded %d pages, giving up", ApiMaxPagesPerRequest)
+		}
+		query.Set("next_token", nextToken)
+	}
+}
+
+// cloneQuery copies the caller's query parameters so pagination can add its own without mutating
+// what the caller passed, and so a nil map is usable.
+func cloneQuery(q url.Values) url.Values {
+	out := make(url.Values, len(q))
+	for k, v := range q {
+		out[k] = append([]string(nil), v...)
+	}
+	return out
 }
 
 // Get is shortcut for Request("GET" ...)

--- a/pkg/wekafs/apiclient/requests.go
+++ b/pkg/wekafs/apiclient/requests.go
@@ -239,17 +239,23 @@ func (a *ApiClient) request(ctx context.Context, Method string, Path string, Pay
 				apiError: reqErr,
 			}
 		}
-		unmarshalErr := json.Unmarshal(rawResponse.Data, v)
-		if unmarshalErr != nil {
-			logger.Error().Err(unmarshalErr).Interface("object_type", reflect.TypeOf(v)).Msg("Failed to marshal JSON request into a valid interface")
+		// An absent data key is not a decode failure. Every DELETE passes &ApiResponse{} and gets
+		// back a body carrying no data at all, and a paginated fetch may legitimately return an
+		// empty page. Unmarshalling nil would fail with "unexpected end of JSON input", so
+		// distinguish "nothing to decode" from "present but malformed" before deciding.
+		var unmarshalErr error
+		if len(rawResponse.Data) > 0 {
+			unmarshalErr = json.Unmarshal(rawResponse.Data, v)
+			if unmarshalErr != nil {
+				logger.Error().Err(unmarshalErr).Interface("object_type", reflect.TypeOf(v)).Msg("Failed to marshal JSON request into a valid interface")
+			}
 		}
 		switch s {
 		case http.StatusOK:
 			if unmarshalErr != nil {
-				// A page whose data fails to decode must not be folded in as an empty page -
-				// that would silently truncate a paginated result. Only the success path can
-				// reach here relying on unmarshalErr; non-200 paths return their own reqErr
-				// below and never look at it.
+				// Data was present but did not decode. Folding it in as an empty page would
+				// silently truncate a paginated result. Only the success path relies on
+				// unmarshalErr; non-200 paths return their own reqErr below.
 				return ApiNonTransientError{apiError: ApiError{
 					Err:         unmarshalErr,
 					Text:        "Failed to unmarshal JSON response body",


### PR DESCRIPTION
### TL;DR
Quota lists are no longer silently truncated when a filesystem has more quotas than fit in one page of results.

### What changed?
- The API client now follows the storage system's pagination and combines all pages into the full result.
- Hardened handling for older clusters without pagination support, and for empty or malformed pages.

### How to test?
1. Query quotas on a filesystem with more quota entries than fit in a single page.
2. Verify the full list is returned, not just the first page.
3. Also covered extensively by automated tests.

### Why make this change?
The client wasn't following the "next page" pointer the storage system returns for long lists, so any sufficiently long list - most noticeably quotas - was silently incomplete.
