### PR TITLE
feat: add TTL-based filesystem name cache to API client

### DIFF
--- a/pkg/wekafs/apiclient/apiclient.go
+++ b/pkg/wekafs/apiclient/apiclient.go
@@ -58,6 +58,11 @@ type ApiClient struct {
 	containers           *ContainersResponse
 	containersUpdateTime time.Time
 	containersLock       sync.RWMutex
+
+	// fsCache memoises filesystem lookups by name. Callers choose how stale an answer they will
+	// accept, so a caller needing certainty can still bypass it via GetFileSystemByName.
+	fsCache   map[string]*fsCacheEntry
+	fsCacheMu sync.RWMutex
 }
 
 // ApiClientOptions carries the settings NewApiClient needs beyond the credentials themselves.
@@ -110,6 +115,7 @@ func NewApiClient(ctx context.Context, credentials Credentials, opts ApiClientOp
 	}
 
 	logger.Trace().Bool("insecure_skip_verify", opts.AllowInsecureHttps).Bool("custom_ca_cert", useCustomCACert).Msg("Creating new API client")
+	a.fsCache = make(map[string]*fsCacheEntry)
 	a.clientHash = a.generateHash()
 	return a, nil
 }

--- a/pkg/wekafs/apiclient/filesystem.go
+++ b/pkg/wekafs/apiclient/filesystem.go
@@ -135,6 +135,85 @@ func (a *ApiClient) GetFileSystemByName(ctx context.Context, name string) (*File
 	return a.GetFileSystemByFilter(ctx, query)
 }
 
