### PR TITLE
feat: add bulk quota map fetching per filesystem with per-filesystem locking

### DIFF
--- a/pkg/wekafs/apiclient/quotamap.go
+++ b/pkg/wekafs/apiclient/quotamap.go
@@ -1,0 +1,136 @@
+package apiclient
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	qs "github.com/google/go-querystring/query"
+	"github.com/google/uuid"
+	"github.com/rs/zerolog/log"
+	"go.opentelemetry.io/otel"
+)
+
+// QuotaListRequest fetches every quota on a filesystem in one call, rather than one request per
+// inode. GetPath is left off by default: resolving each quota's path is expensive on the backend
+// and callers that only need capacity figures do not use it.
+type QuotaListRequest struct {
+	FilesystemUid uuid.UUID `json:"-" url:"-"`
+	GetPath       bool      `url:"get_path"`
+}
+
+func (q *QuotaListRequest) getRequiredFields() []string {
+	return []string{"FilesystemUid"}
+}
+
+func (q *QuotaListRequest) hasRequiredFields() bool {
+	return ObjectRequestHasRequiredFields(q)
+}
+
+func (q *QuotaListRequest) getRelatedObject() ApiObject {
+	return nil
+}
+
+func (q *QuotaListRequest) getApiUrl(a *ApiClient) string {
+	return "filesystems/" + q.FilesystemUid.String() + "/quota"
+}
+
+func (q *QuotaListRequest) String() string {
+	return "QuotaListRequest{" + q.FilesystemUid.String() + "}"
+}
+
+// QuotaInList is one entry of the quota listing. The listing returns a wider record than the
+// single-quota endpoint; only the fields consumed here are declared.
+type QuotaInList struct {
+	InodeId        uint64 `json:"inode_id"`
+	TotalBytes     uint64 `json:"total_bytes"`
+	HardLimitBytes uint64 `json:"hard_limit_bytes"`
+	SoftLimitBytes uint64 `json:"soft_limit_bytes"`
+	Status         string `json:"status"`
+}
+
+// QuotaListResponse is the paginated listing. A filesystem can hold far more quotas than the
+// backend returns in one response, so this implements ApiObjectResponse to be fetched page by page.
+type QuotaListResponse []*QuotaInList
+
+func (q *QuotaListResponse) CombinePartialResponse(page ApiObjectResponse) error {
+	partial, ok := page.(*QuotaListResponse)
+	if !ok {
+		return fmt.Errorf("cannot combine a %T into a quota listing", page)
+	}
+	*q = append(*q, *partial...)
+	return nil
+}
+
+// QuotaMap is every quota on one filesystem, indexed by inode. It is built once by GetQuotaMap and
+// then only read; a refresh constructs a new map and replaces the old one wholesale rather than
+// mutating it in place.
+type QuotaMap struct {
+	sync.RWMutex
+	Quotas        map[uint64]*Quota `json:"quotas"`
+	FileSystemUid uuid.UUID         `json:"filesystem_uid"`
+	LastUpdate    time.Time         `json:"-" url:"-"`
+}
+
+// GetQuotaForInodeId returns the quota for an inode, or nil when the inode has none.
+func (q *QuotaMap) GetQuotaForInodeId(inodeId uint64) *Quota {
+	q.RLock()
+	defer q.RUnlock()
+	return q.Quotas[inodeId]
+}
+
+// Len reports how many quotas the map holds.
+func (q *QuotaMap) Len() int {
+	q.RLock()
+	defer q.RUnlock()
+	return len(q.Quotas)
+}
+
+// GetQuotaMap fetches all quotas of a filesystem in a single paginated listing. Fetching them
+// together costs one request per filesystem instead of one per volume, which is the difference
+// between a bounded and an unbounded number of API calls as volume count grows.
+func (a *ApiClient) GetQuotaMap(ctx context.Context, fs *FileSystem) (*QuotaMap, error) {
+	op := "GetQuotaMap"
+	ctx, span := otel.Tracer(TracerName).Start(ctx, op)
+	defer span.End()
+	ctx = log.With().Str("trace_id", span.SpanContext().TraceID().String()).Str("span_id", span.SpanContext().SpanID().String()).Str("op", op).Logger().WithContext(ctx)
+
+	if fs == nil || fs.Uid == uuid.Nil {
+		return nil, RequestMissingParams
+	}
+	logger := log.Ctx(ctx).With().Str("filesystem", fs.Name).Logger()
+
+	r := &QuotaListRequest{FilesystemUid: fs.Uid}
+	query, err := qs.Values(r)
+	if err != nil {
+		logger.Error().Err(err).Msg("Failed to encode query parameters for quota list request")
+		return nil, RequestMissingParams
+	}
+
+	startTime := time.Now()
+	out := &QuotaListResponse{}
+	if err := a.Get(ctx, r.getApiUrl(a), query, out); err != nil {
+		logger.Error().Err(err).Msg("Failed to get quota list for filesystem")
+		return nil, err
+	}
+
+	ret := &QuotaMap{
+		FileSystemUid: fs.Uid,
+		Quotas:        make(map[uint64]*Quota, len(*out)),
+	}
+	for _, q := range *out {
+		ret.Quotas[q.InodeId] = &Quota{
+			FilesystemUid:  fs.Uid,
+			InodeId:        q.InodeId,
+			TotalBytes:     q.TotalBytes,
+			HardLimitBytes: q.HardLimitBytes,
+			SoftLimitBytes: q.SoftLimitBytes,
+			Status:         q.Status,
+		}
+	}
+	ret.LastUpdate = time.Now()
+
+	logger.Trace().Dur("duration", time.Since(startTime)).Int("object_count", len(*out)).Msg("Fetched QuotaMap for filesystem")
+	return ret, nil
+}

