### PR TITLE
fix: make ApiClient safe for concurrent use, and fix what review found

### DIFF
--- a/pkg/wekafs/apiclient/apiclient.go
+++ b/pkg/wekafs/apiclient/apiclient.go
@@ -51,12 +51,13 @@ type ApiClient struct {
 	CompatibilityMap           *WekaCompatibilityMap
 	clientHash                 uint32
 	hostname                   string
-	NfsInterfaceGroups         map[string]*InterfaceGroup
-	ApiUserRole                ApiUserRole
-	ApiOrgId                   int
-	containerName              string
-	NfsInterfaceGroupName      string
-	NfsClientGroupName         string
+	// nfsInterfaceGroups caches interface groups by name. It carries its own lock - see the type.
+	nfsInterfaceGroups    *interfaceGroups
+	ApiUserRole           ApiUserRole
+	ApiOrgId              int
+	containerName         string
+	NfsInterfaceGroupName string
+	NfsClientGroupName    string
 
 	containers           *ContainersResponse
 	containersUpdateTime time.Time
@@ -107,7 +108,7 @@ func NewApiClient(ctx context.Context, credentials Credentials, opts ApiClientOp
 		CompatibilityMap:   &WekaCompatibilityMap{},
 		hostname:           opts.Hostname,
 		apiEndpoints:       NewApiEndPoints(),
-		NfsInterfaceGroups: make(map[string]*InterfaceGroup),
+		nfsInterfaceGroups: newInterfaceGroups(),
 	}
 	a.resetDefaultEndpoints(ctx)
 	if len(a.Credentials.Endpoints) < 1 {

--- a/pkg/wekafs/apiclient/apiclient.go
+++ b/pkg/wekafs/apiclient/apiclient.go
@@ -122,8 +122,10 @@ func NewApiClient(ctx context.Context, credentials Credentials, opts ApiClientOp
 	return a, nil
 }
 
-// getBaseUrl returns the full HTTP URL of the API endpoint including schema, chosen endpoint and API prefix
-func (a *ApiClient) getBaseUrl(ctx context.Context) string {
+// getBaseUrl returns the full HTTP URL of the API endpoint including schema, chosen endpoint and API
+// prefix. It reports ApiNoEndpointsError, via requireEndpoint, rather than dereferencing a nil
+// endpoint when none is known.
+func (a *ApiClient) getBaseUrl(ctx context.Context) (string, apiError) {
 	scheme := ""
 	switch strings.ToUpper(a.Credentials.HttpScheme) {
 
@@ -134,8 +136,11 @@ func (a *ApiClient) getBaseUrl(ctx context.Context) string {
 	default:
 		scheme = "http"
 	}
-	endpoint := a.getEndpoint(ctx)
-	return fmt.Sprintf("%s://%s:%d/api/v2", scheme, endpoint.IpAddress, endpoint.MgmtPort)
+	endpoint, err := a.requireEndpoint(ctx)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%s://%s:%d/api/v2", scheme, endpoint.IpAddress, endpoint.MgmtPort), nil
 }
 
 // handleTransientErrors checks if the error returned by endpoint is a network error (transient by definition)
@@ -174,9 +179,13 @@ func (a *ApiClient) handleTransientErrors(ctx context.Context, err error) error 
 }
 
 // getUrl returns a URL which consists of baseUrl + path
-func (a *ApiClient) getUrl(ctx context.Context, path string) string {
-	u, _ := url.JoinPath(a.getBaseUrl(ctx), path)
-	return u
+func (a *ApiClient) getUrl(ctx context.Context, path string) (string, apiError) {
+	base, err := a.getBaseUrl(ctx)
+	if err != nil {
+		return "", err
+	}
+	u, _ := url.JoinPath(base, path)
+	return u, nil
 }
 
 // generateHash used for storing multiple clients in hash table. Hash() is created once as connection params might change

--- a/pkg/wekafs/apiclient/apiclient.go
+++ b/pkg/wekafs/apiclient/apiclient.go
@@ -31,14 +31,17 @@ type ApiUserRole string
 // currentEndpointId: refers to the currently working API endpoint
 // Timeout sets max request timeout duration
 type ApiClient struct {
-	sync.Mutex
+	// Guards the mutable state below: Login writes it while concurrent requests read it.
+	sync.RWMutex
+	// loginMu serialises login attempts. Kept separate from RWMutex so a login, which makes several
+	// round-trips, never holds the state lock across I/O.
+	loginMu                    sync.Mutex
 	client                     *http.Client
 	Credentials                Credentials
 	ClusterGuid                uuid.UUID
 	ClusterName                string
 	MountEndpoints             []string
-	actualApiEndpoints         map[string]*ApiEndPoint
-	currentEndpoint            string
+	apiEndpoints               *ApiEndPoints
 	apiToken                   string
 	apiTokenExpiryDate         time.Time
 	refreshToken               string
@@ -93,7 +96,6 @@ func NewApiClient(ctx context.Context, credentials Credentials, opts ApiClientOp
 	}
 
 	a := &ApiClient{
-		Mutex: sync.Mutex{},
 		client: &http.Client{
 			Transport:     tr,
 			CheckRedirect: nil,
@@ -104,7 +106,7 @@ func NewApiClient(ctx context.Context, credentials Credentials, opts ApiClientOp
 		Credentials:        credentials,
 		CompatibilityMap:   &WekaCompatibilityMap{},
 		hostname:           opts.Hostname,
-		actualApiEndpoints: make(map[string]*ApiEndPoint),
+		apiEndpoints:       NewApiEndPoints(),
 		NfsInterfaceGroups: make(map[string]*InterfaceGroup),
 	}
 	a.resetDefaultEndpoints(ctx)

--- a/pkg/wekafs/apiclient/apiclient.go
+++ b/pkg/wekafs/apiclient/apiclient.go
@@ -35,15 +35,21 @@ type ApiClient struct {
 	sync.RWMutex
 	// loginMu serialises login attempts. Kept separate from RWMutex so a login, which makes several
 	// round-trips, never holds the state lock across I/O.
-	loginMu                    sync.Mutex
-	client                     *http.Client
-	Credentials                Credentials
-	ClusterGuid                uuid.UUID
-	ClusterName                string
-	MountEndpoints             []string
-	apiEndpoints               *ApiEndPoints
-	apiToken                   string
-	apiTokenExpiryDate         time.Time
+	loginMu            sync.Mutex
+	client             *http.Client
+	Credentials        Credentials
+	ClusterGuid        uuid.UUID
+	ClusterName        string
+	MountEndpoints     []string
+	apiEndpoints       *ApiEndPoints
+	apiToken           string
+	apiTokenExpiryDate time.Time
+	// loginComplete is true only once a login has published its token *and* finished the post-auth
+	// setup that follows (permission check, cluster info, endpoint discovery). Login clears it the
+	// moment it publishes a new token and sets it only on full success, so a goroutine that was
+	// blocked on loginMu while another goroutine's setup failed observes the failure - via
+	// loginSucceeded - instead of a token that merely exists.
+	loginComplete              bool
 	refreshToken               string
 	apiTokenExpiryInterval     int64
 	refreshTokenExpiryInterval int64

--- a/pkg/wekafs/apiclient/apiclient_race_test.go
+++ b/pkg/wekafs/apiclient/apiclient_race_test.go
@@ -1,0 +1,297 @@
+package apiclient
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/rs/zerolog"
+)
+
+// quietLogs silences the client's per-request trace logging for the duration of a test. These tests
+// issue hundreds of requests, and what is under test is the race detector's verdict, not the output.
+// The level is restored afterwards so other tests in the package are unaffected.
+func quietLogs(t *testing.T) {
+	t.Helper()
+	previous := zerolog.GlobalLevel()
+	zerolog.SetGlobalLevel(zerolog.Disabled)
+	t.Cleanup(func() { zerolog.SetGlobalLevel(previous) })
+}
+
+// This file exercises ApiClient under `go test -race` to catch data races in its concurrency
+// primitives (the RWMutex-guarded auth state, the ApiEndPoints map, and per-endpoint counters).
+// It stands up a fake Weka REST API with httptest and never touches a real cluster or
+// localhost:14000.
+
+// wrapData marshals v and wraps it the way the real Weka API wraps every response: as the "data"
+// field of an envelope. ApiClient's do()/request() unwrap it the same way on the way back in.
+func wrapData(t *testing.T, v interface{}) []byte {
+	t.Helper()
+	inner, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("failed to marshal test fixture: %v", err)
+	}
+	out, err := json.Marshal(struct {
+		Data json.RawMessage `json:"data"`
+	}{Data: inner})
+	if err != nil {
+		t.Fatalf("failed to marshal test envelope: %v", err)
+	}
+	return out
+}
+
+// newRaceTestServer stands up an httptest server that emulates just enough of the Weka REST API
+// for ApiClient to log in, refresh tokens, and rediscover its management endpoints repeatedly.
+//
+// The /api/v2/nodes handler (backing UpdateApiEndpoints) returns a different set of management
+// endpoints on every call, driven by an atomic counter, while keeping every reported IP a
+// genuinely reachable alias of this same server ("127.0.0.1" and "localhost" both resolve to the
+// loopback address httptest.NewServer listens on). That means ApiClient keeps working across
+// repeated logins while its internal endpoint map is genuinely replaced each time - the condition
+// that would surface a "concurrent map read and map write" race.
+func newRaceTestServer(t *testing.T) (hostPort string, mgmtPort int) {
+	t.Helper()
+	var endpointGen int32
+
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/api/v2/login", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(wrapData(t, LoginResponse{
+			AccessToken:  "access-token",
+			TokenType:    "bearer",
+			ExpiresIn:    3600,
+			RefreshToken: "refresh-token",
+		}))
+	})
+
+	mux.HandleFunc("/api/v2/login/refresh", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(wrapData(t, RefreshResponse{
+			AccessToken:  "access-token-2",
+			TokenType:    "bearer",
+			ExpiresIn:    3600,
+			RefreshToken: "refresh-token-2",
+		}))
+	})
+
+	mux.HandleFunc("/api/v2/security/defaultTokensExpiry", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(wrapData(t, TokenExpiryResponse{
+			AccessTokenExpiry:  3600,
+			RefreshTokenExpiry: 86400,
+		}))
+	})
+
+	mux.HandleFunc("/api/v2/cluster", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(wrapData(t, ClusterInfoResponse{
+			Name:    "race-test-cluster",
+			Release: "4.2.0",
+			Guid:    uuid.New(),
+			Capacity: Capacity{
+				TotalBytes:         1 << 40,
+				UnprovisionedBytes: 1 << 39,
+			},
+		}))
+	})
+
+	mux.HandleFunc("/api/v2/users/whoami", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		// Role must satisfy HasCSIPermissions(), or Login() fails permission checks.
+		_, _ = w.Write(wrapData(t, WhoamiResponse{
+			OrgId:    1,
+			Username: "admin",
+			Source:   "local",
+			Uid:      uuid.New(),
+			Role:     ApiUserRoleClusterAdmin,
+			OrgName:  "Root",
+		}))
+	})
+
+	// Registered under both paths: the mock cluster reports a version recent enough that
+	// CompatibilityMap.NewNodeApiObjectPath is true, so WekaNode.GetBasePath resolves to
+	// "processes" rather than "nodes".
+	nodesHandler := func(w http.ResponseWriter, r *http.Request) {
+		gen := atomic.AddInt32(&endpointGen, 1)
+		// Both aliases resolve back to the loopback address this httptest server is bound to,
+		// so every combination below stays reachable while genuinely varying the endpoint set.
+		aliases := []string{"127.0.0.1", "localhost"}
+		var ips []string
+		switch gen % 3 {
+		case 0:
+			ips = aliases[:1]
+		case 1:
+			ips = aliases[1:]
+		default:
+			ips = aliases
+		}
+		nodes := make([]WekaNode, 0, len(ips))
+		for _, ip := range ips {
+			nodes = append(nodes, WekaNode{
+				Id:       fmt.Sprintf("Node.%d", gen),
+				Mode:     NodeModeBackend,
+				Uid:      uuid.New(),
+				Hostname: "race-test-node",
+				Ips:      []string{ip},
+				MgmtPort: mgmtPort,
+				Roles:    []string{NodeRoleManagement, NodeRoleBackend},
+				Status:   "UP",
+			})
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(wrapData(t, nodes))
+	}
+	mux.HandleFunc("/api/v2/nodes", nodesHandler)
+	mux.HandleFunc("/api/v2/processes", nodesHandler)
+
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+
+	u, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("failed to parse test server URL: %v", err)
+	}
+	_, portStr, err := net.SplitHostPort(u.Host)
+	if err != nil {
+		t.Fatalf("failed to split test server host/port: %v", err)
+	}
+	mgmtPort, err = strconv.Atoi(portStr)
+	if err != nil {
+		t.Fatalf("failed to parse test server port: %v", err)
+	}
+	hostPort = u.Host
+	return hostPort, mgmtPort
+}
+
+// newRaceTestClient builds an ApiClient pointed at the fake server, with AutoUpdateEndpoints
+// enabled so every successful Login() replaces the internal endpoint map.
+func newRaceTestClient(t *testing.T, serverAddr string) *ApiClient {
+	t.Helper()
+	creds := Credentials{
+		Username:            "admin",
+		Password:            "admin",
+		Organization:        "Root",
+		HttpScheme:          "http",
+		Endpoints:           []string{serverAddr},
+		AutoUpdateEndpoints: true,
+	}
+	c, err := NewApiClient(context.Background(), creds, ApiClientOptions{
+		AllowInsecureHttps: true,
+		Hostname:           "race-test-client",
+	})
+	if err != nil {
+		t.Fatalf("failed to create API client: %v", err)
+	}
+	return c
+}
+
+// TestApiClientConcurrentUse drives Login, Init, plain requests, and reads of exported state
+// concurrently from many goroutines. It is not asserting on API semantics (some errors here are
+// expected, e.g. a request landing on a rotated-away endpoint mid-flight) - its job is to give
+// `go test -race` enough concurrent access to ApiClient's shared state to flag a real race, and to
+// fail if any of that concurrent access panics.
+func TestApiClientConcurrentUse(t *testing.T) {
+	quietLogs(t)
+	serverAddr, _ := newRaceTestServer(t)
+	c := newRaceTestClient(t, serverAddr)
+	ctx := context.Background()
+
+	const goroutines = 30
+	const iterations = 20
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for g := 0; g < goroutines; g++ {
+		go func(id int) {
+			defer wg.Done()
+			defer func() {
+				if r := recover(); r != nil {
+					t.Errorf("goroutine %d panicked: %v", id, r)
+				}
+			}()
+			for i := 0; i < iterations; i++ {
+				switch i % 4 {
+				case 0:
+					if err := c.Login(ctx); err != nil {
+						t.Logf("goroutine %d: Login: %v", id, err)
+					}
+				case 1:
+					if err := c.Init(ctx); err != nil {
+						t.Logf("goroutine %d: Init: %v", id, err)
+					}
+				case 2:
+					resp := &ClusterInfoResponse{}
+					if err := c.Get(ctx, ApiPathClusterInfo, nil, resp); err != nil {
+						t.Logf("goroutine %d: Get: %v", id, err)
+					}
+				default:
+					_ = c.Hash()
+					_ = c.SupportsQuotaDirectoryAsVolume()
+					_ = c.SupportsFilesystemAsVolume()
+					_ = c.SupportsDirectoryAsVolume()
+					_ = c.SupportsMultipleClusters()
+					_ = c.ClusterName
+					_ = c.ApiUserRole
+					_ = c.HasCSIPermissions()
+				}
+			}
+		}(g)
+	}
+	wg.Wait()
+}
+
+// TestApiClientConcurrentEndpointRotation focuses specifically on the endpoint bookkeeping:
+// UpdateApiEndpoints (which replaces the ApiEndPoints map), rotateEndpoint, and getEndpoint. These
+// are unexported, but this test lives in the same package so it can call them directly rather than
+// only reaching them indirectly through Login.
+func TestApiClientConcurrentEndpointRotation(t *testing.T) {
+	quietLogs(t)
+	serverAddr, _ := newRaceTestServer(t)
+	c := newRaceTestClient(t, serverAddr)
+	ctx := context.Background()
+
+	if err := c.Login(ctx); err != nil {
+		t.Fatalf("initial login failed: %v", err)
+	}
+
+	const goroutines = 30
+	const iterations = 20
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for g := 0; g < goroutines; g++ {
+		go func(id int) {
+			defer wg.Done()
+			defer func() {
+				if r := recover(); r != nil {
+					t.Errorf("goroutine %d panicked: %v", id, r)
+				}
+			}()
+			for i := 0; i < iterations; i++ {
+				switch i % 3 {
+				case 0:
+					if err := c.UpdateApiEndpoints(ctx); err != nil {
+						t.Logf("goroutine %d: UpdateApiEndpoints: %v", id, err)
+					}
+				case 1:
+					c.rotateEndpoint(ctx)
+				default:
+					if ep := c.getEndpoint(ctx); ep != nil {
+						_ = ep.String()
+					}
+				}
+			}
+		}(g)
+	}
+	wg.Wait()
+}

