### PR TITLE
feat: add timestamped Prometheus metric types with thread-safe vec support

### DIFF
--- a/pkg/wekafs/timedmetrics.go
+++ b/pkg/wekafs/timedmetrics.go
@@ -1,0 +1,389 @@
+package wekafs
+
+import (
+	"math"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// atomicFloat64 is a float64 usable without a lock, stored as its bit pattern. The standard library
+// has no atomic float, and these values are written by collection goroutines while a scrape reads
+// them.
+type atomicFloat64 struct{ bits atomic.Uint64 }
+
+func (f *atomicFloat64) Load() float64   { return math.Float64frombits(f.bits.Load()) }
+func (f *atomicFloat64) Store(v float64) { f.bits.Store(math.Float64bits(v)) }
+
+func (f *atomicFloat64) Add(delta float64) {
+	for {
+		old := f.bits.Load()
+		next := math.Float64bits(math.Float64frombits(old) + delta)
+		if f.bits.CompareAndSwap(old, next) {
+			return
+		}
+	}
+}
+
+// atomicTime holds a measurement time as Unix nanoseconds, where zero means "no timestamp was
+// recorded" and the sample is left for Prometheus to stamp at scrape time.
+type atomicTime struct{ nanos atomic.Int64 }
+
+func (t *atomicTime) Store(ts time.Time) {
+	if ts.IsZero() {
+		t.nanos.Store(0)
+		return
+	}
+	t.nanos.Store(ts.UnixNano())
+}
+
+func (t *atomicTime) Load() time.Time {
+	nanos := t.nanos.Load()
+	if nanos == 0 {
+		return time.Time{}
+	}
+	return time.Unix(0, nanos)
+}
+
+// Timed metrics carry the time their value was measured, rather than being stamped with the moment
+// Prometheus happens to scrape them.
+//
+// The driver reads much of what it exports from the Weka API on its own schedule, and serves it
+// from a cache in between. Exporting a quota fetched three minutes ago as though it were sampled at
+// scrape time would misdate it; every rate and every graph would attribute the change to the wrong
+// instant. These collectors attach the measurement's own timestamp instead, via
+// prometheus.NewMetricWithTimestamp.
+//
+// Writing a value without supplying a time records it as measured now, so the sample still carries
+// one. Only a metric that has never been written is exported untimestamped, leaving Prometheus to
+// stamp it at scrape time as usual.
+//
+// Note this requires the scrape config to honor timestamps, which is the default.
+
+// TimedGauge is a gauge that remembers when its value was measured.
+type TimedGauge struct {
+	desc   *prometheus.Desc
+	val    atomicFloat64
+	lastTs atomicTime
+	labels []string
+}
+
+func newTimedGauge(desc *prometheus.Desc, labels []string) *TimedGauge {
+	return &TimedGauge{desc: desc, labels: labels}
+}
+
+func NewTimedGauge(opts prometheus.GaugeOpts) *TimedGauge {
+	return newTimedGauge(timedDesc(opts.Namespace, opts.Subsystem, opts.Name, opts.Help, nil), nil)
+}
+
+// Set records a value measured now.
+func (tg *TimedGauge) Set(v float64) {
+	tg.SetWithTimestamp(v, time.Time{})
+}
+
+// SetWithTimestamp records a value along with the time it was measured. A zero ts means "now".
+func (tg *TimedGauge) SetWithTimestamp(v float64, ts time.Time) *prometheus.Desc {
+	tg.val.Store(v)
+	tg.lastTs.Store(orNow(ts))
+	return tg.desc
+}
+
+func (tg *TimedGauge) Describe(ch chan<- *prometheus.Desc) { ch <- tg.desc }
+
+func (tg *TimedGauge) Collect(ch chan<- prometheus.Metric) {
+	ch <- withTimestamp(
+		prometheus.MustNewConstMetric(tg.desc, prometheus.GaugeValue, tg.val.Load(), tg.labels...),
+		tg.lastTs.Load(),
+	)
+}
+
+// TimedCounter is a counter that remembers when its value was measured.
+type TimedCounter struct {
+	desc   *prometheus.Desc
+	val    atomicFloat64
+	lastTs atomicTime
+	labels []string
+}
+
+func newTimedCounter(desc *prometheus.Desc, labels []string) *TimedCounter {
+	return &TimedCounter{desc: desc, labels: labels}
+}
+
+func NewTimedCounter(opts prometheus.CounterOpts) *TimedCounter {
+	return newTimedCounter(timedDesc(opts.Namespace, opts.Subsystem, opts.Name, opts.Help, nil), nil)
+}
+
+func (tc *TimedCounter) Inc() { tc.Add(1) }
+
+func (tc *TimedCounter) Add(v float64) {
+	tc.val.Add(v)
+	tc.lastTs.Store(time.Now())
+}
+
+// AddWithTimestamp increases the counter and records when the increase was observed.
+func (tc *TimedCounter) AddWithTimestamp(v float64, ts time.Time) {
+	tc.val.Add(v)
+	tc.lastTs.Store(orNow(ts))
+}
+
+// Set overwrites the counter instead of increasing it.
+//
+// A Prometheus counter is normally monotonic and only ever added to. This exists for values that
+// are already accumulated on the other side - the Weka cluster's own counters - where the driver is
+// mirroring an external total rather than counting events itself. Mirroring keeps the series
+// correct across a driver restart, which re-counting from zero would not. Do not use it for
+// anything the driver counts itself.
+func (tc *TimedCounter) Set(v float64) {
+	tc.SetWithTimestamp(v, time.Time{})
+}
+
+// SetWithTimestamp overwrites the counter and records when the value was measured. See Set.
+func (tc *TimedCounter) SetWithTimestamp(v float64, ts time.Time) *prometheus.Desc {
+	tc.val.Store(v)
+	tc.lastTs.Store(orNow(ts))
+	return tc.desc
+}
+
+func (tc *TimedCounter) Describe(ch chan<- *prometheus.Desc) { ch <- tc.desc }
+
+func (tc *TimedCounter) Collect(ch chan<- prometheus.Metric) {
+	ch <- withTimestamp(
+		prometheus.MustNewConstMetric(tc.desc, prometheus.CounterValue, tc.val.Load(), tc.labels...),
+		tc.lastTs.Load(),
+	)
+}
+
+// TimedHistogram is a histogram that remembers when it was last observed into.
+type TimedHistogram struct {
+	desc       *prometheus.Desc
+	buckets    map[float64]*atomic.Uint64
+	bucketDefs []float64
+	sum        atomicFloat64
+	count      atomic.Uint64
+	lastTs     atomicTime
+	labels     []string
+}
+
+func newTimedHistogram(desc *prometheus.Desc, bucketDefs []float64, labels []string) *TimedHistogram {
+	buckets := make(map[float64]*atomic.Uint64, len(bucketDefs))
+	for _, b := range bucketDefs {
+		buckets[b] = new(atomic.Uint64)
+	}
+	return &TimedHistogram{
+		desc:       desc,
+		buckets:    buckets,
+		bucketDefs: bucketDefs,
+		labels:     labels,
+	}
+}
+
+func NewTimedHistogram(opts prometheus.HistogramOpts) *TimedHistogram {
+	return newTimedHistogram(
+		timedDesc(opts.Namespace, opts.Subsystem, opts.Name, opts.Help, nil), opts.Buckets, nil)
+}
+
+func (th *TimedHistogram) Observe(v float64) {
+	th.ObserveWithTimestamp(v, time.Time{})
+}
+
+// ObserveWithTimestamp records an observation along with the time it was taken.
+func (th *TimedHistogram) ObserveWithTimestamp(v float64, ts time.Time) {
+	th.count.Add(1)
+	th.sum.Add(v)
+	// Prometheus histogram buckets are cumulative: an observation counts in its own bucket and in
+	// every wider one.
+	for _, b := range th.bucketDefs {
+		if v <= b {
+			th.buckets[b].Add(1)
+		}
+	}
+	th.lastTs.Store(orNow(ts))
+}
+
+func (th *TimedHistogram) Describe(ch chan<- *prometheus.Desc) { ch <- th.desc }
+
+func (th *TimedHistogram) Collect(ch chan<- prometheus.Metric) {
+	buckets := make(map[float64]uint64, len(th.buckets))
+	for b, c := range th.buckets {
+		buckets[b] = c.Load()
+	}
+	ch <- withTimestamp(
+		prometheus.MustNewConstHistogram(th.desc, th.count.Load(), th.sum.Load(), buckets, th.labels...),
+		th.lastTs.Load(),
+	)
+}
+
+// timedMetric is what a vec holds: something that describes and collects itself.
+type timedMetric interface {
+	Describe(chan<- *prometheus.Desc)
+	Collect(chan<- prometheus.Metric)
+}
+
+// timedVec is the shared machinery behind the vec types: a set of child metrics keyed by label
+// values, created on first use.
+//
+// It exists so the locking is written once. Each vec type used to carry its own copy, and they
+// disagreed - one collected under a read lock, another collected with no lock at all, and a third
+// deleted with no lock. Iterating the map while another goroutine inserts into it is a fatal
+// runtime error, not a race the detector merely reports, and a Prometheus scrape calls Collect
+// concurrently with whatever is updating the metrics.
+type timedVec[T timedMetric] struct {
+	mu     sync.RWMutex
+	desc   *prometheus.Desc
+	values map[string]T
+	newVal func(labels []string) T
+}
+
+func newTimedVec[T timedMetric](desc *prometheus.Desc, newVal func(labels []string) T) timedVec[T] {
+	return timedVec[T]{
+		desc:   desc,
+		values: make(map[string]T),
+		newVal: newVal,
+	}
+}
+
+// key joins label values with a separator that cannot appear in one, so distinct label sets cannot
+// produce the same key. A hash would be smaller but could collide, silently merging two series.
+func labelsKey(values []string) string {
+	return strings.Join(values, "\x00")
+}
+
+func (v *timedVec[T]) withLabelValues(lv ...string) T {
+	key := labelsKey(lv)
+
+	v.mu.RLock()
+	existing, ok := v.values[key]
+	v.mu.RUnlock()
+	if ok {
+		return existing
+	}
+
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	// Re-check: another goroutine may have created it while the lock was not held. Returning the
+	// one already in the map keeps every caller updating the same child metric.
+	if existing, ok := v.values[key]; ok {
+		return existing
+	}
+	created := v.newVal(lv)
+	v.values[key] = created
+	return created
+}
+
+// DeleteLabelValues stops exporting the series for a label set, e.g. once its volume is gone.
+func (v *timedVec[T]) DeleteLabelValues(labelValues ...string) {
+	v.mu.Lock()
+	defer v.mu.Unlock()
+	delete(v.values, labelsKey(labelValues))
+}
+
+// Len reports how many series the vec currently exports.
+func (v *timedVec[T]) Len() int {
+	v.mu.RLock()
+	defer v.mu.RUnlock()
+	return len(v.values)
+}
+
+func (v *timedVec[T]) Describe(ch chan<- *prometheus.Desc) { ch <- v.desc }
+
+func (v *timedVec[T]) Collect(ch chan<- prometheus.Metric) {
+	// Collect the children into a slice under the lock, then send them without it: sending on the
+	// channel blocks until the registry reads, and holding the lock across that would stall every
+	// goroutine trying to record a metric for as long as the scrape takes.
+	v.mu.RLock()
+	children := make([]T, 0, len(v.values))
+	for _, child := range v.values {
+		children = append(children, child)
+	}
+	v.mu.RUnlock()
+
+	for _, child := range children {
+		child.Collect(ch)
+	}
+}
+
+// TimedGaugeVec is a set of TimedGauges, one per label combination.
+type TimedGaugeVec struct{ timedVec[*TimedGauge] }
+
+func NewTimedGaugeVec(opts prometheus.GaugeOpts, labels []string) *TimedGaugeVec {
+	desc := timedDesc(opts.Namespace, opts.Subsystem, opts.Name, opts.Help, labels)
+	return &TimedGaugeVec{newTimedVec(desc, func(lv []string) *TimedGauge {
+		return newTimedGauge(desc, lv)
+	})}
+}
+
+func (v *TimedGaugeVec) WithLabelValues(lv ...string) *TimedGauge { return v.withLabelValues(lv...) }
+
+// TimedCounterVec is a set of TimedCounters, one per label combination.
+type TimedCounterVec struct{ timedVec[*TimedCounter] }
+
+func NewTimedCounterVec(opts prometheus.CounterOpts, labels []string) *TimedCounterVec {
+	desc := timedDesc(opts.Namespace, opts.Subsystem, opts.Name, opts.Help, labels)
+	return &TimedCounterVec{newTimedVec(desc, func(lv []string) *TimedCounter {
+		return newTimedCounter(desc, lv)
+	})}
+}
+
+func (v *TimedCounterVec) WithLabelValues(lv ...string) *TimedCounter {
+	return v.withLabelValues(lv...)
+}
+
+// TimedHistogramVec is a set of TimedHistograms, one per label combination.
+type TimedHistogramVec struct{ timedVec[*TimedHistogram] }
+
+func NewTimedHistogramVec(opts prometheus.HistogramOpts, labels []string) *TimedHistogramVec {
+	desc := timedDesc(opts.Namespace, opts.Subsystem, opts.Name, opts.Help, labels)
+	buckets := opts.Buckets
+	return &TimedHistogramVec{newTimedVec(desc, func(lv []string) *TimedHistogram {
+		return newTimedHistogram(desc, buckets, lv)
+	})}
+}
+
+func (v *TimedHistogramVec) WithLabelValues(lv ...string) *TimedHistogram {
+	return v.withLabelValues(lv...)
+}
+
+// timedDesc builds the descriptor, marking the help text so a reader of the exposed metrics knows
+// the sample carries its own timestamp.
+func timedDesc(namespace, subsystem, name, help string, labels []string) *prometheus.Desc {
+	return prometheus.NewDesc(
+		prometheus.BuildFQName(namespace, subsystem, name),
+		help+" (timestamped)",
+		labels,
+		nil,
+	)
+}
+
+// orNow substitutes the current time for a zero timestamp, so callers that have no measurement time
+// can use the same setters.
+func orNow(ts time.Time) time.Time {
+	if ts.IsZero() {
+		return time.Now()
+	}
+	return ts
+}
+
+// withTimestamp attaches a measurement time to a metric, unless there is none to attach - in which
+// case Prometheus stamps it at scrape time.
+func withTimestamp(m prometheus.Metric, ts time.Time) prometheus.Metric {
+	if ts.IsZero() {
+		return m
+	}
+	return prometheus.NewMetricWithTimestamp(ts, m)
+}
+
+// NormalizeLabelName replaces characters that are not valid in a Prometheus label name.
+func NormalizeLabelName(str string) string {
+	return strings.NewReplacer("/", "_", "-", "_", ".", "_").Replace(str)
+}
+
+func NormalizeLabelNames(labels []string) []string {
+	normalized := make([]string, len(labels))
+	for i, label := range labels {
+		normalized[i] = NormalizeLabelName(label)
+	}
+	return normalized
+}

--- a/pkg/wekafs/timedmetrics_test.go
+++ b/pkg/wekafs/timedmetrics_test.go
@@ -1,0 +1,283 @@
+package wekafs
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+)
+
+// collect gathers everything a collector emits into dto form, which is what a scrape sees.
+func collect(t *testing.T, c prometheus.Collector) []*dto.Metric {
+	t.Helper()
+	ch := make(chan prometheus.Metric, 128)
+	go func() {
+		c.Collect(ch)
+		close(ch)
+	}()
+	var out []*dto.Metric
+	for m := range ch {
+		d := &dto.Metric{}
+		if err := m.Write(d); err != nil {
+			t.Fatalf("failed to write metric: %v", err)
+		}
+		out = append(out, d)
+	}
+	return out
+}
+
+func onlyMetric(t *testing.T, c prometheus.Collector) *dto.Metric {
+	t.Helper()
+	got := collect(t, c)
+	if len(got) != 1 {
+		t.Fatalf("expected exactly one metric, got %d", len(got))
+	}
+	return got[0]
+}
+
+// The point of the type: the measurement's own time is exported, not the scrape time.
+func TestTimedGaugeExportsMeasurementTimestamp(t *testing.T) {
+	measured := time.Date(2026, 3, 4, 5, 6, 7, 0, time.UTC)
+	g := NewTimedGauge(prometheus.GaugeOpts{Namespace: "weka", Name: "test_gauge", Help: "h"})
+	g.SetWithTimestamp(42, measured)
+
+	m := onlyMetric(t, g)
+	if got := m.GetTimestampMs(); got != measured.UnixMilli() {
+		t.Errorf("TimestampMs = %d, want %d (the time the value was measured)", got, measured.UnixMilli())
+	}
+	if got := m.GetGauge().GetValue(); got != 42 {
+		t.Errorf("value = %v, want 42", got)
+	}
+}
+
+// A gauge must be exported as a gauge whether or not a timestamp was supplied. The two paths
+// through Collect used to disagree, exporting the timestamped one as a counter.
+func TestTimedGaugeIsAGaugeOnBothPaths(t *testing.T) {
+	withTs := NewTimedGauge(prometheus.GaugeOpts{Namespace: "weka", Name: "g1", Help: "h"})
+	withTs.SetWithTimestamp(7, time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC))
+
+	withoutTs := NewTimedGauge(prometheus.GaugeOpts{Namespace: "weka", Name: "g2", Help: "h"})
+	withoutTs.SetWithTimestamp(7, time.Time{})
+
+	for name, g := range map[string]*TimedGauge{"timestamped": withTs, "untimestamped": withoutTs} {
+		m := onlyMetric(t, g)
+		if m.GetGauge() == nil {
+			t.Errorf("%s: metric is not a gauge (counter=%v)", name, m.GetCounter())
+		}
+		if m.GetCounter() != nil {
+			t.Errorf("%s: metric was exported as a counter", name)
+		}
+	}
+}
+
+// Set with a zero timestamp means "now", so the sample still carries a time.
+func TestTimedGaugeSetUsesNow(t *testing.T) {
+	g := NewTimedGauge(prometheus.GaugeOpts{Namespace: "weka", Name: "g", Help: "h"})
+	before := time.Now()
+	g.Set(1)
+	m := onlyMetric(t, g)
+	if m.GetTimestampMs() < before.UnixMilli() {
+		t.Errorf("TimestampMs = %d, want >= %d", m.GetTimestampMs(), before.UnixMilli())
+	}
+}
+
+func TestTimedCounterAddAndSet(t *testing.T) {
+	c := NewTimedCounter(prometheus.CounterOpts{Namespace: "weka", Name: "c", Help: "h"})
+	c.Inc()
+	c.Add(4)
+	if got := onlyMetric(t, c).GetCounter().GetValue(); got != 5 {
+		t.Errorf("after Inc+Add(4), value = %v, want 5", got)
+	}
+
+	// Set mirrors an externally accumulated total rather than counting up from here.
+	measured := time.Date(2026, 2, 2, 2, 2, 2, 0, time.UTC)
+	c.SetWithTimestamp(100, measured)
+	m := onlyMetric(t, c)
+	if got := m.GetCounter().GetValue(); got != 100 {
+		t.Errorf("after Set(100), value = %v, want 100", got)
+	}
+	if got := m.GetTimestampMs(); got != measured.UnixMilli() {
+		t.Errorf("TimestampMs = %d, want %d", got, measured.UnixMilli())
+	}
+}
+
+func TestTimedHistogramBucketsAreCumulative(t *testing.T) {
+	h := NewTimedHistogram(prometheus.HistogramOpts{
+		Namespace: "weka", Name: "h", Help: "h", Buckets: []float64{1, 5, 10},
+	})
+	for _, v := range []float64{0.5, 2, 7, 20} {
+		h.Observe(v)
+	}
+
+	m := onlyMetric(t, h)
+	if got := m.GetHistogram().GetSampleCount(); got != 4 {
+		t.Errorf("count = %d, want 4", got)
+	}
+	if got := m.GetHistogram().GetSampleSum(); got != 29.5 {
+		t.Errorf("sum = %v, want 29.5", got)
+	}
+	want := map[float64]uint64{1: 1, 5: 2, 10: 3} // cumulative: 20 falls outside every bucket
+	for _, b := range m.GetHistogram().GetBucket() {
+		if got := b.GetCumulativeCount(); got != want[b.GetUpperBound()] {
+			t.Errorf("bucket le=%v has %d, want %d", b.GetUpperBound(), got, want[b.GetUpperBound()])
+		}
+	}
+}
+
+func TestTimedVecLifecycle(t *testing.T) {
+	v := NewTimedGaugeVec(
+		prometheus.GaugeOpts{Namespace: "weka", Name: "v", Help: "h"},
+		[]string{"pv", "cluster"},
+	)
+	if got := v.Len(); got != 0 {
+		t.Fatalf("Len() = %d, want 0", got)
+	}
+
+	// The same label values must return the same child, or updates would be split across series.
+	first := v.WithLabelValues("pv-1", "c-1")
+	if again := v.WithLabelValues("pv-1", "c-1"); again != first {
+		t.Error("WithLabelValues returned a different child for the same labels")
+	}
+	if other := v.WithLabelValues("pv-2", "c-1"); other == first {
+		t.Error("WithLabelValues returned the same child for different labels")
+	}
+	if got := v.Len(); got != 2 {
+		t.Fatalf("Len() = %d, want 2", got)
+	}
+	if got := len(collect(t, v)); got != 2 {
+		t.Errorf("collected %d series, want 2", got)
+	}
+
+	v.DeleteLabelValues("pv-1", "c-1")
+	if got := v.Len(); got != 1 {
+		t.Errorf("after delete, Len() = %d, want 1", got)
+	}
+	if got := len(collect(t, v)); got != 1 {
+		t.Errorf("after delete, collected %d series, want 1", got)
+	}
+}
+
+// Label values must not be able to alias each other through the key used to index children.
+func TestTimedVecLabelKeysDoNotCollide(t *testing.T) {
+	v := NewTimedGaugeVec(prometheus.GaugeOpts{Namespace: "weka", Name: "k", Help: "h"},
+		[]string{"a", "b"})
+	if v.WithLabelValues("x", "yz") == v.WithLabelValues("xy", "z") {
+		t.Error(`{"x","yz"} and {"xy","z"} share a child`)
+	}
+	if got := v.Len(); got != 2 {
+		t.Errorf("Len() = %d, want 2", got)
+	}
+}
+
+// A scrape calls Collect while the driver is still recording. Iterating the children map while
+// another goroutine inserts into it is a fatal runtime error, not merely a reported race.
+func TestTimedVecConcurrentCollectAndUpdate(t *testing.T) {
+	gauges := NewTimedGaugeVec(prometheus.GaugeOpts{Namespace: "weka", Name: "cg", Help: "h"}, []string{"pv"})
+	counters := NewTimedCounterVec(prometheus.CounterOpts{Namespace: "weka", Name: "cc", Help: "h"}, []string{"pv"})
+	histograms := NewTimedHistogramVec(prometheus.HistogramOpts{
+		Namespace: "weka", Name: "ch", Help: "h", Buckets: []float64{1, 10},
+	}, []string{"pv"})
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+
+	// Scrapers.
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				for _, c := range []prometheus.Collector{gauges, counters, histograms} {
+					ch := make(chan prometheus.Metric, 512)
+					c.Collect(ch)
+					close(ch)
+					for range ch {
+					}
+				}
+			}
+		}()
+	}
+
+	// Writers, creating new label sets and deleting old ones as volumes come and go.
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			for j := 0; j < 200; j++ {
+				pv := fmt.Sprintf("pv-%d-%d", i, j%20)
+				gauges.WithLabelValues(pv).SetWithTimestamp(float64(j), time.Now())
+				counters.WithLabelValues(pv).Add(1)
+				histograms.WithLabelValues(pv).Observe(float64(j % 15))
+				if j%10 == 0 {
+					gauges.DeleteLabelValues(pv)
+					counters.DeleteLabelValues(pv)
+					histograms.DeleteLabelValues(pv)
+				}
+			}
+		}(i)
+	}
+
+	// Wait for writers, then stop the scrapers.
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+	time.Sleep(50 * time.Millisecond)
+	close(stop)
+	<-done
+}
+
+func TestNormalizeLabelNames(t *testing.T) {
+	for in, want := range map[string]string{
+		"weka/fs-name.thing": "weka_fs_name_thing",
+		"plain":              "plain",
+		"":                   "",
+	} {
+		if got := NormalizeLabelName(in); got != want {
+			t.Errorf("NormalizeLabelName(%q) = %q, want %q", in, got, want)
+		}
+	}
+	got := NormalizeLabelNames([]string{"a/b", "c-d"})
+	if len(got) != 2 || got[0] != "a_b" || got[1] != "c_d" {
+		t.Errorf("NormalizeLabelNames = %v, want [a_b c_d]", got)
+	}
+}
+
+// The collectors must satisfy prometheus.Collector, since they are registered as such.
+var (
+	_ prometheus.Collector = (*TimedGauge)(nil)
+	_ prometheus.Collector = (*TimedCounter)(nil)
+	_ prometheus.Collector = (*TimedHistogram)(nil)
+	_ prometheus.Collector = (*TimedGaugeVec)(nil)
+	_ prometheus.Collector = (*TimedCounterVec)(nil)
+	_ prometheus.Collector = (*TimedHistogramVec)(nil)
+)
+
+// A registry must accept them, which also exercises Describe.
+func TestTimedMetricsRegister(t *testing.T) {
+	reg := prometheus.NewRegistry()
+	for i, c := range []prometheus.Collector{
+		NewTimedGauge(prometheus.GaugeOpts{Namespace: "weka", Name: "rg", Help: "h"}),
+		NewTimedCounter(prometheus.CounterOpts{Namespace: "weka", Name: "rc", Help: "h"}),
+		NewTimedHistogram(prometheus.HistogramOpts{Namespace: "weka", Name: "rh", Help: "h", Buckets: []float64{1}}),
+		NewTimedGaugeVec(prometheus.GaugeOpts{Namespace: "weka", Name: "rgv", Help: "h"}, []string{"pv"}),
+		NewTimedCounterVec(prometheus.CounterOpts{Namespace: "weka", Name: "rcv", Help: "h"}, []string{"pv"}),
+		NewTimedHistogramVec(prometheus.HistogramOpts{Namespace: "weka", Name: "rhv", Help: "h", Buckets: []float64{1}}, []string{"pv"}),
+	} {
+		if err := reg.Register(c); err != nil {
+			t.Errorf("collector %d failed to register: %v", i, err)
+		}
+	}
+	if _, err := reg.Gather(); err != nil {
+		t.Errorf("Gather failed: %v", err)
+	}
+}


