### PR TITLE
feat: add Prometheus metrics for API request count and duration

### DIFF
--- a/charts/csi-wekafsplugin/README.md
+++ b/charts/csi-wekafsplugin/README.md
@@ -127,6 +127,9 @@ helm install csi-wekafsplugin csi-wekafs/csi-wekafsplugin --namespace csi-wekafs
 | metrics.snapshotterPort | int | `9093` | Snapshotter metrics port |
 | metrics.nodePort | int | `9094` | Metrics port for Node Serer |
 | metrics.attacherPort | int | `9095` | Attacher metrics port |
+| metrics.podMonitor.enabled | bool | `true` | Create PodMonitors for the controller and node pods |
+| metrics.podMonitor.interval | string | `"30s"` | Scrape interval |
+| metrics.podMonitor.additionalLabels | object | `{}` | Extra labels for the PodMonitor objects. Set this when your Prometheus selects PodMonitors by label, e.g. `release: kube-prometheus-stack`, or the metrics will not be scraped. |
 | hostNetwork | bool | `false` | Set to true to use host networking. Will be always set to true when using NFS mount protocol |
 | pluginConfig.fsGroupPolicy | string | `"File"` | WARNING: Changing this value might require uninstall and re-install of the plugin |
 | pluginConfig.allowInsecureHttps | bool | `false` | Allow insecure HTTPS (skip TLS certificate verification) |