--- a/pkg/wekafs/apiclient/apiclient_race_test.go
+++ b/pkg/wekafs/apiclient/apiclient_race_test.go
@@ -34,19 +34,35 @@ func quietLogs(t *testing.T) {
 
 // wrapData marshals v and wraps it the way the real Weka API wraps every response: as the "data"
 // field of an envelope. ApiClient's do()/request() unwrap it the same way on the way back in.
-func wrapData(t *testing.T, v interface{}) []byte {
-	t.Helper()
+func wrapData(v interface{}) ([]byte, error) {
 	inner, err := json.Marshal(v)
 	if err != nil {
-		t.Fatalf("failed to marshal test fixture: %v", err)
+		return nil, fmt.Errorf("failed to marshal test fixture: %w", err)
 	}
 	out, err := json.Marshal(struct {
 		Data json.RawMessage `json:"data"`
 	}{Data: inner})
 	if err != nil {
-		t.Fatalf("failed to marshal test envelope: %v", err)
+		return nil, fmt.Errorf("failed to marshal test envelope: %w", err)
 	}
-	return out
+	return out, nil
+}
+
+// writeJSON wraps v via wrapData and writes it as the HTTP response body. It runs on the handler's
+// own goroutine (mux.HandleFunc), not the test goroutine, so a marshal failure must not call
+// t.Fatalf: that invokes runtime.Goexit on this goroutine, which aborts the response mid-flight and
+// surfaces to the client as an opaque EOF while the test can still report a pass. t.Errorf plus a
+// 500 response instead fails the test and gives the client a real error to react to.
+func writeJSON(t *testing.T, w http.ResponseWriter, v interface{}) {
+	t.Helper()
+	data, err := wrapData(v)
+	if err != nil {
+		t.Errorf("%v", err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(data)
 }
 
 // newRaceTestServer stands up an httptest server that emulates just enough of the Weka REST API
@@ -65,36 +81,32 @@ func newRaceTestServer(t *testing.T) (hostPort string, mgmtPort int) {
 	mux := http.NewServeMux()
 
 	mux.HandleFunc("/api/v2/login", func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write(wrapData(t, LoginResponse{
+		writeJSON(t, w, LoginResponse{
 			AccessToken:  "access-token",
 			TokenType:    "bearer",
 			ExpiresIn:    3600,
 			RefreshToken: "refresh-token",
-		}))
+		})
 	})
 
 	mux.HandleFunc("/api/v2/login/refresh", func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write(wrapData(t, RefreshResponse{
+		writeJSON(t, w, RefreshResponse{
 			AccessToken:  "access-token-2",
 			TokenType:    "bearer",
 			ExpiresIn:    3600,
 			RefreshToken: "refresh-token-2",
-		}))
+		})
 	})
 
 	mux.HandleFunc("/api/v2/security/defaultTokensExpiry", func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write(wrapData(t, TokenExpiryResponse{
+		writeJSON(t, w, TokenExpiryResponse{
 			AccessTokenExpiry:  3600,
 			RefreshTokenExpiry: 86400,
-		}))
+		})
 	})
 
 	mux.HandleFunc("/api/v2/cluster", func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write(wrapData(t, ClusterInfoResponse{
+		writeJSON(t, w, ClusterInfoResponse{
 			Name:    "race-test-cluster",
 			Release: "4.2.0",
 			Guid:    uuid.New(),
@@ -102,20 +114,26 @@ func newRaceTestServer(t *testing.T) (hostPort string, mgmtPort int) {
 				TotalBytes:         1 << 40,
 				UnprovisionedBytes: 1 << 39,
 			},
-		}))
+		})
 	})
 
 	mux.HandleFunc("/api/v2/users/whoami", func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
 		// Role must satisfy HasCSIPermissions(), or Login() fails permission checks.
-		_, _ = w.Write(wrapData(t, WhoamiResponse{
+		writeJSON(t, w, WhoamiResponse{
 			OrgId:    1,
 			Username: "admin",
 			Source:   "local",
 			Uid:      uuid.New(),
 			Role:     ApiUserRoleClusterAdmin,
 			OrgName:  "Root",
-		}))
+		})
+	})
+
+	// Backs GetNfsInterfaceGroup/GetNfsMountIp for TestGetNfsInterfaceGroup_ConcurrentAccess.
+	mux.HandleFunc("/api/v2/interfaceGroups", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(t, w, []InterfaceGroup{
+			{Name: "default", Type: InterfaceGroupTypeNFS, Ips: []string{"127.0.0.1"}},
+		})
 	})
 
 	// Registered under both paths: the mock cluster reports a version recent enough that
@@ -148,8 +166,7 @@ func newRaceTestServer(t *testing.T) (hostPort string, mgmtPort int) {
 				Status:   "UP",
 			})
 		}
-		w.WriteHeader(http.StatusOK)
-		_, _ = w.Write(wrapData(t, nodes))
+		writeJSON(t, w, nodes)
 	}
 	mux.HandleFunc("/api/v2/nodes", nodesHandler)
 	mux.HandleFunc("/api/v2/processes", nodesHandler)
@@ -240,8 +257,8 @@ func TestApiClientConcurrentUse(t *testing.T) {
 					_ = c.SupportsFilesystemAsVolume()
 					_ = c.SupportsDirectoryAsVolume()
 					_ = c.SupportsMultipleClusters()
-					_ = c.ClusterName
-					_ = c.ApiUserRole
+					_ = c.GetClusterName()
+					_ = c.userRole()
 					_ = c.HasCSIPermissions()
 				}
 			}