### PR DESCRIPTION
### TL;DR
Internal: adds Prometheus metric types that carry their own measurement timestamp instead of the scrape time. No user-visible change yet — nothing uses them in this PR.

### What changed?
- Added `TimedGauge`, `TimedCounter`, `TimedHistogram`, and vector variants, which attach a caller-supplied timestamp to each exported sample.
- Without a timestamp, a metric behaves like a normal Prometheus metric and gets stamped at scrape time.
- Fixed inconsistent locking across the vector types that could crash under concurrent scrape-and-update.

### How to test?
No behavior change yet; covered entirely by automated tests:
1. Run `go test -race ./pkg/wekafs/...`.

### Why make this change?
Several driver metrics (e.g. volume capacity/quota) are read from the Weka API on the driver's own schedule and served from a cache, so a scrape may see a value measured minutes earlier. Stamped with the scrape time, it misdates the sample and skews rates. Once adopted, a value will carry the time it was actually measured.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New, unused library code and tests only; no change to live metric export until a follow-up wires these in.
> 
> **Overview**
> Adds internal Prometheus collectors in `pkg/wekafs` so cached Weka API readings can be exported with **measurement time** via `prometheus.NewMetricWithTimestamp`, instead of scrape time.
> 
> Introduces **`TimedGauge`**, **`TimedCounter`**, **`TimedHistogram`**, and vector variants with `*WithTimestamp` APIs, a shared **`timedVec`** (safe concurrent scrape vs. label churn), and helpers **`NormalizeLabelName`**. Unwritten series are omitted so a scrape-time zero does not cause out-of-order drops under `honor_timestamps`; counters support **`Set`** for mirroring external totals.
> 
> Coverage is in **`timedmetrics_test.go`** (timestamps, pairing, histogram snapshots, vec concurrency). **No existing metrics are switched over in this PR.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2db290d1f19cc1d6ac23f98128fa226505fa18a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->