--- a/pkg/wekafs/quotamaps.go
+++ b/pkg/wekafs/quotamaps.go
@@ -1,0 +1,88 @@
+package wekafs
+
+import (
+	"sync"
+
+	"github.com/google/uuid"
+	"github.com/wekafs/csi-wekafs/pkg/wekafs/apiclient"
+)
+
+// QMLocks hands out one lock per filesystem, so a quota-map refresh for one filesystem does not
+// serialise against refreshes of the others.
+type QMLocks struct {
+	locks sync.Map // map[uuid.UUID]*sync.RWMutex
+}
+
+func NewQMLocks() *QMLocks {
+	return &QMLocks{}
+}
+
+// GetLock returns the lock for uid, creating it on first use.
+//
+// The create-if-absent must be atomic: with a plain Load-then-Store, two goroutines that both miss
+// would each construct a lock and the second would overwrite the first, leaving them holding
+// different mutexes for the same filesystem and excluding nothing. LoadOrStore resolves that in one
+// step, so every caller for a given uid gets the same lock. The Load first is only a fast path that
+// avoids allocating a mutex on the common hit.
+func (qml *QMLocks) GetLock(uid uuid.UUID) *sync.RWMutex {
+	if lock, ok := qml.locks.Load(uid); ok {
+		return lock.(*sync.RWMutex)
+	}
+	lock, _ := qml.locks.LoadOrStore(uid, &sync.RWMutex{})
+	return lock.(*sync.RWMutex)
+}
+
+// Note there is deliberately no way to remove a lock. Deleting one is unsound: a goroutine that
+// already holds the pointer keeps using it while the next caller creates a fresh mutex for the same
+// filesystem, so the two no longer exclude each other. The map only grows with the number of
+// filesystems the driver has seen, which is bounded and small.
+
+// QuotaMapsPerFilesystem caches one quota map per filesystem. The maps are replaced wholesale on
+// refresh, so readers either see the previous map or the new one, never a partially rebuilt one.
+type QuotaMapsPerFilesystem struct {
+	mu        sync.RWMutex
+	locks     *QMLocks
+	quotaMaps map[uuid.UUID]*apiclient.QuotaMap
+}
+
+func NewQuotaMapsPerFilesystem() *QuotaMapsPerFilesystem {
+	return &QuotaMapsPerFilesystem{
+		quotaMaps: make(map[uuid.UUID]*apiclient.QuotaMap),
+		locks:     NewQMLocks(),
+	}
+}
+
+// GetLock returns the refresh lock for a filesystem. Callers take it to keep two refreshes of the
+// same filesystem from both hitting the API.
+func (qms *QuotaMapsPerFilesystem) GetLock(uid uuid.UUID) *sync.RWMutex {
+	return qms.locks.GetLock(uid)
+}
+
+// GetQuotaMap returns the cached map for a filesystem, or nil if none has been fetched yet.
+func (qms *QuotaMapsPerFilesystem) GetQuotaMap(uid uuid.UUID) *apiclient.QuotaMap {
+	qms.mu.RLock()
+	defer qms.mu.RUnlock()
+	return qms.quotaMaps[uid]
+}
+
+// SetQuotaMap installs a freshly fetched map for a filesystem.
+func (qms *QuotaMapsPerFilesystem) SetQuotaMap(uid uuid.UUID, quotaMap *apiclient.QuotaMap) {
+	qms.mu.Lock()
+	defer qms.mu.Unlock()
+	qms.quotaMaps[uid] = quotaMap
+}
+
+// Forget drops the cached map for a filesystem, e.g. once it is no longer observed. The per
+// filesystem lock is intentionally left in place - see the note on QMLocks.
+func (qms *QuotaMapsPerFilesystem) Forget(uid uuid.UUID) {
+	qms.mu.Lock()
+	defer qms.mu.Unlock()
+	delete(qms.quotaMaps, uid)
+}
+
+// Len reports how many filesystems currently have a cached quota map.
+func (qms *QuotaMapsPerFilesystem) Len() int {
+	qms.mu.RLock()
+	defer qms.mu.RUnlock()
+	return len(qms.quotaMaps)
+}