@@ -289,6 +306,46 @@ func TestApiClientConcurrentEndpointRotation(t *testing.T) {
 					if ep := c.getEndpoint(ctx); ep != nil {
 						_ = ep.String()
 					}
+				}
+			}
+		}(g)
+	}
+	wg.Wait()
+}
+
+// TestGetNfsInterfaceGroup_ConcurrentAccess covers fix 6: nfsInterfaceGroups was a plain map with no
+// lock at all, read from GetNfsInterfaceGroup and written from fetchNfsInterfaceGroup. Two goroutines
+// reaching it with a cold cache - as two simultaneous NFS publishes on a shared per-cluster client
+// would - raced a map write against map reads/writes on other goroutines, which Go turns into an
+// unrecoverable "fatal error: concurrent map read and map write" that recover() cannot catch. This
+// drives many goroutines through GetNfsMountIp (which resolves the "default" interface group) from a
+// cold cache simultaneously; -race must report nothing, and the process must not crash.
+func TestGetNfsInterfaceGroup_ConcurrentAccess(t *testing.T) {
+	quietLogs(t)
+	serverAddr, _ := newRaceTestServer(t)
+	c := newRaceTestClient(t, serverAddr)
+	ctx := context.Background()
+
+	if err := c.Login(ctx); err != nil {
+		t.Fatalf("initial login failed: %v", err)
+	}
+
+	const goroutines = 30
+	const iterations = 20
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for g := 0; g < goroutines; g++ {
+		go func(id int) {
+			defer wg.Done()
+			defer func() {
+				if r := recover(); r != nil {
+					t.Errorf("goroutine %d panicked: %v", id, r)
+				}
+			}()
+			for i := 0; i < iterations; i++ {
+				if _, err := c.GetNfsMountIp(ctx); err != nil {
+					t.Logf("goroutine %d: GetNfsMountIp: %v", id, err)
 				}
 			}
 		}(g)

--- a/pkg/wekafs/apiclient/apiendpoint.go
+++ b/pkg/wekafs/apiclient/apiendpoint.go
@@ -5,37 +5,137 @@ import (
 	"errors"
 	"fmt"
 	"math/rand"
-	"reflect"
 	"strconv"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/rs/zerolog/log"
 )
 
+// ApiEndPoint describes a single management endpoint and accumulates per-endpoint request stats.
+//
+// The counters are atomic because every concurrent request increments them on whichever endpoint is
+// currently selected, and they are shared, not copied: an ApiEndPoint must always be passed by
+// pointer.
 type ApiEndPoint struct {
-	IpAddress            string
-	MgmtPort             int
+	IpAddress string
+	MgmtPort  int
+	// lastActive records when the endpoint was first discovered. It is set at construction and never
+	// mutated afterwards, so a rediscovered endpoint keeps its original object and its stats.
 	lastActive           time.Time
-	failCount            int64
-	timeoutCount         int64
-	http400ErrCount      int64
-	http401ErrCount      int64
-	http403ErrCount      int64
-	http404ErrCount      int64
-	http409ErrCount      int64
-	http500ErrCount      int64
-	http503ErrCount      int64
-	generalErrCount      int64
-	transportErrCount    int64
-	noRespCount          int64
-	parseErrCount        int64
-	requestCount         int64
-	requestDurationTotal time.Duration
+	failCount            atomic.Int64
+	timeoutCount         atomic.Int64
+	http400ErrCount      atomic.Int64
+	http401ErrCount      atomic.Int64
+	http403ErrCount      atomic.Int64
+	http404ErrCount      atomic.Int64
+	http409ErrCount      atomic.Int64
+	http500ErrCount      atomic.Int64
+	http503ErrCount      atomic.Int64
+	generalErrCount      atomic.Int64
+	transportErrCount    atomic.Int64
+	noRespCount          atomic.Int64
+	parseErrCount        atomic.Int64
+	requestCount         atomic.Int64
+	requestDurationTotal atomic.Int64 // nanoseconds
 }
 
 func (e *ApiEndPoint) String() string {
 	return fmt.Sprintf("%s:%d", e.IpAddress, e.MgmtPort)
+}
+
+// ApiEndPoints holds the API endpoints known for a cluster and the one currently in use.
+//
+// Both are read on every request and replaced whenever the cluster's management addresses are
+// refetched, which happens during login while other requests are in flight - so the state lives
+// behind a lock rather than as loose fields on ApiClient.
+type ApiEndPoints struct {
+	sync.RWMutex
+	currentEndpoint *ApiEndPoint
+	endpoints       map[string]*ApiEndPoint
+}
+
+func NewApiEndPoints() *ApiEndPoints {
+	return &ApiEndPoints{endpoints: make(map[string]*ApiEndPoint)}
+}
+
+// Replace swaps in a freshly discovered set of endpoints, keeping the current one selected if it
+// still exists so an in-flight rotation is not lost.
+func (eps *ApiEndPoints) Replace(endpoints map[string]*ApiEndPoint) {
+	eps.Lock()
+	defer eps.Unlock()
+	eps.endpoints = endpoints
+	if eps.currentEndpoint != nil {
+		if _, stillThere := endpoints[eps.currentEndpoint.String()]; stillThere {
+			return
+		}
+	}
+	eps.currentEndpoint = nil
+}
+
+// Len reports how many endpoints are known.
+func (eps *ApiEndPoints) Len() int {
+	eps.RLock()
+	defer eps.RUnlock()
+	return len(eps.endpoints)
+}
+
+// Snapshot returns a copy of the endpoint map, so a caller can rebuild the set without holding the
+// lock while another goroutine replaces the map. The ApiEndPoint values are deliberately shared, not
+// copied: carrying the same objects forward is what preserves their accumulated stats, and their
+// counters are atomic precisely so they can be shared.
+func (eps *ApiEndPoints) Snapshot() map[string]*ApiEndPoint {
+	eps.RLock()
+	defer eps.RUnlock()
+	out := make(map[string]*ApiEndPoint, len(eps.endpoints))
+	for k, v := range eps.endpoints {
+		out[k] = v
+	}
+	return out
+}
+
+// Keys returns the endpoint keys as a snapshot. Returning the map itself would let a caller iterate
+// it after the lock is released, while another goroutine replaces it.
+func (eps *ApiEndPoints) Keys() []string {
+	eps.RLock()
+	defer eps.RUnlock()
+	out := make([]string, 0, len(eps.endpoints))
+	for k := range eps.endpoints {
+		out = append(out, k)
+	}
+	return out
+}
+
+// Rotate picks a different endpoint at random. It is a no-op when none are known.
+func (eps *ApiEndPoints) Rotate() {
+	eps.Lock()
+	defer eps.Unlock()
+	if len(eps.endpoints) == 0 {
+		eps.currentEndpoint = nil
+		return
+	}
+	keys := make([]string, 0, len(eps.endpoints))
+	for k := range eps.endpoints {
+		keys = append(keys, k)
+	}
+	eps.currentEndpoint = eps.endpoints[keys[rand.Intn(len(keys))]]
+}
+
+// Current returns the endpoint to use, selecting one if none is chosen yet. It returns nil when no
+// endpoints are known rather than waiting for one to appear.
+func (eps *ApiEndPoints) Current() *ApiEndPoint {
+	eps.RLock()
+	current := eps.currentEndpoint
+	eps.RUnlock()
+	if current != nil {
+		return current
+	}
+	eps.Rotate()
+	eps.RLock()
+	defer eps.RUnlock()
+	return eps.currentEndpoint
 }
 
 func (a *ApiClient) resetDefaultEndpoints(ctx context.Context) {
@@ -65,17 +165,10 @@ func (a *ApiClient) resetDefaultEndpoints(ctx context.Context) {
 			log.Ctx(ctx).Error().Err(err).Str("port", port).Msg("Failed to parse port number, using default")
 			portNum = 14000
 		}
-		endPoint := &ApiEndPoint{
-			IpAddress:            ip,
-			MgmtPort:             portNum,
-			lastActive:           time.Now(),
-			failCount:            0,
-			requestCount:         0,
-			requestDurationTotal: 0,
-		}
+		endPoint := &ApiEndPoint{IpAddress: ip, MgmtPort: portNum, lastActive: time.Now()}
 		actualEndPoints[e] = endPoint
 	}
-	a.actualApiEndpoints = actualEndPoints
+	a.apiEndpoints.Replace(actualEndPoints)
 }
 
 // fetchMountEndpoints used to obtain actual data plane IP addresses
@@ -111,12 +204,7 @@ func (a *ApiClient) UpdateApiEndpoints(ctx context.Context) error {
 	newEndpoints := make(map[string]*ApiEndPoint)
 	updateTime := time.Now()
 
-	// Create a copy of all existing endpoints to swap without locking
-	existingEndpoints := make(map[string]*ApiEndPoint)
-	for k, v := range a.actualApiEndpoints {
-		newEndPoint := *v
-		existingEndpoints[k] = &newEndPoint
-	}
+	existingEndpoints := a.apiEndpoints.Snapshot()
 
 	for _, n := range *nodes {
 		// Make sure that only backends and not clients are added to the list
@@ -126,25 +214,24 @@ func (a *ApiClient) UpdateApiEndpoints(ctx context.Context) error {
 				existingEndpoint, ok := existingEndpoints[endpointKey]
 				if ok {
 					logger.Debug().Str("endpoint", endpointKey).Msg("Updating existing API endpoint")
-					existingEndpoint.lastActive = updateTime
 					newEndpoints[endpointKey] = existingEndpoint
 				} else {
 					logger.Info().Str("endpoint", endpointKey).Msg("Adding new API endpoint")
-					endpoint := &ApiEndPoint{IpAddress: IpAddress, MgmtPort: n.MgmtPort, lastActive: updateTime, failCount: 0, requestCount: 0, requestDurationTotal: 0}
+					endpoint := &ApiEndPoint{IpAddress: IpAddress, MgmtPort: n.MgmtPort, lastActive: updateTime}
 					newEndpoints[endpointKey] = endpoint
 				}
 			}
 		}
 	}
-	// prune endpoints which are not active anymore (not existing on cluster)
-	for _, endpoint := range existingEndpoints {
-		if endpoint.lastActive.Before(updateTime) {
-			logger.Warn().Time("endpoint_last_active_time", endpoint.lastActive).Str("endpoint", endpoint.String()).Msg("Removing inactive API endpoint")
-			delete(newEndpoints, endpoint.String())
+	// Endpoints no longer present on the cluster are dropped simply by not being carried over:
+	// newEndpoints is built from what discovery just returned, so anything missing from it is gone.
+	for key := range existingEndpoints {
+		if _, stillPresent := newEndpoints[key]; !stillPresent {
+			logger.Warn().Str("endpoint", key).Msg("Removing inactive API endpoint")
 		}
 	}
 
-	a.actualApiEndpoints = newEndpoints
+	a.apiEndpoints.Replace(newEndpoints)
 
 	// always rotate endpoint to make sure we distribute load between different Weka Nodes
 	a.rotateEndpoint(ctx)
@@ -154,24 +241,23 @@ func (a *ApiClient) UpdateApiEndpoints(ctx context.Context) error {
 // rotateEndpoint returns a random endpoint of the configured ones
 func (a *ApiClient) rotateEndpoint(ctx context.Context) {
 	logger := log.Ctx(ctx)
-	if len(a.actualApiEndpoints) == 0 || a.actualApiEndpoints == nil {
+	if a.apiEndpoints.Len() == 0 {
 		a.resetDefaultEndpoints(ctx)
 	}
-	if len(a.actualApiEndpoints) == 0 {
-		a.currentEndpoint = ""
+	a.apiEndpoints.Rotate()
+	current := a.apiEndpoints.Current()
+	if current == nil {
 		logger.Error().Msg("Failed to choose random endpoint, no endpoints exist")
 		return
 	}
-	keys := reflect.ValueOf(a.actualApiEndpoints).MapKeys()
-	key := keys[rand.Intn(len(keys))].String()
-	logger.Debug().Str("new_endpoint", key).Str("previous_endpoint", a.currentEndpoint).Msg("Switched to new API endpoint")
-	a.currentEndpoint = key
+	logger.Debug().Str("new_endpoint", current.String()).Msg("Switched to new API endpoint")
 }
 
 // getEndpoint returns last known endpoint to work against
 func (a *ApiClient) getEndpoint(ctx context.Context) *ApiEndPoint {
-	if a.currentEndpoint == "" {
-		a.rotateEndpoint(ctx)
+	if current := a.apiEndpoints.Current(); current != nil {
+		return current
 	}
-	return a.actualApiEndpoints[a.currentEndpoint]
+	a.resetDefaultEndpoints(ctx)
+	return a.apiEndpoints.Current()
 }

--- a/pkg/wekafs/apiclient/apiendpoint.go
+++ b/pkg/wekafs/apiclient/apiendpoint.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
-	"time"
 
 	"github.com/rs/zerolog/log"
 )
@@ -20,11 +19,8 @@ import (
 // currently selected, and they are shared, not copied: an ApiEndPoint must always be passed by
 // pointer.
 type ApiEndPoint struct {
-	IpAddress string
-	MgmtPort  int
-	// lastActive records when the endpoint was first discovered. It is set at construction and never
-	// mutated afterwards, so a rediscovered endpoint keeps its original object and its stats.
-	lastActive           time.Time
+	IpAddress            string
+	MgmtPort             int
 	failCount            atomic.Int64
 	timeoutCount         atomic.Int64
 	http400ErrCount      atomic.Int64
@@ -108,19 +104,35 @@ func (eps *ApiEndPoints) Keys() []string {
 	return out
 }
 
-// Rotate picks a different endpoint at random. It is a no-op when none are known.
-func (eps *ApiEndPoints) Rotate() {
+// Rotate picks a different endpoint at random, excluding the current selection whenever more than
+// one endpoint is known - callers rotate specifically to move off an endpoint that just failed, so
+// re-selecting it defeats the purpose. It returns the endpoint it picked, or nil when none are
+// known, so a caller that rotates to escape a failure doesn't have to re-read the selection
+// afterwards (and risk logging one it never actually chose).
+func (eps *ApiEndPoints) Rotate() *ApiEndPoint {
 	eps.Lock()
 	defer eps.Unlock()
 	if len(eps.endpoints) == 0 {
 		eps.currentEndpoint = nil
-		return
+		return nil
 	}
 	keys := make([]string, 0, len(eps.endpoints))
-	for k := range eps.endpoints {
+	for k, v := range eps.endpoints {
+		if v == eps.currentEndpoint {
+			continue
+		}
 		keys = append(keys, k)
 	}
+	if len(keys) == 0 {
+		// Either there is only one endpoint, or (defensively) every entry aliases the current
+		// pointer. Either way, fall back to the full set rather than the current-exclusion leaving
+		// nothing to pick from.
+		for k := range eps.endpoints {
+			keys = append(keys, k)
+		}
+	}
 	eps.currentEndpoint = eps.endpoints[keys[rand.Intn(len(keys))]]
+	return eps.currentEndpoint
 }
 
 // Current returns the endpoint to use, selecting one if none is chosen yet. It returns nil when no
@@ -132,10 +144,7 @@ func (eps *ApiEndPoints) Current() *ApiEndPoint {
 	if current != nil {
 		return current
 	}
-	eps.Rotate()
-	eps.RLock()
-	defer eps.RUnlock()
-	return eps.currentEndpoint
+	return eps.Rotate()
 }
 
 func (a *ApiClient) resetDefaultEndpoints(ctx context.Context) {
@@ -165,8 +174,13 @@ func (a *ApiClient) resetDefaultEndpoints(ctx context.Context) {
 			log.Ctx(ctx).Error().Err(err).Str("port", port).Msg("Failed to parse port number, using default")
 			portNum = 14000
 		}
-		endPoint := &ApiEndPoint{IpAddress: ip, MgmtPort: portNum, lastActive: time.Now()}
-		actualEndPoints[e] = endPoint
+		endPoint := &ApiEndPoint{IpAddress: ip, MgmtPort: portNum}
+		// Key by the same "ip:port" form ApiEndPoint.String() and UpdateApiEndpoints use, not the
+		// raw credential string: the raw string may carry no port (or a hostname alias) and would
+		// then never match eps.currentEndpoint.String() in Replace, nor existingEndpoints[key] in
+		// UpdateApiEndpoints - silently dropping the current selection and the accumulated counters
+		// on every reset.
+		actualEndPoints[endPoint.String()] = endPoint
 	}
 	a.apiEndpoints.Replace(actualEndPoints)
 }
@@ -202,7 +216,6 @@ func (a *ApiClient) UpdateApiEndpoints(ctx context.Context) error {
 	}
 
 	newEndpoints := make(map[string]*ApiEndPoint)
-	updateTime := time.Now()
 
 	existingEndpoints := a.apiEndpoints.Snapshot()
 
@@ -217,7 +230,7 @@ func (a *ApiClient) UpdateApiEndpoints(ctx context.Context) error {
 					newEndpoints[endpointKey] = existingEndpoint
 				} else {
 					logger.Info().Str("endpoint", endpointKey).Msg("Adding new API endpoint")
-					endpoint := &ApiEndPoint{IpAddress: IpAddress, MgmtPort: n.MgmtPort, lastActive: updateTime}
+					endpoint := &ApiEndPoint{IpAddress: IpAddress, MgmtPort: n.MgmtPort}
 					newEndpoints[endpointKey] = endpoint
 				}
 			}
@@ -238,14 +251,13 @@ func (a *ApiClient) UpdateApiEndpoints(ctx context.Context) error {
 	return nil
 }
 
-// rotateEndpoint returns a random endpoint of the configured ones
+// rotateEndpoint switches to a random endpoint other than the one currently in use.
 func (a *ApiClient) rotateEndpoint(ctx context.Context) {
 	logger := log.Ctx(ctx)
 	if a.apiEndpoints.Len() == 0 {
 		a.resetDefaultEndpoints(ctx)
 	}
-	a.apiEndpoints.Rotate()
-	current := a.apiEndpoints.Current()
+	current := a.apiEndpoints.Rotate()
 	if current == nil {
 		logger.Error().Msg("Failed to choose random endpoint, no endpoints exist")
 		return
@@ -253,11 +265,26 @@ func (a *ApiClient) rotateEndpoint(ctx context.Context) {
 	logger.Debug().Str("new_endpoint", current.String()).Msg("Switched to new API endpoint")
 }
 
-// getEndpoint returns last known endpoint to work against
+// getEndpoint returns last known endpoint to work against. It returns nil when the credentials
+// contain no endpoint that survived validation in resetDefaultEndpoints - callers that would
+// otherwise dereference the result directly should go through requireEndpoint instead.
 func (a *ApiClient) getEndpoint(ctx context.Context) *ApiEndPoint {
 	if current := a.apiEndpoints.Current(); current != nil {
 		return current
 	}
 	a.resetDefaultEndpoints(ctx)
 	return a.apiEndpoints.Current()
+}
+
+// requireEndpoint returns the endpoint to use, or ApiNoEndpointsError when none is known.
+// NewApiClient only rejects a raw endpoint list with zero entries; a secret whose entries all fail
+// isValidIPv4Address/isValidIPv6Address/isValidHostname still constructs a client, just with an
+// empty endpoint map, and getEndpoint reports that with nil rather than blocking for one to appear.
+// Every caller that would otherwise dereference getEndpoint's result directly must go through this.
+func (a *ApiClient) requireEndpoint(ctx context.Context) (*ApiEndPoint, apiError) {
+	endpoint := a.getEndpoint(ctx)
+	if endpoint == nil {
+		return nil, &ApiNoEndpointsError{Err: errors.New("no endpoints could be found for API client")}
+	}
+	return endpoint, nil
 }

--- a/pkg/wekafs/apiclient/apiendpoint_test.go
+++ b/pkg/wekafs/apiclient/apiendpoint_test.go
@@ -1,0 +1,177 @@
+package apiclient
+
+import (
+	"context"
+	"testing"
+)
+
+// TestResetDefaultEndpoints_KeysMatchEndpointString covers fix 2: resetDefaultEndpoints used to key
+// its map by the raw credential string (which may carry no port), while Replace tests the current
+// selection's membership with ApiEndPoint.String() ("ip:port"), and UpdateApiEndpoints looks up
+// existing endpoints the same way. A raw endpoint with no explicit port is the case that most
+// visibly breaks: its raw key ("127.0.0.1") never matches its own String() ("127.0.0.1:14000").
+func TestResetDefaultEndpoints_KeysMatchEndpointString(t *testing.T) {
+	a := &ApiClient{
+		Credentials:  Credentials{Endpoints: []string{"127.0.0.1"}},
+		apiEndpoints: NewApiEndPoints(),
+	}
+	a.resetDefaultEndpoints(context.Background())
+
+	current := a.apiEndpoints.Current()
+	if current == nil {
+		t.Fatal("expected an endpoint to be selected after resetDefaultEndpoints")
+	}
+
+	snapshot := a.apiEndpoints.Snapshot()
+	got, ok := snapshot[current.String()]
+	if !ok {
+		t.Fatalf("endpoint not found under its own String() key %q; map keys: %v", current.String(), keysOf(snapshot))
+	}
+	if got != current {
+		t.Fatalf("expected the endpoint stored under key %q to be the selected endpoint", current.String())
+	}
+}
+
+// TestUpdateApiEndpoints_ReusesDefaultEndpointObject covers the concrete consequence of fix 2:
+// before it, a default endpoint minted by resetDefaultEndpoints (raw-string keyed) could never match
+// existingEndpoints[endpointKey] in UpdateApiEndpoints (ip:port keyed), so rediscovering the very
+// same address produced a brand new *ApiEndPoint and silently dropped its accumulated counters. This
+// exercises the same map lookup UpdateApiEndpoints performs, without needing a live cluster to drive
+// GetNodesByRole.
+func TestUpdateApiEndpoints_ReusesDefaultEndpointObject(t *testing.T) {
+	a := &ApiClient{
+		Credentials:  Credentials{Endpoints: []string{"127.0.0.1"}}, // no explicit port
+		apiEndpoints: NewApiEndPoints(),
+	}
+	a.resetDefaultEndpoints(context.Background())
+
+	defaultEndpoint := a.apiEndpoints.Current()
+	if defaultEndpoint == nil {
+		t.Fatal("expected a default endpoint")
+	}
+	defaultEndpoint.requestCount.Add(7)
+	defaultEndpoint.failCount.Add(3)
+
+	// This mirrors UpdateApiEndpoints's own lookup: a freshly discovered node at the same
+	// "ip:port" the default endpoint already uses should resolve to the very same object.
+	existingEndpoints := a.apiEndpoints.Snapshot()
+	endpointKey := defaultEndpoint.String()
+	existingEndpoint, ok := existingEndpoints[endpointKey]
+	if !ok {
+		t.Fatalf("default endpoint not found under discovery's key format %q; map keys: %v", endpointKey, keysOf(existingEndpoints))
+	}
+	if existingEndpoint != defaultEndpoint {
+		t.Fatalf("expected UpdateApiEndpoints's lookup to reuse the same *ApiEndPoint object")
+	}
+	if existingEndpoint.requestCount.Load() != 7 || existingEndpoint.failCount.Load() != 3 {
+		t.Fatalf("expected accumulated counters to survive, got requestCount=%d failCount=%d",
+			existingEndpoint.requestCount.Load(), existingEndpoint.failCount.Load())
+	}
+}
+
+// TestApiEndPoints_ReplaceKeepsCurrentSelectionAcrossReset covers the other consequence named in fix
+// 2: Replace only preserves the current selection when its String() key is present in the freshly
+// discovered map. Before the fix, a reset that rediscovers the very same address produced a map
+// keyed differently than the current selection expects, so the selection - and the object carrying
+// its stats - was dropped every time.
+func TestApiEndPoints_ReplaceKeepsCurrentSelectionAcrossReset(t *testing.T) {
+	eps := NewApiEndPoints()
+	first := &ApiEndPoint{IpAddress: "127.0.0.1", MgmtPort: 14000}
+	eps.Replace(map[string]*ApiEndPoint{first.String(): first})
+	if got := eps.Rotate(); got != first {
+		t.Fatalf("expected the single known endpoint to be selected, got %v", got)
+	}
+
+	// A later rediscovery of the same address, as both resetDefaultEndpoints and UpdateApiEndpoints
+	// perform it: a brand new map, keyed consistently with ApiEndPoint.String().
+	second := &ApiEndPoint{IpAddress: "127.0.0.1", MgmtPort: 14000}
+	eps.Replace(map[string]*ApiEndPoint{second.String(): second})
+
+	if eps.Current() == nil {
+		t.Fatal("expected the current selection to survive a reset that rediscovers the same address")
+	}
+}
+
+// keysOf returns the keys of an endpoint map for use in test failure messages.
+func keysOf(m map[string]*ApiEndPoint) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
+// TestApiEndPoints_RotateExcludesCurrentEndpoint covers fix 7: Rotate's doc promises a *different*
+// endpoint, but it used to sample uniformly including the current one, so request()'s retry after a
+// transient error - which calls rotateEndpoint specifically to move off a failing node - stayed on
+// the dead endpoint about half the time with two known endpoints. 50 iterations makes a surviving
+// bug's failure probability (0.5^50) indistinguishable from zero.
+func TestApiEndPoints_RotateExcludesCurrentEndpoint(t *testing.T) {
+	eps := NewApiEndPoints()
+	epA := &ApiEndPoint{IpAddress: "10.0.0.1", MgmtPort: 14000}
+	epB := &ApiEndPoint{IpAddress: "10.0.0.2", MgmtPort: 14000}
+	eps.Replace(map[string]*ApiEndPoint{epA.String(): epA, epB.String(): epB})
+	eps.currentEndpoint = epA
+
+	for i := 0; i < 50; i++ {
+		previous := eps.Current()
+		next := eps.Rotate()
+		if next == nil {
+			t.Fatalf("iteration %d: expected a non-nil endpoint", i)
+		}
+		if next == previous {
+			t.Fatalf("iteration %d: Rotate returned the current endpoint; with 2+ endpoints it must always move off it", i)
+		}
+	}
+}
+
+// TestApiEndPoints_RotateSingleEndpointIsStable checks that the fix 7 exclusion logic does not
+// leave Rotate with nothing to pick from when only one endpoint is known.
+func TestApiEndPoints_RotateSingleEndpointIsStable(t *testing.T) {
+	eps := NewApiEndPoints()
+	only := &ApiEndPoint{IpAddress: "10.0.0.1", MgmtPort: 14000}
+	eps.Replace(map[string]*ApiEndPoint{only.String(): only})
+
+	for i := 0; i < 5; i++ {
+		if got := eps.Rotate(); got != only {
+			t.Fatalf("iteration %d: expected the single known endpoint to be selected, got %v", i, got)
+		}
+	}
+}
+
+// TestNewApiClient_AllInvalidEndpoints_ReturnsErrorInsteadOfPanicking covers fix 8. NewApiClient only
+// rejects a raw endpoint list with zero entries; a secret whose entries all fail
+// isValidIPv4Address/isValidIPv6Address/isValidHostname still constructs a client, just with an
+// empty endpoint map. Before the fix, the first request dereferenced that nil endpoint directly in
+// getBaseUrl and in do()'s stats bookkeeping and panicked.
+func TestNewApiClient_AllInvalidEndpoints_ReturnsErrorInsteadOfPanicking(t *testing.T) {
+	quietLogs(t)
+	creds := Credentials{
+		Username:     "admin",
+		Password:     "admin",
+		Organization: "Root",
+		HttpScheme:   "http",
+		Endpoints:    []string{"not a valid host!!"},
+	}
+	c, err := NewApiClient(context.Background(), creds, ApiClientOptions{Hostname: "no-endpoints-test"})
+	if err != nil {
+		t.Fatalf("NewApiClient should succeed here - validation failure only empties the endpoint map, it doesn't reject the raw list: %v", err)
+	}
+
+	var gotErr error
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Fatalf("Get panicked instead of returning an error: %v", r)
+			}
+		}()
+		gotErr = c.Get(context.Background(), "cluster", nil, &ClusterInfoResponse{})
+	}()
+
+	if gotErr == nil {
+		t.Fatal("expected an error when the client has no valid endpoints")
+	}
+	if _, ok := gotErr.(*ApiNoEndpointsError); !ok {
+		t.Fatalf("expected *ApiNoEndpointsError, got %T: %v", gotErr, gotErr)
+	}
+}

--- a/pkg/wekafs/apiclient/cluster.go
+++ b/pkg/wekafs/apiclient/cluster.go
@@ -38,8 +38,10 @@ func (a *ApiClient) updateTokensExpiryInterval(ctx context.Context) error {
 	if err := a.Get(ctx, ApiPathTokenExpiry, nil, responseData); err != nil {
 		return err
 	}
+	a.Lock()
 	a.refreshTokenExpiryInterval = responseData.RefreshTokenExpiry
 	a.apiTokenExpiryInterval = responseData.AccessTokenExpiry
+	a.Unlock()
 	log.Ctx(ctx).Trace().Msg("Updated refresh token validity period")
 	return nil
 }
@@ -50,12 +52,18 @@ func (a *ApiClient) fetchClusterInfo(ctx context.Context) error {
 	if err := a.Get(ctx, ApiPathClusterInfo, nil, responseData); err != nil {
 		return err
 	}
+	clusterVersion := fmt.Sprintf("v%s", responseData.Release)
+	// fillIn mutates in place, so build the map here and publish it by pointer swap: readers take a
+	// fully populated map or the previous one, never a half-filled one.
+	compat := &WekaCompatibilityMap{}
+	compat.fillIn(clusterVersion)
+	a.Lock()
 	a.ClusterName = responseData.Name
 	a.ClusterGuid = responseData.Guid
-	clusterVersion := fmt.Sprintf("v%s", responseData.Release)
-	a.CompatibilityMap.fillIn(clusterVersion)
-	logger := log.Logger.With().Str("cluster_name", a.ClusterName).Logger()
-	logger.Info().Str("cluster_guid", a.ClusterGuid.String()).
+	a.CompatibilityMap = compat
+	a.Unlock()
+	logger := log.Logger.With().Str("cluster_name", responseData.Name).Logger()
+	logger.Info().Str("cluster_guid", responseData.Guid.String()).
 		Str("cluster_version", clusterVersion).Msg("Successfully connected to cluster")
 	logger.Info().Msg(fmt.Sprintf("Cluster compatibility for filesystem as CSI volume: %t", a.SupportsFilesystemAsVolume()))
 	logger.Info().Msg(fmt.Sprintf("Cluster compatibility for quota directory as CSI volume: %t", a.SupportsQuotaDirectoryAsVolume()))
@@ -551,19 +559,22 @@ func (a *ApiClient) fetchUserRoleAndOrgId(ctx context.Context) {
 		return
 	}
 	if ret != nil {
+		a.Lock()
 		a.ApiUserRole = ret.Role
 		a.ApiOrgId = ret.OrgId
+		a.Unlock()
 	}
 }
 
 func (a *ApiClient) ensureSufficientPermissions(ctx context.Context) error {
 	logger := log.Ctx(ctx)
 	a.fetchUserRoleAndOrgId(ctx)
-	if a.ApiUserRole == "" {
+	role := a.userRole()
+	if role == "" {
 		logger.Error().Msg("Could not determine user role, assuming old version of WEKA cluster")
 	}
 	if !a.HasCSIPermissions() {
-		logger.Error().Str("username", a.Credentials.Username).Str("role", string(a.ApiUserRole)).Msg("User does not have necessary CSI permissions and cannot be used. Refer to WEKA CSI Plugin /documentation")
+		logger.Error().Str("username", a.Credentials.Username).Str("role", string(role)).Msg("User does not have necessary CSI permissions and cannot be used. Refer to WEKA CSI Plugin /documentation")
 		return errors.New(fmt.Sprintf("user %s does not have sufficient permissions for performing CSI operations", a.Credentials.Username))
 	}
 	return nil

--- a/pkg/wekafs/apiclient/cluster.go
+++ b/pkg/wekafs/apiclient/cluster.go
@@ -83,6 +83,33 @@ func (a *ApiClient) fetchClusterInfo(ctx context.Context) error {
 	return nil
 }
 
+// GetClusterName returns the cluster name established at the last successful login. Reads go
+// through here, mirroring compatibility()/userRole(), because fetchClusterInfo overwrites the field
+// under the state lock on every re-login while readers outside this package have no lock of their
+// own to take.
+func (a *ApiClient) GetClusterName() string {
+	a.RLock()
+	defer a.RUnlock()
+	return a.ClusterName
+}
+
+// GetClusterGuid returns the cluster GUID established at the last successful login, for the same
+// reason as GetClusterName. Going through the lock also avoids handing back a torn uuid.UUID, which
+// is a plain byte array a concurrent write could update non-atomically.
+func (a *ApiClient) GetClusterGuid() uuid.UUID {
+	a.RLock()
+	defer a.RUnlock()
+	return a.ClusterGuid
+}
+
+// GetApiOrgId returns the organization ID established at the last successful login.
+// fetchUserRoleAndOrgId overwrites it under the state lock on every re-login.
+func (a *ApiClient) GetApiOrgId() int {
+	a.RLock()
+	defer a.RUnlock()
+	return a.ApiOrgId
+}
+
 func (a *ApiClient) GetFreeCapacity(ctx context.Context) (uint64, error) {
 	responseData := &ClusterInfoResponse{}
 	if err := a.Get(ctx, ApiPathClusterInfo, nil, responseData); err != nil {

--- a/pkg/wekafs/apiclient/compatibility.go
+++ b/pkg/wekafs/apiclient/compatibility.go
@@ -127,75 +127,84 @@ func (cm *WekaCompatibilityMap) fillIn(versionStr string) {
 	cm.SetSelfAsFilesystemOwnerOnCreate = v.GreaterThanOrEqual(sfo)
 }
 
+// compatibility returns the compatibility map established at login. Reads go through here because
+// fetchClusterInfo replaces it on every login, concurrently with requests that consult it.
+func (a *ApiClient) compatibility() *WekaCompatibilityMap {
+	a.RLock()
+	defer a.RUnlock()
+	return a.CompatibilityMap
+}
+
 func (a *ApiClient) SupportsQuotaDirectoryAsVolume() bool {
-	return a.CompatibilityMap.QuotaOnDirectoryVolume
+	return a.compatibility().QuotaOnDirectoryVolume
 }
 
 func (a *ApiClient) SupportsQuotaOnSnapshots() bool {
-	return a.CompatibilityMap.QuotaOnSnapshot
+	return a.compatibility().QuotaOnSnapshot
 }
 
 func (a *ApiClient) SupportsFilesystemAsVolume() bool {
-	return a.CompatibilityMap.FilesystemAsCSIVolume
+	return a.compatibility().FilesystemAsCSIVolume
 }
 
 func (a *ApiClient) SupportsDirectoryAsVolume() bool {
-	return a.CompatibilityMap.DirectoryAsCSIVolume
+	return a.compatibility().DirectoryAsCSIVolume
 }
 
 func (a *ApiClient) SupportsAuthenticatedMounts() bool {
-	return a.CompatibilityMap.MountFilesystemsUsingAuthToken
+	return a.compatibility().MountFilesystemsUsingAuthToken
 }
 
 func (a *ApiClient) SupportsFilesystemCloning() bool {
-	return a.CompatibilityMap.CloneFilesystem
+	return a.compatibility().CloneFilesystem
 }
 
 func (a *ApiClient) SupportsNewFileSystemFromSnapshot() bool {
-	return a.CompatibilityMap.CreateNewFilesystemFromSnapshot
+	return a.compatibility().CreateNewFilesystemFromSnapshot
 }
 
 func (a *ApiClient) SupportsUrlQueryParams() bool {
-	return a.CompatibilityMap.UrlQueryParams
+	return a.compatibility().UrlQueryParams
 }
 
 func (a *ApiClient) SupportsSyncOnCloseMountOption() bool {
-	return a.CompatibilityMap.SyncOnCloseMountOption
+	return a.compatibility().SyncOnCloseMountOption
 }
 
 func (a *ApiClient) SupportsMultipleClusters() bool {
-	return a.CompatibilityMap.SingleClientMultipleClusters
+	return a.compatibility().SingleClientMultipleClusters
 }
 
 func (a *ApiClient) SupportsEncryptionWithNoKms() bool {
-	return a.CompatibilityMap.EncryptionWithNoKms
+	return a.compatibility().EncryptionWithNoKms
 }
 
 func (a *ApiClient) SupportsEncryptionWithCommonKey() bool {
-	return a.CompatibilityMap.EncryptionWithClusterKey
+	return a.compatibility().EncryptionWithClusterKey
 }
 
 func (a *ApiClient) SupportsCustomEncryptionSettings() bool {
-	return a.CompatibilityMap.EncryptionWithCustomSettings
+	return a.compatibility().EncryptionWithCustomSettings
 }
 
 func (a *ApiClient) RequiresNewNodePath() bool {
-	return a.CompatibilityMap.NewNodeApiObjectPath
+	return a.compatibility().NewNodeApiObjectPath
 }
 
 func (a *ApiClient) SupportsResolvePathToInode() bool {
-	if !a.CompatibilityMap.ResolvePathToInode {
+	if !a.compatibility().ResolvePathToInode {
 		return false
 	}
-	if a.ApiUserRole == "" {
+	role := a.userRole()
+	if role == "" {
 		return false
 	}
-	if a.ApiUserRole == ApiUserRoleCSI {
-		return a.CompatibilityMap.ResolvePathToInodeCsiRole
+	if role == ApiUserRoleCSI {
+		return a.compatibility().ResolvePathToInodeCsiRole
 	}
 	return true
 }
 
 func (a *ApiClient) SupportsSettingSelfAsFilesystemOwner() bool {
-	return a.CompatibilityMap.SetSelfAsFilesystemOwnerOnCreate
+	return a.compatibility().SetSelfAsFilesystemOwnerOnCreate
 }

--- a/pkg/wekafs/apiclient/interfacegroup.go
+++ b/pkg/wekafs/apiclient/interfacegroup.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"sync"
 
 	"github.com/google/uuid"
 	"github.com/rs/zerolog/log"
@@ -165,11 +166,45 @@ func (a *ApiClient) fetchNfsInterfaceGroup(ctx context.Context, name string) err
 				}
 				return errors.New("no IP addresses found for nfs interface group \"" + name + "\"")
 			}
-			a.NfsInterfaceGroups[igname] = &ig
+			a.nfsInterfaceGroups.set(igname, &ig)
 			return nil
 		}
 	}
 	return errors.New(fmt.Sprintf("no nfs interface group named '%s' found", name))
+}
+
+// interfaceGroups caches NFS interface groups by name. It owns its lock rather than borrowing the
+// ApiClient's, mirroring ApiEndPoints: the cache is filled from fetchNfsInterfaceGroup, which makes
+// an HTTP round trip through Request - and Request takes the client's own lock - so sharing that
+// lock here would deadlock the moment a fetch happened while it was held.
+type interfaceGroups struct {
+	sync.RWMutex
+	groups map[string]*InterfaceGroup
+}
+
+func newInterfaceGroups() *interfaceGroups {
+	return &interfaceGroups{groups: make(map[string]*InterfaceGroup)}
+}
+
+// get returns the cached group for name, if it has been fetched.
+func (i *interfaceGroups) get(name string) (*InterfaceGroup, bool) {
+	i.RLock()
+	defer i.RUnlock()
+	ig, ok := i.groups[name]
+	return ig, ok
+}
+
+// set caches a group under name.
+func (i *interfaceGroups) set(name string, ig *InterfaceGroup) {
+	i.Lock()
+	defer i.Unlock()
+	i.groups[name] = ig
+}
+
+// has reports whether a group is cached under name.
+func (i *interfaceGroups) has(name string) bool {
+	_, ok := i.get(name)
+	return ok
 }
 
 func (a *ApiClient) GetNfsInterfaceGroup(ctx context.Context, name string) *InterfaceGroup {
@@ -177,14 +212,14 @@ func (a *ApiClient) GetNfsInterfaceGroup(ctx context.Context, name string) *Inte
 	if name == "" {
 		igName = "default"
 	}
-	_, ok := a.NfsInterfaceGroups[igName]
+	ig, ok := a.nfsInterfaceGroups.get(igName)
 	if !ok {
-		err := a.fetchNfsInterfaceGroup(ctx, name)
-		if err != nil {
+		if err := a.fetchNfsInterfaceGroup(ctx, name); err != nil {
 			return nil
 		}
+		ig, _ = a.nfsInterfaceGroups.get(igName)
 	}
-	return a.NfsInterfaceGroups[igName]
+	return ig
 }
 
 // GetNfsMountIp returns the IP address of the NFS interface group to be used for NFS mount

--- a/pkg/wekafs/apiclient/interfacegroup_test.go
+++ b/pkg/wekafs/apiclient/interfacegroup_test.go
@@ -14,7 +14,7 @@ func TestGetNfsInterfaceGroup(t *testing.T) {
 	// Test case: Valid interface group
 	ig := apiClient.GetNfsInterfaceGroup(context.Background(), "")
 	assert.NotNil(t, ig)
-	assert.Contains(t, apiClient.NfsInterfaceGroups, "default")
+	assert.True(t, apiClient.nfsInterfaceGroups.has("default"))
 
 	// Test case: Invalid interface group
 	ig = apiClient.GetNfsInterfaceGroup(context.Background(), "NFS")
@@ -23,7 +23,7 @@ func TestGetNfsInterfaceGroup(t *testing.T) {
 	// Test case: Invalid interface group
 	ig = apiClient.GetNfsInterfaceGroup(context.Background(), "Data")
 	assert.NotNil(t, ig)
-	assert.Contains(t, apiClient.NfsInterfaceGroups, "Data")
+	assert.True(t, apiClient.nfsInterfaceGroups.has("Data"))
 
 }
 

--- a/pkg/wekafs/apiclient/login.go
+++ b/pkg/wekafs/apiclient/login.go
@@ -26,7 +26,7 @@ func loginInProgress(ctx context.Context) bool {
 // Login logs into API, updates refresh token expiry
 func (a *ApiClient) Login(ctx context.Context) error {
 	logger := log.Ctx(ctx)
-	if a.isLoggedIn() {
+	if a.loginSucceeded() {
 		return nil
 	}
 	// loginMu serialises login attempts; it is deliberately NOT the lock guarding the client state.
@@ -35,8 +35,12 @@ func (a *ApiClient) Login(ctx context.Context) error {
 	// take the state lock themselves to read the auth token.
 	a.loginMu.Lock()
 	defer a.loginMu.Unlock()
-	// Re-check: another goroutine may have completed a login while we waited for loginMu.
-	if a.isLoggedIn() {
+	// Re-check: another goroutine may have completed a login while we waited for loginMu. This must
+	// test loginSucceeded, not isLoggedIn: isLoggedIn goes true the moment a token is published,
+	// which happens below *before* the post-auth setup (permissions, cluster info, endpoints) that
+	// can still fail. Testing isLoggedIn here would report success for a login that is about to
+	// return an error, leaving every waiter with an all-false CompatibilityMap.
+	if a.loginSucceeded() {
 		return nil
 	}
 	ctx = withLoginInProgress(ctx)
@@ -58,11 +62,13 @@ func (a *ApiClient) Login(ctx context.Context) error {
 		return err
 	}
 	// Publish the token before the calls below, which issue requests of their own and need it to
-	// authenticate.
+	// authenticate. loginComplete is cleared in the same critical section: from this point isLoggedIn
+	// is true but the login is not yet done, and a concurrent caller must not be told otherwise.
 	a.Lock()
 	a.apiToken = responseData.AccessToken
 	a.refreshToken = responseData.RefreshToken
 	a.apiTokenExpiryDate = time.Now().Add(time.Duration(responseData.ExpiresIn-30) * time.Second)
+	a.loginComplete = false
 	needExpiryInterval := a.refreshTokenExpiryInterval < 1
 	a.Unlock()
 
@@ -94,6 +100,12 @@ func (a *ApiClient) Login(ctx context.Context) error {
 	} else {
 		logger.Debug().Str("current_endpoint", a.getEndpoint(ctx).String()).Msg("Auto update of API endpoints is disabled")
 	}
+	// Everything that determines whether the client can actually operate (permissions, cluster info)
+	// has succeeded at this point; a failed UpdateApiEndpoints above was already logged and does not
+	// fail Login, so it must not hold back loginComplete either.
+	a.Lock()
+	a.loginComplete = true
+	a.Unlock()
 	return nil
 }
 
@@ -164,6 +176,17 @@ func (a *ApiClient) isLoggedInLocked() bool {
 		return false
 	}
 	return true
+}
+
+// loginSucceeded reports whether the client is not just holding a token, but finished a login
+// completely: isLoggedIn alone goes true the instant a token is published, before the post-auth
+// setup that follows can still fail. Login's own re-check under loginMu, and its opportunistic
+// check before taking loginMu at all, both need this rather than isLoggedIn - otherwise a goroutine
+// racing a login whose setup is still in flight (or has already failed) is told it succeeded.
+func (a *ApiClient) loginSucceeded() bool {
+	a.RLock()
+	defer a.RUnlock()
+	return a.isLoggedInLocked() && a.loginComplete
 }
 
 // userRole returns the role established at login, which fetchUserRoleAndOrgId rewrites on every

--- a/pkg/wekafs/apiclient/login.go
+++ b/pkg/wekafs/apiclient/login.go
@@ -5,8 +5,23 @@ import (
 	"time"
 
 	"github.com/rs/zerolog/log"
-	"golang.org/x/exp/maps"
 )
+
+type loginInProgressKey struct{}
+
+// withLoginInProgress marks ctx as running inside Login, and loginInProgress reports it. Login makes
+// several requests after authenticating, each of which passes through Init; without this marker a
+// token that came back already near expiry would send Init back into Login on the same goroutine,
+// which is holding loginMu — a self-deadlock. The marker travels with the context, so it applies to
+// exactly the call chain Login started and to no other goroutine.
+func withLoginInProgress(ctx context.Context) context.Context {
+	return context.WithValue(ctx, loginInProgressKey{}, true)
+}
+
+func loginInProgress(ctx context.Context) bool {
+	inProgress, _ := ctx.Value(loginInProgressKey{}).(bool)
+	return inProgress
+}
 
 // Login logs into API, updates refresh token expiry
 func (a *ApiClient) Login(ctx context.Context) error {
@@ -14,8 +29,17 @@ func (a *ApiClient) Login(ctx context.Context) error {
 	if a.isLoggedIn() {
 		return nil
 	}
-	a.Lock()
-	defer a.Unlock()
+	// loginMu serialises login attempts; it is deliberately NOT the lock guarding the client state.
+	// Logging in makes four round-trips, and holding the state lock across them would both block
+	// every concurrent reader for the duration and deadlock, since the requests those calls issue
+	// take the state lock themselves to read the auth token.
+	a.loginMu.Lock()
+	defer a.loginMu.Unlock()
+	// Re-check: another goroutine may have completed a login while we waited for loginMu.
+	if a.isLoggedIn() {
+		return nil
+	}
+	ctx = withLoginInProgress(ctx)
 	r := LoginRequest{
 		Username: a.Credentials.Username,
 		Password: a.Credentials.Password,
@@ -33,13 +57,21 @@ func (a *ApiClient) Login(ctx context.Context) error {
 		logger.Error().Err(err).Msg("")
 		return err
 	}
+	// Publish the token before the calls below, which issue requests of their own and need it to
+	// authenticate.
+	a.Lock()
 	a.apiToken = responseData.AccessToken
 	a.refreshToken = responseData.RefreshToken
 	a.apiTokenExpiryDate = time.Now().Add(time.Duration(responseData.ExpiresIn-30) * time.Second)
-	if a.refreshTokenExpiryInterval < 1 {
+	needExpiryInterval := a.refreshTokenExpiryInterval < 1
+	a.Unlock()
+
+	if needExpiryInterval {
 		_ = a.updateTokensExpiryInterval(ctx)
 	}
+	a.Lock()
 	a.refreshTokenExpiryDate = time.Now().Add(time.Duration(a.refreshTokenExpiryInterval) * time.Second)
+	a.Unlock()
 
 	err = a.ensureSufficientPermissions(ctx)
 	if err != nil {
@@ -57,7 +89,7 @@ func (a *ApiClient) Login(ctx context.Context) error {
 		if err := a.UpdateApiEndpoints(ctx); err != nil {
 			logger.Error().Err(err).Msg("Failed to update actual API endpoints")
 		} else {
-			logger.Debug().Strs("new_api_endpoints", maps.Keys(a.actualApiEndpoints)).Str("current_endpoint", a.getEndpoint(ctx).String()).Msg("Updated API endpoints")
+			logger.Debug().Strs("new_api_endpoints", a.apiEndpoints.Keys()).Str("current_endpoint", a.getEndpoint(ctx).String()).Msg("Updated API endpoints")
 		}
 	} else {
 		logger.Debug().Str("current_endpoint", a.getEndpoint(ctx).String()).Msg("Auto update of API endpoints is disabled")
@@ -67,32 +99,64 @@ func (a *ApiClient) Login(ctx context.Context) error {
 
 // Init checks if API token refresh is required and transparently refreshes or fails back to (re)login
 func (a *ApiClient) Init(ctx context.Context) error {
-	if a.apiTokenExpiryDate.After(time.Now()) {
+	if loginInProgress(ctx) {
+		// A login is already under way on this call chain and has published its token; the requests it
+		// makes to finish setting up must not try to authenticate again.
 		return nil
-	} else {
-		log.Ctx(ctx).Trace().TimeDiff("valid_for", a.apiTokenExpiryDate, time.Now()).Msg("Auth token is expired")
 	}
+	a.RLock()
+	tokenExpiry := a.apiTokenExpiryDate
+	a.RUnlock()
+	if tokenExpiry.After(time.Now()) {
+		return nil
+	}
+	log.Ctx(ctx).Trace().TimeDiff("valid_for", tokenExpiry, time.Now()).Msg("Auth token is expired")
 	if !a.isLoggedIn() {
 		log.Ctx(ctx).Trace().Msg("Client is not authenticated, logging in...")
 		return a.Login(ctx)
 	}
 
+	a.RLock()
 	r := RefreshRequest{RefreshToken: a.refreshToken}
+	a.RUnlock()
 	responseData := &RefreshResponse{}
 	payload, _ := marshalRequest(r)
 	if _, err := a.request(ctx, "POST", ApiPathRefresh, payload, nil, responseData); err != nil {
 		log.Ctx(ctx).Trace().Msg("Failed to refresh auth token, logging in...")
 		return a.Login(ctx)
 	}
+	a.Lock()
 	a.refreshToken = responseData.RefreshToken
 	a.apiToken = responseData.AccessToken
 	a.apiTokenExpiryDate = time.Now().Add(time.Duration(a.apiTokenExpiryInterval-30) * time.Second)
-	log.Ctx(ctx).Trace().TimeDiff("valid_for", a.refreshTokenExpiryDate, time.Now()).Msg("Auth token is valid")
+	refreshExpiry := a.refreshTokenExpiryDate
+	a.Unlock()
+	log.Ctx(ctx).Trace().TimeDiff("valid_for", refreshExpiry, time.Now()).Msg("Auth token is valid")
 	return nil
+}
+
+// authToken returns the bearer token to authenticate requests with, or an empty string if the client
+// is not logged in. Returning the token under the same lock that tests for it keeps a concurrent
+// login from swapping it in between the two.
+func (a *ApiClient) authToken() string {
+	a.RLock()
+	defer a.RUnlock()
+	if !a.isLoggedInLocked() {
+		return ""
+	}
+	return a.apiToken
 }
 
 // isLoggedIn returns true if client has a refresh token and it is not expired so it can refresh or perform ops directly
 func (a *ApiClient) isLoggedIn() bool {
+	a.RLock()
+	defer a.RUnlock()
+	return a.isLoggedInLocked()
+}
+
+// isLoggedInLocked is isLoggedIn for callers that already hold the lock.
+// REQUIRES: a's read or write lock is held by the caller.
+func (a *ApiClient) isLoggedInLocked() bool {
 	if a.apiToken == "" {
 		return false
 	}
@@ -102,9 +166,18 @@ func (a *ApiClient) isLoggedIn() bool {
 	return true
 }
 
+// userRole returns the role established at login, which fetchUserRoleAndOrgId rewrites on every
+// re-login while requests are in flight.
+func (a *ApiClient) userRole() ApiUserRole {
+	a.RLock()
+	defer a.RUnlock()
+	return a.ApiUserRole
+}
+
 func (a *ApiClient) HasCSIPermissions() bool {
-	if a.ApiUserRole != "" {
-		return a.ApiUserRole == ApiUserRoleCSI || a.ApiUserRole == ApiUserRoleClusterAdmin || a.ApiUserRole == ApiUserRoleOrgAdmin
+	role := a.userRole()
+	if role != "" {
+		return role == ApiUserRoleCSI || role == ApiUserRoleClusterAdmin || role == ApiUserRoleOrgAdmin
 	}
 	return false
 }

--- a/pkg/wekafs/apiclient/login_test.go
+++ b/pkg/wekafs/apiclient/login_test.go
@@ -1,0 +1,142 @@
+package apiclient
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// writeLoginJSON is local to this file on purpose. Borrowing the race test's writeJSON would couple
+// these tests to a harness that a later change in the stack replaces wholesale, breaking this file
+// from a commit that never touches it.
+func writeLoginJSON(t *testing.T, w http.ResponseWriter, v interface{}) {
+	t.Helper()
+	inner, err := json.Marshal(v)
+	if err != nil {
+		t.Errorf("failed to marshal test fixture: %v", err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	out, err := json.Marshal(struct {
+		Data json.RawMessage `json:"data"`
+	}{Data: inner})
+	if err != nil {
+		t.Errorf("failed to marshal test envelope: %v", err)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(out)
+}
+
+// newLoginFailureTestServer stands up a fake Weka API where the login call itself always succeeds
+// (publishing a token), but the whoami call that ensureSufficientPermissions makes right after
+// returns a role that fails HasCSIPermissions, so Login fails during its post-auth setup - after
+// the token is already visible to isLoggedIn().
+//
+// The whoami handler blocks the first request it receives until the test calls the returned
+// release function, and it reports (via the returned channel) the instant it was entered. That lets
+// a test start a second, independent Login call while the first is holding loginMu with its token
+// already published but its setup not yet finished - the exact window fix 1 closes.
+func newLoginFailureTestServer(t *testing.T) (hostPort string, whoamiEntered <-chan struct{}, release func()) {
+	t.Helper()
+	entered := make(chan struct{})
+	var enteredOnce sync.Once
+	gate := make(chan struct{})
+	var gateOnce sync.Once
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v2/login", func(w http.ResponseWriter, r *http.Request) {
+		writeLoginJSON(t, w, LoginResponse{
+			AccessToken:  "access-token",
+			TokenType:    "bearer",
+			ExpiresIn:    3600,
+			RefreshToken: "refresh-token",
+		})
+	})
+	mux.HandleFunc("/api/v2/security/defaultTokensExpiry", func(w http.ResponseWriter, r *http.Request) {
+		writeLoginJSON(t, w, TokenExpiryResponse{
+			AccessTokenExpiry:  3600,
+			RefreshTokenExpiry: 86400,
+		})
+	})
+	mux.HandleFunc("/api/v2/users/whoami", func(w http.ResponseWriter, r *http.Request) {
+		enteredOnce.Do(func() { close(entered) })
+		<-gate
+		// An empty role fails HasCSIPermissions, so ensureSufficientPermissions - and therefore
+		// Login - returns an error after the token has already been published.
+		writeLoginJSON(t, w, WhoamiResponse{OrgId: 1, Username: "nobody", Source: "local", Uid: uuid.New()})
+	})
+	mux.HandleFunc("/api/v2/cluster", func(w http.ResponseWriter, r *http.Request) {
+		writeLoginJSON(t, w, ClusterInfoResponse{Name: "login-test-cluster", Release: "4.2.0", Guid: uuid.New()})
+	})
+
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+	u, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("failed to parse test server URL: %v", err)
+	}
+	return u.Host, entered, func() { gateOnce.Do(func() { close(gate) }) }
+}
+
+// TestLogin_FailedPostAuthSetupNotReportedAsSuccess reproduces the regression described in fix 1:
+// Login publishes the token before ensureSufficientPermissions/fetchClusterInfo/UpdateApiEndpoints
+// run, so isLoggedIn() alone goes true while the login is still in the middle of failing. Before the
+// fix, both Login's opportunistic check before taking loginMu and its re-check after taking it used
+// isLoggedIn(), so a second caller - whether it arrives while the first is still holding loginMu, or
+// afterward once the first has already returned its error - was told the login succeeded, leaving it
+// to operate with an all-false CompatibilityMap for the token's lifetime.
+func TestLogin_FailedPostAuthSetupNotReportedAsSuccess(t *testing.T) {
+	quietLogs(t)
+	serverAddr, whoamiEntered, release := newLoginFailureTestServer(t)
+
+	creds := Credentials{
+		Username:     "admin",
+		Password:     "admin",
+		Organization: "Root",
+		HttpScheme:   "http",
+		Endpoints:    []string{serverAddr},
+	}
+	c, err := NewApiClient(context.Background(), creds, ApiClientOptions{Hostname: "login-test-client"})
+	if err != nil {
+		t.Fatalf("failed to create API client: %v", err)
+	}
+
+	err1Ch := make(chan error, 1)
+	go func() {
+		err1Ch <- c.Login(context.Background())
+	}()
+
+	select {
+	case <-whoamiEntered:
+		// The first Login has published its token and is now blocked inside the permission check,
+		// still holding loginMu.
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for the first login to reach the permission check")
+	}
+
+	err2Ch := make(chan error, 1)
+	go func() {
+		err2Ch <- c.Login(context.Background())
+	}()
+
+	release()
+
+	err1 := <-err1Ch
+	err2 := <-err2Ch
+
+	if err1 == nil {
+		t.Fatal("expected the first login's permission check failure to surface")
+	}
+	if err2 == nil {
+		t.Fatal("a second Login must not report success for a login whose post-auth setup failed")
+	}
+}

--- a/pkg/wekafs/apiclient/node.go
+++ b/pkg/wekafs/apiclient/node.go
@@ -43,7 +43,7 @@ func (n *WekaNode) GetType() string {
 
 func (n *WekaNode) GetBasePath(a *ApiClient) string {
 	if a != nil {
-		if a.CompatibilityMap.NewNodeApiObjectPath {
+		if a.compatibility().NewNodeApiObjectPath {
 			return "processes"
 		}
 	}

--- a/pkg/wekafs/apiclient/requests.go
+++ b/pkg/wekafs/apiclient/requests.go
@@ -44,8 +44,8 @@ func (a *ApiClient) do(ctx context.Context, Method string, Path string, Payload 
 		}
 	}
 	r.Header.Set("content-type", "application/json")
-	if a.isLoggedIn() {
-		r.Header.Set("Authorization", fmt.Sprintf("Bearer %s", a.apiToken))
+	if token := a.authToken(); token != "" {
+		r.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
 	}
 
 	//add query params
@@ -63,30 +63,30 @@ func (a *ApiClient) do(ctx context.Context, Method string, Path string, Payload 
 
 	//perform the request and update endpoint with stats
 	endpoint := a.getEndpoint(ctx)
-	endpoint.requestCount++
+	endpoint.requestCount.Add(1)
 	start := time.Now()
 	response, err := a.client.Do(r)
 
 	if err != nil {
-		endpoint.transportErrCount++
+		endpoint.transportErrCount.Add(1)
 		return nil, &transportError{err}
 	}
 
 	if response == nil {
-		endpoint.noRespCount++
+		endpoint.noRespCount.Add(1)
 		return nil, &transportError{errors.New("received no response")}
 	}
 
 	// update endpoint stats for success and total duration
-	endpoint.requestDurationTotal += time.Since(start)
+	endpoint.requestDurationTotal.Add(int64(time.Since(start)))
 	if response.StatusCode != http.StatusOK {
-		endpoint.failCount++
+		endpoint.failCount.Add(1)
 	}
 
 	responseBody, err := io.ReadAll(response.Body)
 	logger.Trace().Str("response", maskPayload(string(responseBody))).Msg("")
 	if err != nil {
-		endpoint.parseErrCount++
+		endpoint.parseErrCount.Add(1)
 		return nil, &ApiInternalError{
 			Err:         err,
 			Text:        fmt.Sprintf("Failed to parse response: %s", err.Error()),
@@ -102,9 +102,9 @@ func (a *ApiClient) do(ctx context.Context, Method string, Path string, Payload 
 
 	Response := &ApiResponse{}
 	err = json.Unmarshal(responseBody, Response)
-	endpoint.parseErrCount++
 	Response.HttpStatusCode = response.StatusCode
 	if err != nil {
+		endpoint.parseErrCount.Add(1)
 		logger.Error().Err(err).Int("http_status_code", Response.HttpStatusCode).Msg("Could not parse response JSON")
 		return nil, &ApiError{
 			Err:         err,
@@ -125,7 +125,7 @@ func (a *ApiClient) do(ctx context.Context, Method string, Path string, Payload 
 	case http.StatusNoContent: //203
 		return Response, nil
 	case http.StatusBadRequest: //400
-		endpoint.http400ErrCount++
+		endpoint.http400ErrCount.Add(1)
 		return Response, &ApiBadRequestError{
 			Err:         nil,
 			Text:        "Operation failed",
@@ -134,7 +134,7 @@ func (a *ApiClient) do(ctx context.Context, Method string, Path string, Payload 
 			ApiResponse: Response,
 		}
 	case http.StatusUnauthorized: //401
-		endpoint.http401ErrCount++
+		endpoint.http401ErrCount.Add(1)
 		return Response, &ApiAuthorizationError{
 			Err:         nil,
 			Text:        "Operation failed",
@@ -143,7 +143,7 @@ func (a *ApiClient) do(ctx context.Context, Method string, Path string, Payload 
 			ApiResponse: Response,
 		}
 	case http.StatusForbidden: //403
-		endpoint.http403ErrCount++
+		endpoint.http403ErrCount.Add(1)
 		return Response, &ApiForbiddenError{
 			Err:         err,
 			Text:        "Permission denied",
@@ -152,7 +152,7 @@ func (a *ApiClient) do(ctx context.Context, Method string, Path string, Payload 
 			ApiResponse: Response,
 		}
 	case http.StatusNotFound: //404
-		endpoint.http404ErrCount++
+		endpoint.http404ErrCount.Add(1)
 		return Response, &ApiNotFoundError{
 			Err:         nil,
 			Text:        "Object not found",
@@ -161,7 +161,7 @@ func (a *ApiClient) do(ctx context.Context, Method string, Path string, Payload 
 			ApiResponse: Response,
 		}
 	case http.StatusConflict: //409
-		endpoint.http409ErrCount++
+		endpoint.http409ErrCount.Add(1)
 		return Response, &ApiConflictError{
 			ApiError: ApiError{
 				Err:         nil,
@@ -174,7 +174,7 @@ func (a *ApiClient) do(ctx context.Context, Method string, Path string, Payload 
 		}
 
 	case http.StatusInternalServerError: //500
-		endpoint.http500ErrCount++
+		endpoint.http500ErrCount.Add(1)
 		return Response, &ApiInternalError{
 			Err:         nil,
 			Text:        Response.Message,
@@ -184,7 +184,7 @@ func (a *ApiClient) do(ctx context.Context, Method string, Path string, Payload 
 		}
 
 	case http.StatusServiceUnavailable: //503
-		endpoint.http503ErrCount++
+		endpoint.http503ErrCount.Add(1)
 		return Response, &ApiNotAvailableError{
 			Err:         nil,
 			Text:        Response.Message,
@@ -194,7 +194,7 @@ func (a *ApiClient) do(ctx context.Context, Method string, Path string, Payload 
 		}
 
 	default:
-		endpoint.generalErrCount++
+		endpoint.generalErrCount.Add(1)
 		return Response, &ApiError{
 			Err:         err,
 			Text:        "General failure during API command",

--- a/pkg/wekafs/apiclient/requests.go
+++ b/pkg/wekafs/apiclient/requests.go
@@ -24,7 +24,10 @@ func (a *ApiClient) do(ctx context.Context, Method string, Path string, Payload 
 			Err: errors.New("no endpoints could be found for API client"),
 		}
 	}
-	u := a.getUrl(ctx, Path)
+	u, uErr := a.getUrl(ctx, Path)
+	if uErr != nil {
+		return &ApiResponse{}, uErr
+	}
 
 	//construct base request and add auth if exists
 	var body *bytes.Reader
@@ -62,7 +65,10 @@ func (a *ApiClient) do(ctx context.Context, Method string, Path string, Payload 
 	logger.Trace().Str("method", Method).Str("url", r.URL.RequestURI()).Str("payload", maskPayload(payload)).Msg("")
 
 	//perform the request and update endpoint with stats
-	endpoint := a.getEndpoint(ctx)
+	endpoint, epErr := a.requireEndpoint(ctx)
+	if epErr != nil {
+		return &ApiResponse{}, epErr
+	}
 	endpoint.requestCount.Add(1)
 	start := time.Now()
 	response, err := a.client.Do(r)

--- a/pkg/wekafs/apistore.go
+++ b/pkg/wekafs/apistore.go
@@ -62,7 +62,7 @@ func (api *ApiStore) getByClusterGuid(guid uuid.UUID) (*apiclient.ApiClient, err
 	api.RLock()
 	defer api.RUnlock()
 	for _, val := range api.apis {
-		if val.ClusterGuid == guid {
+		if val.GetClusterGuid() == guid {
 			return val, nil
 		}
 	}
@@ -184,7 +184,7 @@ func (api *ApiStore) fromCredentials(ctx context.Context, credentials apiclient.
 		return nil, errors.New(fmt.Sprintf(
 			"Using Organization %s is not supported on Weka cluster \"%s\".\n"+
 				"To support organization other than Root please upgrade to version %s or higher",
-			credentials.Organization, newClient.ClusterName, apiclient.MinimumSupportedWekaVersions.MountFilesystemsUsingAuthToken))
+			credentials.Organization, newClient.GetClusterName(), apiclient.MinimumSupportedWekaVersions.MountFilesystemsUsingAuthToken))
 	}
 	if (api.config.allowNfsFailback || api.config.useNfs) && !api.config.isInDevMode() {
 		newClient.NfsInterfaceGroupName = api.config.interfaceGroupName

--- a/pkg/wekafs/nfsmount.go
+++ b/pkg/wekafs/nfsmount.go
@@ -171,9 +171,9 @@ func (m *nfsMount) doMount(ctx context.Context, apiClient *apiclient.ApiClient, 
 		return errors.New("no API client for mount, cannot do NFS mount")
 	}
 	// to validate that the organization is root, otherwise cannot mount NFS volumes
-	if apiClient.ApiOrgId != 0 {
+	if orgId := apiClient.GetApiOrgId(); orgId != 0 {
 		err := errors.New("cannot mount NFS volumes with non-Root organization")
-		logger.Error().Err(err).Int("organization_id", apiClient.ApiOrgId).Msg("Cannot mount NFS volumes with non-Root organization")
+		logger.Error().Err(err).Int("organization_id", orgId).Msg("Cannot mount NFS volumes with non-Root organization")
 		return err
 	}
 

--- a/pkg/wekafs/volume.go
+++ b/pkg/wekafs/volume.go
@@ -455,7 +455,7 @@ func (v *Volume) getFreeSpaceOnStorage(ctx context.Context) (int64, error) {
 	}
 	maxCapacity, err := v.apiClient.GetFreeCapacity(ctx)
 	if err != nil {
-		return -1, status.Errorf(codes.FailedPrecondition, "Could not obtain free capacity for filesystem %s on cluster %s: %s", v.GetId(), v.apiClient.ClusterName, err.Error())
+		return -1, status.Errorf(codes.FailedPrecondition, "Could not obtain free capacity for filesystem %s on cluster %s: %s", v.GetId(), v.apiClient.GetClusterName(), err.Error())
 	}
 
 	logger.Debug().Uint64("max_capacity", maxCapacity).Msg("Resolved free capacity")


### PR DESCRIPTION
### TL;DR
Fixed bugs that could crash the driver, or make it misjudge storage cluster features, when many volume operations ran at once.

### What changed?
- Made the driver's storage API client safe for many volume operations running at once
- Fixed a partly-failed login being treated as successful, which left the driver with wrong assumptions about cluster capabilities for up to an hour (refusing valid volumes, skipping quota enforcement, or rejecting valid organizations)

### How to test?
Only reliably shown by automated tests, since the failures depend on timing under concurrent load:
1. Run the automated concurrency test suite added in this change
2. It reproduces the crashes and wrong behavior on the old code, and passes cleanly after the fix

### Why make this change?
Under concurrent load — normal in production, since Kubernetes creates and deletes many volumes in parallel — the driver could crash or silently run on wrong assumptions, causing hard-to-diagnose failures.