--- a/charts/csi-wekafsplugin/templates/controllerserver-podmonitor.yaml
+++ b/charts/csi-wekafsplugin/templates/controllerserver-podmonitor.yaml
@@ -1,0 +1,43 @@
+{{- if and .Values.metrics.enabled .Values.metrics.podMonitor.enabled }}
+{{- if .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ .Release.Name }}-controller
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Release.Name }}-controller
+    component: {{ .Release.Name }}-controller
+    release: {{ .Release.Name }}
+    {{- with .Values.metrics.podMonitor.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}-controller
+      component: {{ .Release.Name }}-controller
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  # One entry per named metrics port. A PodMonitor selects ports by name, so every container whose
+  # metrics should be collected needs its own entry and its own unique port name.
+  podMetricsEndpoints:
+    - port: metrics
+      path: /metrics
+      interval: {{ .Values.metrics.podMonitor.interval }}
+    - port: at-metrics
+      path: /metrics
+      interval: {{ .Values.metrics.podMonitor.interval }}
+    - port: pr-metrics
+      path: /metrics
+      interval: {{ .Values.metrics.podMonitor.interval }}
+    - port: rs-metrics
+      path: /metrics
+      interval: {{ .Values.metrics.podMonitor.interval }}
+    - port: sn-metrics
+      path: /metrics
+      interval: {{ .Values.metrics.podMonitor.interval }}
+{{- end }}
+{{- end }}

--- a/charts/csi-wekafsplugin/templates/nodeserver-podmonitor.yaml
+++ b/charts/csi-wekafsplugin/templates/nodeserver-podmonitor.yaml
@@ -1,0 +1,29 @@
+{{- if and .Values.metrics.enabled .Values.metrics.podMonitor.enabled }}
+{{- if .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ .Release.Name }}-node
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Release.Name }}-node
+    component: {{ .Release.Name }}-node
+    release: {{ .Release.Name }}
+    {{- with .Values.metrics.podMonitor.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}-node
+      component: {{ .Release.Name }}-node
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  podMetricsEndpoints:
+    - port: metrics
+      path: /metrics
+      interval: {{ .Values.metrics.podMonitor.interval }}
+{{- end }}
+{{- end }}

--- a/charts/csi-wekafsplugin/values.schema.json
+++ b/charts/csi-wekafsplugin/values.schema.json
@@ -352,6 +352,20 @@
                 "nodePort": {
                     "type": "integer"
                 },
+                "podMonitor": {
+                    "type": "object",
+                    "properties": {
+                        "additionalLabels": {
+                            "type": "object"
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "interval": {
+                            "type": "string"
+                        }
+                    }
+                },
                 "provisionerPort": {
                     "type": "integer"
                 },

--- a/charts/csi-wekafsplugin/values.yaml
+++ b/charts/csi-wekafsplugin/values.yaml
@@ -215,6 +215,16 @@ metrics:
   snapshotterPort: 9093
   # -- Metrics port for Node Serer
   nodePort: 9094
+  # -- PodMonitor resources for the Prometheus Operator. Only rendered when the
+  #    monitoring.coreos.com/v1 CRDs are present in the cluster.
+  podMonitor:
+    # -- Create PodMonitors for the controller and node pods
+    enabled: true
+    # -- Scrape interval
+    interval: 30s
+    # -- Extra labels for the PodMonitor objects. Set this when your Prometheus selects PodMonitors
+    #    by label, e.g. `release: kube-prometheus-stack`, or the metrics will not be scraped.
+    additionalLabels: {}
   # -- Attacher metrics port
   attacherPort: 9095
 # -- Tracing URL (For Jaeger tracing engine / OpenTelemetry), optional

--- a/cmd/wekafsplugin/main.go
+++ b/cmd/wekafsplugin/main.go
@@ -28,6 +28,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
@@ -35,6 +36,7 @@ import (
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 
 	"github.com/wekafs/csi-wekafs/pkg/wekafs"
+	"github.com/wekafs/csi-wekafs/pkg/wekafs/apiclient"
 )
 
 func init() {
@@ -158,6 +160,9 @@ func main() {
 	log.Info().Str("csi_mode", string(csiMode)).Bool("selinux_mode", *selinuxSupport).Msg("Started CSI driver")
 
 	if enableMetrics != nil && *enableMetrics {
+		// The API client builds its collectors but does not register them, so that importing the
+		// package has no effect on any registry. Register them here, where /metrics is served.
+		prometheus.MustRegister(apiclient.Collectors()...)
 		go func() {
 			http.Handle("/metrics", promhttp.Handler())
 			if err := http.ListenAndServe(fmt.Sprintf(":%s", *metricsPort), nil); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/kubernetes-csi/csi-lib-utils v0.24.0
 	github.com/pkg/xattr v0.4.12
 	github.com/prometheus/client_golang v1.24.1
+	github.com/prometheus/client_model v0.6.2
 	github.com/rs/zerolog v1.35.1
 	github.com/showa-93/go-mask v0.6.2
 	github.com/stretchr/testify v1.11.1
@@ -64,7 +65,6 @@ require (
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.70.1 // indirect
 	github.com/prometheus/procfs v0.21.1 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect

--- a/pkg/wekafs/apiclient/apiclient.go
+++ b/pkg/wekafs/apiclient/apiclient.go
@@ -57,6 +57,7 @@ type ApiClient struct {
 	CompatibilityMap           *WekaCompatibilityMap
 	clientHash                 uint32
 	hostname                   string
+	driverName                 string
 	// nfsInterfaceGroups caches interface groups by name. It carries its own lock - see the type.
 	nfsInterfaceGroups    *interfaceGroups
 	ApiUserRole           ApiUserRole
@@ -83,6 +84,9 @@ type ApiClientOptions struct {
 	AllowInsecureHttps bool
 	// Hostname identifies this client to the Weka cluster.
 	Hostname string
+	// DriverName labels the metrics this client records, so several drivers scraped together stay
+	// distinguishable.
+	DriverName string
 }
 
 func NewApiClient(ctx context.Context, credentials Credentials, opts ApiClientOptions) (*ApiClient, error) {
@@ -113,6 +117,7 @@ func NewApiClient(ctx context.Context, credentials Credentials, opts ApiClientOp
 		Credentials:        credentials,
 		CompatibilityMap:   &WekaCompatibilityMap{},
 		hostname:           opts.Hostname,
+		driverName:         opts.DriverName,
 		apiEndpoints:       NewApiEndPoints(),
 		nfsInterfaceGroups: newInterfaceGroups(),
 	}

--- a/pkg/wekafs/apiclient/metrics.go
+++ b/pkg/wekafs/apiclient/metrics.go
@@ -1,0 +1,81 @@
+package apiclient
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const (
+	metricsNamespace = "weka_csi"
+	metricsSubsystem = "api"
+)
+
+// apiMetricLabels are shared by every API request metric. Each is bounded: the driver name and
+// cluster guid are fixed per process, the endpoint is one of a handful of management addresses, and
+// status is one of the constants set in do(). The url label carries a generalised path rather than
+// the request path, since raw paths embed filesystem uids and would grow a new time series per
+// object - see generalizeUrlPathForMetrics.
+var apiMetricLabels = []string{"csi_driver_name", "cluster_guid", "endpoint", "method", "url", "status"}
+
+// ApiMetrics are the Prometheus metrics recorded for calls to the Weka API.
+type ApiMetrics struct {
+	requestCounters  *prometheus.CounterVec
+	requestDurations *prometheus.HistogramVec
+}
+
+// apiMetrics is process-wide because the metrics describe traffic to the Weka API as a whole, and
+// the cluster is already a label. Constructing the collectors has no side effect; they are only
+// exported once something registers them, which is what Collectors is for.
+var apiMetrics = newApiMetrics()
+
+func newApiMetrics() *ApiMetrics {
+	return &ApiMetrics{
+		requestCounters: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: metricsNamespace,
+				Subsystem: metricsSubsystem,
+				Name:      "request_count",
+				Help:      "Total number of API requests, by endpoint, method, url and status",
+			},
+			apiMetricLabels,
+		),
+		requestDurations: prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Namespace: metricsNamespace,
+				Subsystem: metricsSubsystem,
+				Name:      "request_duration_seconds",
+				Help:      "Duration of API requests in seconds, by endpoint, method, url and status",
+				Buckets:   []float64{0.1, 0.25, 0.5, 1, 2.5, 5, 7.5, 10, 15, 30, 60, 120, 300},
+			},
+			apiMetricLabels,
+		),
+	}
+}
+
+// Collectors returns the API metrics for the caller to register.
+//
+// Registration is deliberately the caller's decision rather than an init() that registers with the
+// default registry: a package that registers on import cannot be used with a custom registry, and
+// gives a test no way to start from a clean one.
+func Collectors() []prometheus.Collector {
+	return []prometheus.Collector{apiMetrics.requestCounters, apiMetrics.requestDurations}
+}
+
+var (
+	// Matches a UUID anywhere in the path, e.g. filesystems/<uid>/quota.
+	uuidInPath = regexp.MustCompile(`[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}`)
+	// Matches a path segment that is entirely digits, e.g. an inode id.
+	numericPathSegment = regexp.MustCompile(`\b\d+\b`)
+)
+
+// generalizeUrlPathForMetrics turns a request path into the shape of the request, so that calls
+// against different objects share one time series. Without it every filesystem, snapshot and inode
+// would produce its own series and the metric's cardinality would track the number of objects on
+// the cluster.
+func generalizeUrlPathForMetrics(urlPath string) string {
+	path := uuidInPath.ReplaceAllString(urlPath, "{guid}")
+	path = numericPathSegment.ReplaceAllString(path, "{id}")
+	return strings.TrimSuffix(path, "/")
+}

--- a/pkg/wekafs/apiclient/metrics_test.go
+++ b/pkg/wekafs/apiclient/metrics_test.go
@@ -1,0 +1,139 @@
+package apiclient
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+
+	"github.com/wekafs/csi-wekafs/pkg/wekafs/apiclient/apiclienttest"
+)
+
+func TestGeneralizeUrlPathForMetrics(t *testing.T) {
+	for _, tc := range []struct {
+		in   string
+		want string
+	}{
+		{"filesystems", "filesystems"},
+		{
+			"filesystems/8c1a5d4e-1b2f-4c3a-9d5e-6f7a8b9c0d1e/quota",
+			"filesystems/{guid}/quota",
+		},
+		{
+			"FILESYSTEMS/8C1A5D4E-1B2F-4C3A-9D5E-6F7A8B9C0D1E/quota",
+			"FILESYSTEMS/{guid}/quota",
+		},
+		{"fileSystems/1234/snapshots", "fileSystems/{id}/snapshots"},
+		{"cluster/", "cluster"},
+		// A version segment is not a bare number, so it must survive intact - otherwise every
+		// request would collapse onto the same series.
+		{"api/v2/cluster", "api/v2/cluster"},
+		{
+			"filesystems/8c1a5d4e-1b2f-4c3a-9d5e-6f7a8b9c0d1e/quotas/42",
+			"filesystems/{guid}/quotas/{id}",
+		},
+	} {
+		if got := generalizeUrlPathForMetrics(tc.in); got != tc.want {
+			t.Errorf("generalizeUrlPathForMetrics(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// The whole point of generalizing the path is that the number of series must not grow with the
+// number of objects on the cluster.
+func TestGeneralizeUrlPathBoundsCardinality(t *testing.T) {
+	seen := map[string]struct{}{}
+	for i := 0; i < 100; i++ {
+		path := "filesystems/" + uuid.New().String() + "/quota"
+		seen[generalizeUrlPathForMetrics(path)] = struct{}{}
+	}
+	if len(seen) != 1 {
+		t.Errorf("100 filesystems produced %d distinct label values, want 1: %v", len(seen), seen)
+	}
+}
+
+func TestCollectorsAreNotRegisteredOnImport(t *testing.T) {
+	// Registering into a fresh registry must succeed, which it cannot if the package already
+	// registered these collectors somewhere on import.
+	reg := prometheus.NewRegistry()
+	if err := reg.Register(apiMetrics.requestCounters); err != nil {
+		t.Fatalf("request counters were already registered elsewhere: %v", err)
+	}
+	if got := len(Collectors()); got != 2 {
+		t.Errorf("Collectors() returned %d collectors, want 2", got)
+	}
+}
+
+// End to end: drive a real client against the fake API and check the request metrics are recorded
+// with the labels we expect.
+//
+// apiMetrics is process-wide, so other tests in this package record into the same collectors. The
+// assertions therefore select this test's own series by a driver name nothing else uses, rather
+// than looking at the metric as a whole.
+func TestApiRequestMetricsAreRecorded(t *testing.T) {
+	quietLogs(t)
+	const driverName = "csi.weka.io.metrics-test"
+	server := apiclienttest.New(t)
+
+	client, err := NewApiClient(context.Background(), Credentials{
+		Username:     "admin",
+		Password:     "password",
+		Organization: "Root",
+		HttpScheme:   "http",
+		Endpoints:    []string{server.Addr()},
+	}, ApiClientOptions{AllowInsecureHttps: true, Hostname: "test", DriverName: driverName})
+	if err != nil {
+		t.Fatalf("failed to create client: %v", err)
+	}
+	if err := client.Login(context.Background()); err != nil {
+		t.Fatalf("failed to log in: %v", err)
+	}
+
+	var found bool
+	for _, mf := range gather(t) {
+		if mf.GetName() != "weka_csi_api_request_count" {
+			continue
+		}
+		for _, m := range mf.GetMetric() {
+			labels := map[string]string{}
+			for _, l := range m.GetLabel() {
+				labels[l.GetName()] = l.GetValue()
+			}
+			if labels["csi_driver_name"] != driverName || labels["url"] != "login" {
+				continue
+			}
+			found = true
+			if labels["method"] != "POST" {
+				t.Errorf("method = %q, want POST", labels["method"])
+			}
+			if !strings.HasPrefix(labels["status"], "http_") {
+				t.Errorf("status = %q, want an http_ status for a completed request", labels["status"])
+			}
+			if labels["endpoint"] == "" {
+				t.Error("endpoint label is empty")
+			}
+			if got := m.GetCounter().GetValue(); got < 1 {
+				t.Errorf("counter = %v, want at least 1", got)
+			}
+		}
+	}
+	if !found {
+		t.Errorf("no request_count series recorded for the login call of driver %q", driverName)
+	}
+}
+
+func gather(t *testing.T) []*dto.MetricFamily {
+	t.Helper()
+	reg := prometheus.NewRegistry()
+	if err := reg.Register(apiMetrics.requestCounters); err != nil {
+		t.Fatalf("failed to register counters: %v", err)
+	}
+	mfs, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("failed to gather: %v", err)
+	}
+	return mfs
+}

--- a/pkg/wekafs/apiclient/requests.go
+++ b/pkg/wekafs/apiclient/requests.go
@@ -29,6 +29,23 @@ func (a *ApiClient) do(ctx context.Context, Method string, Path string, Payload 
 		return &ApiResponse{}, uErr
 	}
 
+	// status is overwritten as soon as the outcome is known; the initial value only survives if the
+	// function returns through a path that sets none.
+	status := "error"
+	startTime := time.Now()
+	defer func() {
+		labels := []string{
+			a.driverName,
+			a.ClusterGuid.String(),
+			a.getEndpoint(ctx).IpAddress,
+			Method,
+			generalizeUrlPathForMetrics(Path),
+			status,
+		}
+		apiMetrics.requestCounters.WithLabelValues(labels...).Inc()
+		apiMetrics.requestDurations.WithLabelValues(labels...).Observe(time.Since(startTime).Seconds())
+	}()
+
 	//construct base request and add auth if exists
 	var body *bytes.Reader
 	if Payload != nil {
@@ -75,11 +92,13 @@ func (a *ApiClient) do(ctx context.Context, Method string, Path string, Payload 
 
 	if err != nil {
 		endpoint.transportErrCount.Add(1)
+		status = "transport_error"
 		return nil, &transportError{err}
 	}
 
 	if response == nil {
 		endpoint.noRespCount.Add(1)
+		status = "no_response_from_server"
 		return nil, &transportError{errors.New("received no response")}
 	}
 
@@ -93,6 +112,7 @@ func (a *ApiClient) do(ctx context.Context, Method string, Path string, Payload 
 	logger.Trace().Str("response", maskPayload(string(responseBody))).Msg("")
 	if err != nil {
 		endpoint.parseErrCount.Add(1)
+		status = "response_parse_error"
 		return nil, &ApiInternalError{
 			Err:         err,
 			Text:        fmt.Sprintf("Failed to parse response: %s", err.Error()),
@@ -111,6 +131,7 @@ func (a *ApiClient) do(ctx context.Context, Method string, Path string, Payload 
 	Response.HttpStatusCode = response.StatusCode
 	if err != nil {
 		endpoint.parseErrCount.Add(1)
+		status = "response_parse_error"
 		logger.Error().Err(err).Int("http_status_code", Response.HttpStatusCode).Msg("Could not parse response JSON")
 		return nil, &ApiError{
 			Err:         err,
@@ -120,6 +141,10 @@ func (a *ApiClient) do(ctx context.Context, Method string, Path string, Payload 
 			ApiResponse: Response,
 		}
 	}
+
+	// From here the HTTP status is known, so it becomes the metric's status. The switch below
+	// turns each code into a typed error, but they all share one label shape.
+	status = fmt.Sprintf("http_%d", response.StatusCode)
 
 	switch response.StatusCode {
 	case http.StatusOK: //200

--- a/pkg/wekafs/apistore.go
+++ b/pkg/wekafs/apistore.go
@@ -41,6 +41,9 @@ type ApiStore struct {
 	legacySecrets *map[string]string
 	config        *DriverConfig
 	Hostname      string
+	// driverName labels the API metrics recorded by clients this store creates. It is passed in
+	// rather than read from config.GetDriver(), which is still nil when the store is constructed.
+	driverName string
 }
 
 // getByHash returns pointer to existing API if found by hash, or nil
@@ -182,6 +185,7 @@ func (api *ApiStore) fromCredentials(ctx context.Context, credentials apiclient.
 	newClient, err := apiclient.NewApiClient(ctx, credentials, apiclient.ApiClientOptions{
 		AllowInsecureHttps: api.config.allowInsecureHttps,
 		Hostname:           hostname,
+		DriverName:         api.driverName,
 	})
 	if err != nil {
 		return nil, errors.New("could not create API client object from supplied params")
@@ -266,11 +270,12 @@ func (api *ApiStore) GetClientFromSecrets(ctx context.Context, secrets map[strin
 	return client, nil
 }
 
-func NewApiStore(config *DriverConfig, hostname string) *ApiStore {
+func NewApiStore(config *DriverConfig, hostname, driverName string) *ApiStore {
 	s := &ApiStore{
-		apis:     make(map[uint32]*apiclient.ApiClient),
-		config:   config,
-		Hostname: hostname,
+		apis:       make(map[uint32]*apiclient.ApiClient),
+		config:     config,
+		Hostname:   hostname,
+		driverName: driverName,
 	}
 	secrets, err := s.GetDefaultSecrets()
 	if err != nil {

--- a/pkg/wekafs/driver.go
+++ b/pkg/wekafs/driver.go
@@ -98,7 +98,7 @@ func NewWekaFsDriver(
 		version:           vendorVersion,
 		endpoint:          endpoint,
 		maxVolumesPerNode: maxVolumesPerNode,
-		api:               NewApiStore(config, nodeID),
+		api:               NewApiStore(config, nodeID, driverName),
 		debugPath:         debugPath,
 		csiMode:           csiMode, // either "controller", "node", "all"
 		selinuxSupport:    selinuxSupport,


### PR DESCRIPTION
### TL;DR
Adds Prometheus metrics for every Weka API request, plus PodMonitors so the Prometheus Operator scrapes them.

### What changed?
- New metrics `weka_csi_api_request_count` (counter) and `weka_csi_api_request_duration_seconds` (histogram), labeled by `csi_driver_name`, `cluster_guid`, `endpoint`, `method`, `url`, and `status`.
- `url` is a generalized path (UUIDs/numeric IDs replaced with placeholders) so it doesn't grow a new series per filesystem or snapshot.
- New Helm values `metrics.podMonitor.enabled`, `metrics.podMonitor.interval`, and `metrics.podMonitor.additionalLabels` for the new PodMonitor resources (rendered only when the Prometheus Operator CRDs are present).

### How to test?
1. Upgrade the chart with `metrics.enabled: true` (default); set `metrics.podMonitor.additionalLabels` to match your Prometheus instance's selector if needed.
2. Query `weka_csi_api_request_count` / `weka_csi_api_request_duration_seconds` after driving some volume operations.

### Why make this change?
API traffic and latency between the driver and the Weka cluster were previously only visible in logs. These metrics surface request volume, latency, and error rate per cluster directly in Prometheus/Grafana.