--- a/pkg/wekafs/quotamaps_test.go
+++ b/pkg/wekafs/quotamaps_test.go
@@ -1,0 +1,139 @@
+package wekafs
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/wekafs/csi-wekafs/pkg/wekafs/apiclient"
+)
+
+// TestQMLocksGetLockIsStable is the regression test for the create-if-absent race: concurrent
+// callers for the same filesystem must all receive the identical *sync.RWMutex. A Load-then-Store
+// implementation hands out more than one and fails here (usually, since it depends on the
+// interleaving - run with -race and -count to shake it out).
+func TestQMLocksGetLockIsStable(t *testing.T) {
+	const goroutines = 50
+	locks := NewQMLocks()
+	uid := uuid.New()
+
+	got := make([]*sync.RWMutex, goroutines)
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start // release them together, to make the miss-then-create window overlap
+			got[i] = locks.GetLock(uid)
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+
+	for i, lock := range got {
+		if lock == nil {
+			t.Fatalf("goroutine %d got a nil lock", i)
+		}
+		if lock != got[0] {
+			t.Fatalf("goroutine %d got a different lock (%p) than goroutine 0 (%p): "+
+				"callers would not exclude each other", i, lock, got[0])
+		}
+	}
+}
+
+// A lock actually excludes, and different filesystems do not share one.
+func TestQMLocksPerFilesystem(t *testing.T) {
+	locks := NewQMLocks()
+	a, b := uuid.New(), uuid.New()
+
+	if locks.GetLock(a) == locks.GetLock(b) {
+		t.Fatal("two filesystems share a lock, so their refreshes would serialise")
+	}
+	if locks.GetLock(a) != locks.GetLock(a) {
+		t.Fatal("repeated GetLock for one filesystem returned different locks")
+	}
+
+	lock := locks.GetLock(a)
+	counter := 0
+	var wg sync.WaitGroup
+	for i := 0; i < 100; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			lock.Lock()
+			defer lock.Unlock()
+			counter++ // -race proves the lock is doing its job
+		}()
+	}
+	wg.Wait()
+	if counter != 100 {
+		t.Fatalf("counter = %d, want 100", counter)
+	}
+}
+
+func TestQuotaMapsPerFilesystem(t *testing.T) {
+	qms := NewQuotaMapsPerFilesystem()
+	uid := uuid.New()
+
+	if got := qms.GetQuotaMap(uid); got != nil {
+		t.Fatalf("expected no cached map before one is set, got %v", got)
+	}
+	if got := qms.Len(); got != 0 {
+		t.Fatalf("Len() = %d, want 0", got)
+	}
+
+	quotaMap := &apiclient.QuotaMap{
+		FileSystemUid: uid,
+		Quotas:        map[uint64]*apiclient.Quota{42: {InodeId: 42, TotalBytes: 1024}},
+	}
+	qms.SetQuotaMap(uid, quotaMap)
+
+	got := qms.GetQuotaMap(uid)
+	if got != quotaMap {
+		t.Fatalf("GetQuotaMap returned %v, want the map that was set", got)
+	}
+	if q := got.GetQuotaForInodeId(42); q == nil || q.TotalBytes != 1024 {
+		t.Fatalf("GetQuotaForInodeId(42) = %v, want the quota with 1024 bytes", q)
+	}
+	if q := got.GetQuotaForInodeId(43); q != nil {
+		t.Fatalf("GetQuotaForInodeId(43) = %v, want nil for an inode with no quota", q)
+	}
+	if got := qms.Len(); got != 1 {
+		t.Fatalf("Len() = %d, want 1", got)
+	}
+
+	qms.Forget(uid)
+	if got := qms.GetQuotaMap(uid); got != nil {
+		t.Fatalf("expected the map to be dropped, got %v", got)
+	}
+}
+
+// Concurrent readers and writers across filesystems must not race.
+func TestQuotaMapsPerFilesystemConcurrent(t *testing.T) {
+	qms := NewQuotaMapsPerFilesystem()
+	uids := make([]uuid.UUID, 8)
+	for i := range uids {
+		uids[i] = uuid.New()
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 40; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			uid := uids[i%len(uids)]
+			lock := qms.GetLock(uid)
+			lock.Lock()
+			qms.SetQuotaMap(uid, &apiclient.QuotaMap{FileSystemUid: uid, Quotas: map[uint64]*apiclient.Quota{}})
+			lock.Unlock()
+			_ = qms.GetQuotaMap(uid)
+			_ = qms.Len()
+		}(i)
+	}
+	wg.Wait()
+
+	if got := qms.Len(); got != len(uids) {
+		t.Fatalf("Len() = %d, want %d", got, len(uids))
+	}
+}