+type fsCacheEntry struct {
+	fs        *FileSystem
+	timestamp time.Time
+}
+
+// FileSystems is a paginated list of filesystems.
+type FileSystems []FileSystem
+
+func (f *FileSystems) CombinePartialResponse(page ApiObjectResponse) error {
+	partial, ok := page.(*FileSystems)
+	if !ok {
+		return fmt.Errorf("cannot combine a %T into a filesystem list", page)
+	}
+	*f = append(*f, *partial...)
+	return nil
+}
+
+// CachedGetFileSystemByName returns a filesystem by name, reusing a previously fetched copy when it
+// is younger than acceptedTtl.
+//
+// On a miss it fetches the whole filesystem list and caches all of it, because callers that ask for
+// one filesystem by name generally go on to ask for others - one list is far cheaper than a lookup
+// per name. Callers that must not see a stale answer should use GetFileSystemByName instead.
+func (a *ApiClient) CachedGetFileSystemByName(ctx context.Context, name string, acceptedTtl time.Duration) (*FileSystem, error) {
+	if fs, ok := a.cachedFileSystem(name, acceptedTtl); ok {
+		return fs, nil
+	}
+
+	// Deliberately fetched without holding the lock. Holding it across the request would serialise
+	// every filesystem lookup on this client behind one network round trip. Concurrent callers may
+	// each fetch once; they converge on the same result and only the cache write is serialised.
+	fsList := &FileSystems{}
+	if err := a.FindFileSystemsByFilter(ctx, &FileSystem{}, (*[]FileSystem)(fsList)); err != nil {
+		return nil, err
+	}
+	a.cacheFileSystems(*fsList)
+
+	// Accept whatever that listing produced regardless of acceptedTtl: it was just fetched, and
+	// re-applying the TTL here would make a caller asking for zero staleness fall through to a
+	// second, redundant request.
+	a.fsCacheMu.RLock()
+	entry, found := a.fsCache[name]
+	a.fsCacheMu.RUnlock()
+	if found {
+		return entry.fs, nil
+	}
+
+	// Not present in the listing: fall back to a direct lookup so a filesystem the caller is
+	// allowed to see but the list omitted is still found.
+	fs, err := a.GetFileSystemByName(ctx, name)
+	if err != nil {
+		return nil, err
+	}
+	if fs != nil {
+		a.cacheFileSystems([]FileSystem{*fs})
+	}
+	return fs, nil
+}
+
+func (a *ApiClient) cachedFileSystem(name string, acceptedTtl time.Duration) (*FileSystem, bool) {
+	a.fsCacheMu.RLock()
+	defer a.fsCacheMu.RUnlock()
+	entry, found := a.fsCache[name]
+	if !found || time.Since(entry.timestamp) >= acceptedTtl {
+		return nil, false
+	}
+	return entry.fs, true
+}
+
+func (a *ApiClient) cacheFileSystems(filesystems []FileSystem) {
+	now := time.Now()
+	a.fsCacheMu.Lock()
+	defer a.fsCacheMu.Unlock()
+	for i := range filesystems {
+		fs := filesystems[i]
+		a.fsCache[fs.Name] = &fsCacheEntry{fs: &fs, timestamp: now}
+	}
+}
+
 func (a *ApiClient) CreateFileSystem(ctx context.Context, r *FileSystemCreateRequest, fs *FileSystem) error {
 	op := "CreateFileSystem"
 	ctx, span := otel.Tracer(TracerName).Start(ctx, op)

--- a/pkg/wekafs/apiclient/fscache_test.go
+++ b/pkg/wekafs/apiclient/fscache_test.go
@@ -1,0 +1,125 @@
+package apiclient
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func fsServer(t *testing.T, calls *int32) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "fileSystems") {
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"data": map[string]any{"access_token": "t", "refresh_token": "r", "expires_in": 3600},
+			})
+			return
+		}
+		atomic.AddInt32(calls, 1)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"data": []map[string]any{{"name": "default"}, {"name": "snapvols"}},
+		})
+	}))
+}
+
+func fsTestClient(t *testing.T, srv *httptest.Server) *ApiClient {
+	t.Helper()
+	u, _ := url.Parse(srv.URL)
+	c, err := NewApiClient(t.Context(), Credentials{
+		Username: "u", Password: "p", Organization: "Root",
+		Endpoints: []string{u.Host}, HttpScheme: "http",
+	}, ApiClientOptions{AllowInsecureHttps: true, Hostname: "test"})
+	if err != nil {
+		t.Fatalf("client: %v", err)
+	}
+	c.apiToken = "t"
+	c.CompatibilityMap = &WekaCompatibilityMap{UrlQueryParams: true}
+	return c
+}
+
+func TestCachedGetFileSystemByNameServesFromCache(t *testing.T) {
+	var calls int32
+	srv := fsServer(t, &calls)
+	defer srv.Close()
+	c := fsTestClient(t, srv)
+
+	fs, err := c.CachedGetFileSystemByName(t.Context(), "default", time.Minute)
+	if err != nil || fs == nil || fs.Name != "default" {
+		t.Fatalf("first lookup: fs=%v err=%v", fs, err)
+	}
+	// A second name from the same listing must not cost another request.
+	fs2, err := c.CachedGetFileSystemByName(t.Context(), "snapvols", time.Minute)
+	if err != nil || fs2 == nil || fs2.Name != "snapvols" {
+		t.Fatalf("second lookup: fs=%v err=%v", fs2, err)
+	}
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Fatalf("expected one listing to serve both names, got %d requests", got)
+	}
+}
+
+// Each cached name must keep its own filesystem. Building entries from the address of a loop
+// variable used to alias them all onto the last element.
+func TestCachedFileSystemsAreDistinct(t *testing.T) {
+	var calls int32
+	srv := fsServer(t, &calls)
+	defer srv.Close()
+	c := fsTestClient(t, srv)
+
+	a, _ := c.CachedGetFileSystemByName(t.Context(), "default", time.Minute)
+	b, _ := c.CachedGetFileSystemByName(t.Context(), "snapvols", time.Minute)
+	if a == nil || b == nil || a.Name == b.Name {
+		t.Fatalf("cache entries alias each other: %v / %v", a, b)
+	}
+}
+
+func TestCachedGetFileSystemByNameHonoursTtl(t *testing.T) {
+	var calls int32
+	srv := fsServer(t, &calls)
+	defer srv.Close()
+	c := fsTestClient(t, srv)
+
+	if _, err := c.CachedGetFileSystemByName(t.Context(), "default", time.Minute); err != nil {
+		t.Fatalf("warm: %v", err)
+	}
+	// A zero TTL means nothing cached is acceptable, so this must go back to the API.
+	if _, err := c.CachedGetFileSystemByName(t.Context(), "default", 0); err != nil {
+		t.Fatalf("ttl 0: %v", err)
+	}
+	if got := atomic.LoadInt32(&calls); got != 2 {
+		t.Fatalf("expected a zero TTL to force a refetch, got %d requests", got)
+	}
+}
+
+// The cache is read and written from concurrent request handlers, so its own accessors must be
+// safe. This exercises the cache directly rather than through the client, because ApiClient's
+// endpoint and token state is not yet concurrency-safe - see the endpoint rewrite still to be
+// ported. Run with -race.
+func TestFileSystemCacheAccessorsAreConcurrencySafe(t *testing.T) {
+	c := &ApiClient{fsCache: make(map[string]*fsCacheEntry)}
+	names := []string{"default", "snapvols", "scratch"}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			for j := 0; j < 200; j++ {
+				c.cacheFileSystems([]FileSystem{{Name: names[j%len(names)]}})
+				c.cachedFileSystem(names[(j+1)%len(names)], time.Minute)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	for _, n := range names {
+		if fs, ok := c.cachedFileSystem(n, time.Minute); !ok || fs.Name != n {
+			t.Fatalf("expected %s to be cached under its own name, got %v ok=%v", n, fs, ok)
+		}
+	}
+}


### PR DESCRIPTION
### TL;DR
Filesystem lookups are now cached briefly, cutting repeated calls to the storage system.

### What changed?
- Filesystem lookups reuse a recent result for a short time instead of querying the storage system every time.
- Operations that need guaranteed fresh data are unaffected and always fetch live data.

### How to test?
1. This is an internal performance optimization, verified by automated tests included in this change.
2. Operators may notice fewer repeated filesystem lookup calls to the storage cluster when the same filesystems are used repeatedly.

### Why make this change?
Workloads that resolve many filesystems in quick succession were generating a burst of repeated, identical requests to the storage cluster.
