### PR TITLE
refactor: replace positional params in `NewApiClient` with `ApiClientOptions` struct

### DIFF
--- a/pkg/wekafs/apiclient/apiclient.go
+++ b/pkg/wekafs/apiclient/apiclient.go
@@ -60,10 +60,20 @@ type ApiClient struct {
 	containersLock       sync.RWMutex
 }
 
-func NewApiClient(ctx context.Context, credentials Credentials, allowInsecureHttps bool, hostname string) (*ApiClient, error) {
+// ApiClientOptions carries the settings NewApiClient needs beyond the credentials themselves.
+// Grouping them keeps the constructor from growing another positional parameter each time a
+// setting is added.
+type ApiClientOptions struct {
+	// AllowInsecureHttps skips TLS certificate verification.
+	AllowInsecureHttps bool
+	// Hostname identifies this client to the Weka cluster.
+	Hostname string
+}
+
+func NewApiClient(ctx context.Context, credentials Credentials, opts ApiClientOptions) (*ApiClient, error) {
 	logger := log.Ctx(ctx)
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: allowInsecureHttps},
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: opts.AllowInsecureHttps},
 	}
 	useCustomCACert := credentials.CaCertificate != ""
 	if useCustomCACert {
@@ -88,7 +98,7 @@ func NewApiClient(ctx context.Context, credentials Credentials, allowInsecureHtt
 		ClusterGuid:        uuid.UUID{},
 		Credentials:        credentials,
 		CompatibilityMap:   &WekaCompatibilityMap{},
-		hostname:           hostname,
+		hostname:           opts.Hostname,
 		actualApiEndpoints: make(map[string]*ApiEndPoint),
 		NfsInterfaceGroups: make(map[string]*InterfaceGroup),
 	}
@@ -99,7 +109,7 @@ func NewApiClient(ctx context.Context, credentials Credentials, allowInsecureHtt
 		}
 	}
 
-	logger.Trace().Bool("insecure_skip_verify", allowInsecureHttps).Bool("custom_ca_cert", useCustomCACert).Msg("Creating new API client")
+	logger.Trace().Bool("insecure_skip_verify", opts.AllowInsecureHttps).Bool("custom_ca_cert", useCustomCACert).Msg("Creating new API client")
 	a.clientHash = a.generateHash()
 	return a, nil
 }

--- a/pkg/wekafs/apiclient/apiclient_test.go
+++ b/pkg/wekafs/apiclient/apiclient_test.go
@@ -175,7 +175,10 @@ func GetApiClientForTest(t *testing.T) *ApiClient {
 	endpoints := strings.Split(endpoint, ",")
 	creds.Endpoints = endpoints
 	if client == nil {
-		apiClient, err := NewApiClient(context.Background(), creds, true, endpoint)
+		apiClient, err := NewApiClient(context.Background(), creds, ApiClientOptions{
+			AllowInsecureHttps: true,
+			Hostname:           endpoint,
+		})
 		if err != nil {
 			t.Fatalf("Failed to create API client: %v", err)
 		}

--- a/pkg/wekafs/apiclient/pagination_test.go
+++ b/pkg/wekafs/apiclient/pagination_test.go
@@ -43,7 +43,7 @@ func testClient(t *testing.T, srv *httptest.Server) *ApiClient {
 	c, err := NewApiClient(t.Context(), Credentials{
 		Username: "u", Password: "p", Organization: "Root",
 		Endpoints: []string{u.Host}, HttpScheme: "http",
-	}, true, "test")
+	}, ApiClientOptions{AllowInsecureHttps: true, Hostname: "test"})
 	if err != nil {
 		t.Fatalf("client: %v", err)
 	}

--- a/pkg/wekafs/apistore.go
+++ b/pkg/wekafs/apistore.go
@@ -158,7 +158,10 @@ func (api *ApiStore) fromCredentials(ctx context.Context, credentials apiclient.
 	logger := log.Ctx(ctx)
 	logger.Trace().Str("api_client", credentials.String()).Msg("Creating new Weka API client")
 	// doing this to fetch a client hash
-	newClient, err := apiclient.NewApiClient(ctx, credentials, api.config.allowInsecureHttps, hostname)
+	newClient, err := apiclient.NewApiClient(ctx, credentials, apiclient.ApiClientOptions{
+		AllowInsecureHttps: api.config.allowInsecureHttps,
+		Hostname:           hostname,
+	})
 	if err != nil {
 		return nil, errors.New("could not create API client object from supplied params")
 	}

--- a/pkg/wekafs/gc_test.go
+++ b/pkg/wekafs/gc_test.go
@@ -15,7 +15,7 @@ func testApiClient(t *testing.T, org string) *apiclient.ApiClient {
 		Organization: org,
 		Endpoints:    []string{"10.0.0.1:14000"},
 		HttpScheme:   "https",
-	}, true, "test-host")
+	}, apiclient.ApiClientOptions{AllowInsecureHttps: true, Hostname: "test-host"})
 	if err != nil {
 		t.Fatalf("could not build api client for %s: %v", org, err)
 	}

--- a/pkg/wekafs/volume_test.go
+++ b/pkg/wekafs/volume_test.go
@@ -80,7 +80,10 @@ func TestMain(m *testing.M) {
 func GetApiClientForTest(t *testing.T) *apiclient.ApiClient {
 	creds.Endpoints = []string{endpoint}
 	if client == nil {
-		apiClient, err := apiclient.NewApiClient(context.Background(), creds, true, endpoint)
+		apiClient, err := apiclient.NewApiClient(context.Background(), creds, apiclient.ApiClientOptions{
+			AllowInsecureHttps: true,
+			Hostname:           endpoint,
+		})
 		if err != nil {
 			t.Fatalf("Failed to create API client: %v", err)
 		}


### PR DESCRIPTION
### TL;DR
No user-visible change; this is internal cleanup of how the storage API client is constructed.

### What changed?
- Reorganized how the driver's connection to the storage system is set up internally.
- No behavior differs for operators or users.

### How to test?
1. Not applicable - no observable behavior change.
2. Existing automated tests continue to pass.

### Why make this change?
Prepares the code for upcoming settings on this connection so they can be added cleanly instead of accumulating as unrelated parameters.
