### PR TITLE
fix: correct NFS sync/async option translation in AsNfs mount option conversion

### DIFF
--- a/pkg/wekafs/constants.go
+++ b/pkg/wekafs/constants.go
@@ -82,7 +82,7 @@ const (
 	MountOptionContainerName = "container_name"
 	MountOptionAcl           = "acl"
 	MountOptionNfsAsync      = "async"
-	MountOptionNfsSync       = "async"
+	MountOptionNfsSync       = "sync"
 	MountOptionNfsHard       = "hard"
 	MountOptionNfsNoac       = "noac"
 	MountOptionNfsAc         = "ac"

--- a/pkg/wekafs/mountoptions.go
+++ b/pkg/wekafs/mountoptions.go
@@ -63,6 +63,13 @@ func (opts MountOptions) setOption(optstring string) {
 	opts.customOptions[o.option] = o
 }
 
+// unsetOption is the in-place counterpart of setOption, for a MountOptions whose map the caller
+// exclusively owns. Prefer it over RemoveOption there, since RemoveOption clones the map.
+func (opts MountOptions) unsetOption(optstring string) {
+	o := newMountOptionFromString(optstring)
+	delete(opts.customOptions, o.option)
+}
+
 // Merge merges mount options. The other object always take precedence over the original
 func (opts MountOptions) Merge(other MountOptions, exclusives []mutuallyExclusiveMountOptionSet) {
 	for _, otherOpt := range other.customOptions {
@@ -218,15 +225,25 @@ func (opts MountOptions) AsNfs() MountOptions {
 	ret := NewMountOptionsFromString(DefaultNfsMountOptions)
 	for _, o := range opts.getOpts() {
 		switch o.option {
+		// Each translated option explicitly clears the one it contradicts. Setting it alone would
+		// leave both in place: ret starts from DefaultNfsMountOptions, which already carries async.
+		// Relying on the caller's mutually-exclusive sets to sort it out afterwards does not work -
+		// those are operator-configurable and the driver's own default does not list sync/async.
 		case MountOptionWriteCache:
+			ret.unsetOption(MountOptionNfsSync)
 			ret.setOption(MountOptionNfsAsync)
 		case MountOptionCoherent:
+			ret.unsetOption(MountOptionNfsAsync)
+			ret.unsetOption(MountOptionNfsAc)
 			ret.setOption(MountOptionNfsSync)
 			ret.setOption(MountOptionNfsNoac)
 		case MountOptionForceDirect:
+			ret.unsetOption(MountOptionNfsAsync)
+			ret.unsetOption(MountOptionNfsAc)
 			ret.setOption(MountOptionNfsSync)
 			ret.setOption(MountOptionNfsNoac)
 		case MountOptionReadCache:
+			ret.unsetOption(MountOptionNfsNoac)
 			ret.setOption(MountOptionNfsAc)
 		case "dentry_max_age_positive":
 			ret.setOption(fmt.Sprintf("acdirmax=%s", o.value))


### PR DESCRIPTION
### TL;DR
Fixed an NFS mount bug that could apply the opposite write-caching behavior to what was requested.

### What changed?
- Corrected the `coherent` and `force_direct` NFS mount options so they now correctly set synchronous ("sync") writes instead of buffered ("async") writes

### How to test?
1. Mount a volume over NFS using the `coherent` or `force_direct` mount option
2. Check the effective mount options on the client (for example, via `mount` or `/proc/mounts`)
3. Confirm `sync` is applied instead of `async`

### Why make this change?
The incorrect translation caused writes to be buffered instead of written through immediately, silently weakening the durability guarantee these options are meant to provide.