### PR DESCRIPTION
### TL;DR
Adds a way to fetch every quota on a filesystem in one bulk API call, instead of one call per volume.

### What changed?
- Added `GetQuotaMap` to the Weka API client: fetches all quotas for a filesystem via a single paginated call.
- Added a per-filesystem quota cache with an independent refresh lock per filesystem, so refreshing one doesn't block another.
- This is the mechanism only — nothing calls it yet, so there's no behavior change in this PR.

### How to test?
No consumer yet, so this can only be exercised via automated tests:
1. Run `go test ./pkg/wekafs/... ./pkg/wekafs/apiclient/...` (add `-race` for the concurrency tests).

### Why make this change?
Quota lookups today cost one API call per volume, so call volume scales with volume count. Fetching all quotas for a filesystem at once turns that into one call per filesystem, which is what lets quota-based metrics scale to large volume counts. This lands ahead of the code that will use it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New, unused infrastructure with tests only; no wiring into CSI paths or runtime behavior in this PR.
> 
> **Overview**
> Introduces **bulk quota listing** for a filesystem so quota data can be loaded with one paginated API call per filesystem instead of scaling with volume count. The apiclient adds `GetQuotaMap`, list request/response types, and an inode-indexed `QuotaMap`; the list URL is built via `Quota.GetBasePath` (with a test guarding the `fileSystems` path spelling).
> 
> Adds **`QuotaMapsPerFilesystem`** caching in `wekafs`: per-filesystem refresh locks (`QMLocks` via atomic `LoadOrStore`) and wholesale map replacement on refresh, plus `Forget` to drop cache entries. **No production callers yet**—tests cover path correctness, lock stability under concurrency, and cache behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d18e19c4d500e4129e3a3c5ff69721a4903cb75d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->