### PR TITLE
feat: add Prometheus metrics for controller and node server operations

### DIFF
--- a/cmd/wekafsplugin/main.go
+++ b/cmd/wekafsplugin/main.go
@@ -160,9 +160,17 @@ func main() {
 	log.Info().Str("csi_mode", string(csiMode)).Bool("selinux_mode", *selinuxSupport).Msg("Started CSI driver")
 
 	if enableMetrics != nil && *enableMetrics {
-		// The API client builds its collectors but does not register them, so that importing the
-		// package has no effect on any registry. Register them here, where /metrics is served.
+		// Collectors are built without registering themselves, so that importing a package has no
+		// effect on any registry. Register them here, where /metrics is served, and only for the
+		// role this process serves - a node pod exporting a permanently-zero set of controller
+		// series would be misleading.
 		prometheus.MustRegister(apiclient.Collectors()...)
+		if csiMode == wekafs.CsiModeController || csiMode == wekafs.CsiModeAll {
+			prometheus.MustRegister(wekafs.ControllerCollectors()...)
+		}
+		if csiMode == wekafs.CsiModeNode || csiMode == wekafs.CsiModeAll {
+			prometheus.MustRegister(wekafs.NodeCollectors()...)
+		}
 		go func() {
 			http.Handle("/metrics", promhttp.Handler())
 			if err := http.ListenAndServe(fmt.Sprintf(":%s", *metricsPort), nil); err != nil {
@@ -279,5 +287,6 @@ func handle(ctx context.Context) {
 		os.Exit(1)
 	}
 	config.SetDriver(driver)
+
 	driver.Run(ctx)
 }

--- a/pkg/wekafs/constants.go
+++ b/pkg/wekafs/constants.go
@@ -72,6 +72,16 @@ const (
 )
 
 const (
+	VolumeBackingTypeDirectory  VolumeBackingType = "DIRECTORY"
+	VolumeBackingTypeFilesystem VolumeBackingType = "FILESYSTEM"
+	VolumeBackingTypeSnapshot   VolumeBackingType = "SNAPSHOT"
+	VolumeBackingTypeHybrid     VolumeBackingType = "HYBRID"
+	// VolumeBackingTypeUnknown is used when a request failed before its volume was constructed, so
+	// the backing type was never determined.
+	VolumeBackingTypeUnknown VolumeBackingType = "UNKNOWN"
+)
+
+const (
 	selinuxContextWekaFs     = "wekafs_csi_volume_t"
 	selinuxContextNfs        = "nfs_t"
 	MountOptionSyncOnClose   = "sync_on_close"

--- a/pkg/wekafs/controllerserver.go
+++ b/pkg/wekafs/controllerserver.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"go.opentelemetry.io/otel"
@@ -203,17 +204,47 @@ func (cs *ControllerServer) acquireSemaphore(ctx context.Context, op string) (er
 	cs.initializeSemaphore(ctx, op)
 	sem := cs.semaphores[op]
 
+	// select the concurrency gauge + wait-duration histogram matching this operation
+	var histogram *prometheus.HistogramVec
+	var gauge *prometheus.GaugeVec
+	var driverName string
+	switch op {
+	case "CreateVolume":
+		histogram, gauge = controllerMetrics.Concurrency.CreateVolumeWaitDuration, controllerMetrics.Concurrency.CreateVolume
+	case "DeleteVolume":
+		histogram, gauge = controllerMetrics.Concurrency.DeleteVolumeWaitDuration, controllerMetrics.Concurrency.DeleteVolume
+	case "ExpandVolume":
+		histogram, gauge = controllerMetrics.Concurrency.ExpandVolumeWaitDuration, controllerMetrics.Concurrency.ExpandVolume
+	case "CreateSnapshot":
+		histogram, gauge = controllerMetrics.Concurrency.CreateSnapshotWaitDuration, controllerMetrics.Concurrency.CreateSnapshot
+	case "DeleteSnapshot":
+		histogram, gauge = controllerMetrics.Concurrency.DeleteSnapshotWaitDuration, controllerMetrics.Concurrency.DeleteSnapshot
+	}
+	driverName = cs.getConfig().GetDriver().name
+
 	logger.Trace().Msg("Acquiring semaphore")
 	start := time.Now()
 	err := sem.Acquire(ctx, 1)
 	elapsed := time.Since(start)
 	if err == nil {
+		if gauge != nil {
+			gauge.WithLabelValues(driverName, "acquired").Inc()
+		}
+		if histogram != nil {
+			histogram.WithLabelValues(driverName, "success").Observe(elapsed.Seconds())
+		}
 		logger.Trace().Dur("acquire_duration", elapsed).Str("op", op).Msg("Successfully acquired semaphore")
 		return nil, func() {
 			elapsed = time.Since(start)
 			logger.Trace().Dur("total_operation_time", elapsed).Str("op", op).Msg("Releasing semaphore")
 			sem.Release(1)
+			if gauge != nil {
+				gauge.WithLabelValues(driverName, "acquired").Dec()
+			}
 		}
+	}
+	if histogram != nil {
+		histogram.WithLabelValues(driverName, "failure").Observe(elapsed.Seconds())
 	}
 	logger.Trace().Dur("acquire_duration", elapsed).Str("op", op).Msg("Failed to acquire semaphore")
 	return err, func() {}
@@ -252,11 +283,24 @@ func (cs *ControllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 	logger := log.Ctx(ctx)
 	logger.Info().Str("name", req.GetName()).Fields(params).Msg(">>>> Received request")
 
+	start := time.Now()
+	var backingType VolumeBackingType
 	defer func() {
 		level := zerolog.InfoLevel
 		if result != "SUCCESS" {
 			level = zerolog.ErrorLevel
 		}
+		// backingType is only known once the volume has been constructed, so a request that
+		// failed before that point has none. Record it as unknown rather than skipping the
+		// sample: dropping it would hide exactly the early failures these counters exist to
+		// surface.
+		bt := string(backingType)
+		if bt == "" {
+			bt = string(VolumeBackingTypeUnknown)
+		}
+		driverName := cs.getConfig().GetDriver().name
+		controllerMetrics.Operations.CreateVolumeTotalCapacity.WithLabelValues(driverName, result, bt).Add(float64(req.GetCapacityRange().GetRequiredBytes()))
+		recordOperation(controllerMetrics.Operations.CreateVolumeCounter, controllerMetrics.Operations.CreateVolumeDuration, start, driverName, result, bt)
 		logger.WithLevel(level).Str("result", result).Msg("<<<< Completed processing request")
 	}()
 
@@ -282,6 +326,7 @@ func (cs *ControllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 	if volume == nil {
 		return CreateVolumeError(ctx, codes.Internal, "Could not initialize volume representation object from request")
 	}
+	backingType = volume.GetBackingType()
 
 	// check if with current API client state we can modify this volume or not
 	// (basically only legacy dirVolume with xAttr fallback can be operated without API client)
@@ -443,11 +488,23 @@ func (cs *ControllerServer) DeleteVolume(ctx context.Context, req *csi.DeleteVol
 	logger := log.Ctx(ctx)
 	result := "FAILURE"
 	logger.Info().Str("volume_id", volumeID).Msg(">>>> Received request")
+	start := time.Now()
+	var backingType VolumeBackingType
 	defer func() {
 		level := zerolog.InfoLevel
 		if result != "SUCCESS" {
 			level = zerolog.ErrorLevel
 		}
+		// backingType is only known once the volume has been constructed, so a request that
+		// failed before that point has none. Record it as unknown rather than skipping the
+		// sample: dropping it would hide exactly the early failures these counters exist to
+		// surface.
+		bt := string(backingType)
+		if bt == "" {
+			bt = string(VolumeBackingTypeUnknown)
+		}
+		driverName := cs.getConfig().GetDriver().name
+		recordOperation(controllerMetrics.Operations.DeleteVolumeCounter, controllerMetrics.Operations.DeleteVolumeDuration, start, driverName, result, bt)
 		logger.WithLevel(level).Str("result", result).Msg("<<<< Completed processing request")
 	}()
 
@@ -474,6 +531,7 @@ func (cs *ControllerServer) DeleteVolume(ctx context.Context, req *csi.DeleteVol
 		result = "SUCCESS"
 		return &csi.DeleteVolumeResponse{}, nil
 	}
+	backingType = volume.GetBackingType()
 
 	if err := cs.validateControllerServiceRequest(csi.ControllerServiceCapability_RPC_CREATE_DELETE_VOLUME); err != nil {
 		logger.Warn().Err(err).Msg("invalid delete volume request")
@@ -526,11 +584,26 @@ func (cs *ControllerServer) ControllerExpandVolume(ctx context.Context, req *csi
 		capacity = capRange.GetRequiredBytes()
 	}
 	logger.Info().Int64("capacity", capacity).Msg(">>>> Received request")
+	start := time.Now()
+	var backingType VolumeBackingType
 	defer func() {
 		level := zerolog.InfoLevel
 		if result != "SUCCESS" {
 			level = zerolog.ErrorLevel
 		}
+		// backingType is only known once the volume has been constructed, so a request that
+		// failed before that point has none. Record it as unknown rather than skipping the
+		// sample: dropping it would hide exactly the early failures these counters exist to
+		// surface.
+		bt := string(backingType)
+		if bt == "" {
+			bt = string(VolumeBackingTypeUnknown)
+		}
+		driverName := cs.getConfig().GetDriver().name
+		if capacity > 0 {
+			controllerMetrics.Operations.ExpandVolumeTotalCapacity.WithLabelValues(driverName, result, bt).Add(float64(capacity))
+		}
+		recordOperation(controllerMetrics.Operations.ExpandVolumeCounter, controllerMetrics.Operations.ExpandVolumeDuration, start, driverName, result, bt)
 		logger.WithLevel(level).Str("result", result).Msg("<<<< Completed processing request")
 	}()
 
@@ -560,6 +633,7 @@ func (cs *ControllerServer) ControllerExpandVolume(ctx context.Context, req *csi
 	if err != nil {
 		return ExpandVolumeError(ctx, codes.NotFound, fmt.Sprintf("Volume with id %s does not exist", req.GetVolumeId()))
 	}
+	backingType = volume.GetBackingType()
 
 	maxStorageCapacity, err := volume.getMaxCapacity(ctx)
 	if err != nil {
@@ -621,11 +695,14 @@ func (cs *ControllerServer) CreateSnapshot(ctx context.Context, req *csi.CreateS
 	logger := log.Ctx(ctx)
 	result := "FAILURE"
 	logger.Info().Str("src_volume_id", srcVolumeId).Str("name", snapName).Msg(">>>> Received request")
+	start := time.Now()
 	defer func() {
 		level := zerolog.InfoLevel
 		if result != "SUCCESS" {
 			level = zerolog.ErrorLevel
 		}
+		driverName := cs.getConfig().GetDriver().name
+		recordOperation(controllerMetrics.Operations.CreateSnapshotCounter, controllerMetrics.Operations.CreateSnapshotDuration, start, driverName, result)
 		logger.WithLevel(level).Str("result", result).Msg("<<<< Completed processing request")
 	}()
 
@@ -693,11 +770,14 @@ func (cs *ControllerServer) DeleteSnapshot(ctx context.Context, req *csi.DeleteS
 	logger := log.Ctx(ctx)
 	result := "FAILURE"
 	logger.Info().Str("snapshot_id", snapshotID).Msg(">>>> Received request")
+	start := time.Now()
 	defer func() {
 		level := zerolog.InfoLevel
 		if result != "SUCCESS" {
 			level = zerolog.ErrorLevel
 		}
+		driverName := cs.getConfig().GetDriver().name
+		recordOperation(controllerMetrics.Operations.DeleteSnapshotCounter, controllerMetrics.Operations.DeleteSnapshotDuration, start, driverName, result)
 		logger.WithLevel(level).Str("result", result).Msg("<<<< Completed processing request")
 	}()
 

--- a/pkg/wekafs/interfaces.go
+++ b/pkg/wekafs/interfaces.go
@@ -59,4 +59,8 @@ type AnyMount interface {
 
 type VolumeType string
 
+// VolumeBackingType classifies how a volume is physically backed (plain filesystem, legacy
+// directory, snapshot, or a directory rooted on a snapshot), used only as a metrics label.
+type VolumeBackingType string
+
 type CsiPluginMode string

--- a/pkg/wekafs/metrics.go
+++ b/pkg/wekafs/metrics.go
@@ -1,0 +1,249 @@
+package wekafs
+
+import (
+	"slices"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	CsiCommonLabels                             = []string{"csi_driver_name"}
+	CsiControllerConcurrencyMetricsLabels       = []string{"status"}
+	CsiControllerVolumeOperationMetricsLabels   = []string{"status", "backing_type"}
+	CsiControllerSnapshotOperationMetricsLabels = []string{"status"}
+	CsiNodeConcurrencyMetricsLabels             = []string{"status"}
+	CsiNodeVolumeOperationMetricsLabels         = []string{"status"}
+)
+
+const MetricsPrefix = "weka_csi"
+
+// There is one controller server and one node server per process, so the metrics they record are
+// process-wide, exactly like the API client's. Constructing them has no side effect; nothing is
+// exported until something registers the collectors, which is what ControllerCollectors and
+// NodeCollectors are for. Registering only the role this process actually serves keeps a node pod
+// from exporting a permanently-zero set of controller series, and vice versa.
+var (
+	controllerMetrics = NewControllerServerMetrics()
+	nodeMetrics       = NewNodeServerMetrics()
+)
+
+// The metric declarations below differ only in name, help and which labels they carry, so the
+// shared opts live here rather than being spelled out 32 times.
+func newCounterVec(subsystem, name, help string, labels []string) *prometheus.CounterVec {
+	return prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: MetricsPrefix, Subsystem: subsystem, Name: name, Help: help,
+	}, slices.Concat(CsiCommonLabels, labels))
+}
+
+func newHistogramVec(subsystem, name, help string, labels []string) *prometheus.HistogramVec {
+	return prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Namespace: MetricsPrefix, Subsystem: subsystem, Name: name, Help: help,
+	}, slices.Concat(CsiCommonLabels, labels))
+}
+
+func newGaugeVec(subsystem, name, help string, labels []string) *prometheus.GaugeVec {
+	return prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: MetricsPrefix, Subsystem: subsystem, Name: name, Help: help,
+	}, slices.Concat(CsiCommonLabels, labels))
+}
+
+// recordOperation records one finished operation: its outcome on the counter and how long it took
+// on the histogram, under the same labels. The two always move together, and keeping them in one
+// place stops the pair drifting apart across the handlers that record them.
+func recordOperation(counter *prometheus.CounterVec, duration *prometheus.HistogramVec, start time.Time, labels ...string) {
+	counter.WithLabelValues(labels...).Inc()
+	duration.WithLabelValues(labels...).Observe(time.Since(start).Seconds())
+}
+
+// ControllerCollectors returns the controller server metrics for the caller to register.
+func ControllerCollectors() []prometheus.Collector { return controllerMetrics.Collectors() }
+
+// NodeCollectors returns the node server metrics for the caller to register.
+func NodeCollectors() []prometheus.Collector { return nodeMetrics.Collectors() }
+
+type ControllerOperationMetrics struct {
+	CreateVolumeCounter       *prometheus.CounterVec
+	CreateVolumeDuration      *prometheus.HistogramVec
+	CreateVolumeTotalCapacity *prometheus.CounterVec
+	DeleteVolumeCounter       *prometheus.CounterVec
+	DeleteVolumeDuration      *prometheus.HistogramVec
+	ExpandVolumeCounter       *prometheus.CounterVec
+	ExpandVolumeDuration      *prometheus.HistogramVec
+	ExpandVolumeTotalCapacity *prometheus.CounterVec
+	CreateSnapshotCounter     *prometheus.CounterVec
+	CreateSnapshotDuration    *prometheus.HistogramVec
+	DeleteSnapshotCounter     *prometheus.CounterVec
+	DeleteSnapshotDuration    *prometheus.HistogramVec
+}
+
+// Collectors returns the metrics for the caller to register.
+func (c *ControllerOperationMetrics) Collectors() []prometheus.Collector {
+	return []prometheus.Collector{
+		c.CreateVolumeCounter,
+		c.CreateVolumeDuration,
+		c.CreateVolumeTotalCapacity,
+		c.DeleteVolumeCounter,
+		c.DeleteVolumeDuration,
+		c.ExpandVolumeCounter,
+		c.ExpandVolumeDuration,
+		c.ExpandVolumeTotalCapacity,
+		c.CreateSnapshotCounter,
+		c.CreateSnapshotDuration,
+		c.DeleteSnapshotCounter,
+		c.DeleteSnapshotDuration,
+	}
+}
+
+func NewControllerOperationMetrics(volumeLabels, snapshotLabels []string) *ControllerOperationMetrics {
+	return &ControllerOperationMetrics{
+		CreateVolumeCounter:       newCounterVec("controller", "create_volume_total", "Total number of ControllerCreateVolume calls", volumeLabels),
+		CreateVolumeDuration:      newHistogramVec("controller", "create_volume_duration_seconds", "Duration of ControllerCreateVolume calls in seconds", volumeLabels),
+		CreateVolumeTotalCapacity: newCounterVec("controller", "create_volume_total_capacity_bytes", "Total capacity of volumes created by ControllerCreateVolume in bytes", volumeLabels),
+		DeleteVolumeCounter:       newCounterVec("controller", "delete_volume_total", "Total number of ControllerDeleteVolume calls", volumeLabels),
+		DeleteVolumeDuration:      newHistogramVec("controller", "delete_volume_duration_seconds", "Duration of ControllerDeleteVolume calls in seconds", volumeLabels),
+		ExpandVolumeCounter:       newCounterVec("controller", "expand_volume_total", "Total number of ControllerExpandVolume calls", volumeLabels),
+		ExpandVolumeDuration:      newHistogramVec("controller", "expand_volume_duration_seconds", "Duration of ControllerExpandVolume calls in seconds", volumeLabels),
+		ExpandVolumeTotalCapacity: newCounterVec("controller", "expand_volume_total_capacity_bytes", "Total capacity of volumes expanded by ControllerExpandVolume in bytes", volumeLabels),
+		CreateSnapshotCounter:     newCounterVec("controller", "create_snapshot_total", "Total number of ControllerCreateSnapshot calls", snapshotLabels),
+		CreateSnapshotDuration:    newHistogramVec("controller", "create_snapshot_duration_seconds", "Duration of ControllerCreateSnapshot calls in seconds", snapshotLabels),
+		DeleteSnapshotCounter:     newCounterVec("controller", "delete_snapshot_total", "Total number of ControllerDeleteSnapshot calls", snapshotLabels),
+		DeleteSnapshotDuration:    newHistogramVec("controller", "delete_snapshot_duration_seconds", "Duration of ControllerDeleteSnapshot calls in seconds", snapshotLabels),
+	}
+}
+
+type ControllerConcurrencyMetrics struct {
+	CreateVolume               *prometheus.GaugeVec
+	DeleteVolume               *prometheus.GaugeVec
+	ExpandVolume               *prometheus.GaugeVec
+	CreateSnapshot             *prometheus.GaugeVec
+	DeleteSnapshot             *prometheus.GaugeVec
+	CreateVolumeWaitDuration   *prometheus.HistogramVec
+	DeleteVolumeWaitDuration   *prometheus.HistogramVec
+	ExpandVolumeWaitDuration   *prometheus.HistogramVec
+	CreateSnapshotWaitDuration *prometheus.HistogramVec
+	DeleteSnapshotWaitDuration *prometheus.HistogramVec
+}
+
+func NewControllerConcurrencyMetrics(labels []string) *ControllerConcurrencyMetrics {
+	return &ControllerConcurrencyMetrics{
+		CreateVolume:               newGaugeVec("controller", "concurrency_create_volume", "Current number of concurrent ControllerCreateVolume operations", labels),
+		DeleteVolume:               newGaugeVec("controller", "concurrency_delete_volume", "Current number of concurrent ControllerDeleteVolume operations", labels),
+		ExpandVolume:               newGaugeVec("controller", "concurrency_expand_volume", "Current number of concurrent ControllerExpandVolume operations", labels),
+		CreateSnapshot:             newGaugeVec("controller", "concurrency_create_snapshot", "Current number of concurrent ControllerCreateSnapshot operations", labels),
+		DeleteSnapshot:             newGaugeVec("controller", "concurrency_delete_snapshot", "Current number of concurrent ControllerDeleteSnapshot operations", labels),
+		CreateVolumeWaitDuration:   newHistogramVec("controller", "concurrency_create_volume_wait_duration_seconds", "Duration of waiting for ControllerCreateVolume semaphore in seconds", labels),
+		DeleteVolumeWaitDuration:   newHistogramVec("controller", "concurrency_delete_volume_wait_duration_seconds", "Duration of waiting for ControllerDeleteVolume semaphore in seconds", labels),
+		ExpandVolumeWaitDuration:   newHistogramVec("controller", "concurrency_expand_volume_wait_duration_seconds", "Duration of waiting for ControllerExpandVolume semaphore in seconds", labels),
+		CreateSnapshotWaitDuration: newHistogramVec("controller", "concurrency_create_snapshot_wait_duration_seconds", "Duration of waiting for ControllerCreateSnapshot semaphore in seconds", labels),
+		DeleteSnapshotWaitDuration: newHistogramVec("controller", "concurrency_delete_snapshot_wait_duration_seconds", "Duration of waiting for ControllerDeleteSnapshot semaphore in seconds", labels),
+	}
+}
+
+// Collectors returns the metrics for the caller to register.
+func (c *ControllerConcurrencyMetrics) Collectors() []prometheus.Collector {
+	return []prometheus.Collector{
+		c.CreateVolume,
+		c.DeleteVolume,
+		c.ExpandVolume,
+		c.CreateSnapshot,
+		c.DeleteSnapshot,
+		c.CreateVolumeWaitDuration,
+		c.DeleteVolumeWaitDuration,
+		c.ExpandVolumeWaitDuration,
+		c.CreateSnapshotWaitDuration,
+		c.DeleteSnapshotWaitDuration,
+	}
+}
+
+type ControllerServerMetrics struct {
+	Concurrency *ControllerConcurrencyMetrics
+	Operations  *ControllerOperationMetrics
+}
+
+func NewControllerServerMetrics() *ControllerServerMetrics {
+	return &ControllerServerMetrics{
+		Operations:  NewControllerOperationMetrics(CsiControllerVolumeOperationMetricsLabels, CsiControllerSnapshotOperationMetricsLabels),
+		Concurrency: NewControllerConcurrencyMetrics(CsiControllerConcurrencyMetricsLabels),
+	}
+}
+
+// Collectors returns every controller metric for the caller to register.
+func (m *ControllerServerMetrics) Collectors() []prometheus.Collector {
+	return append(m.Operations.Collectors(), m.Concurrency.Collectors()...)
+}
+
+type NodeServerConcurrencyMetrics struct {
+	PublishVolume               *prometheus.GaugeVec
+	UnpublishVolume             *prometheus.GaugeVec
+	PublishVolumeWaitDuration   *prometheus.HistogramVec
+	UnpublishVolumeWaitDuration *prometheus.HistogramVec
+}
+
+// Collectors returns the metrics for the caller to register.
+func (m *NodeServerConcurrencyMetrics) Collectors() []prometheus.Collector {
+	return []prometheus.Collector{
+		m.PublishVolume,
+		m.UnpublishVolume,
+		m.PublishVolumeWaitDuration,
+		m.UnpublishVolumeWaitDuration,
+	}
+}
+
+func NewNodeConcurrencyMetrics(labels []string) *NodeServerConcurrencyMetrics {
+	return &NodeServerConcurrencyMetrics{
+		PublishVolume:               newGaugeVec("node", "concurrency_node_publish_volume", "Current number of concurrent NodePublishVolume operations", labels),
+		UnpublishVolume:             newGaugeVec("node", "concurrency_node_unpublish_volume", "Current number of concurrent NodeUnpublishVolume operations", labels),
+		PublishVolumeWaitDuration:   newHistogramVec("node", "concurrency_node_publish_volume_wait_duration_seconds", "Duration of waiting for NodePublishVolume semaphore in seconds", labels),
+		UnpublishVolumeWaitDuration: newHistogramVec("node", "concurrency_node_unpublish_volume_wait_duration_seconds", "Duration of waiting for NodeUnpublishVolume semaphore in seconds", labels),
+	}
+}
+
+type NodeServerOperationMetrics struct {
+	PublishVolume           *prometheus.CounterVec
+	PublishVolumeDuration   *prometheus.HistogramVec
+	UnpublishVolume         *prometheus.CounterVec
+	UnpublishVolumeDuration *prometheus.HistogramVec
+	GetVolumeStats          *prometheus.CounterVec
+	GetVolumeStatsDuration  *prometheus.HistogramVec
+}
+
+// Collectors returns the metrics for the caller to register.
+func (m *NodeServerOperationMetrics) Collectors() []prometheus.Collector {
+	return []prometheus.Collector{
+		m.PublishVolume,
+		m.UnpublishVolume,
+		m.PublishVolumeDuration,
+		m.UnpublishVolumeDuration,
+		m.GetVolumeStats,
+		m.GetVolumeStatsDuration,
+	}
+}
+
+func NewNodeOperationMetrics(volumeLabels []string) *NodeServerOperationMetrics {
+	return &NodeServerOperationMetrics{
+		PublishVolume:           newCounterVec("node", "publish_volume_total", "Total number of NodePublishVolume calls", volumeLabels),
+		PublishVolumeDuration:   newHistogramVec("node", "publish_volume_duration_seconds", "Duration of NodePublishVolume calls in seconds", volumeLabels),
+		UnpublishVolume:         newCounterVec("node", "unpublish_volume_total", "Total number of NodeUnpublishVolume calls", volumeLabels),
+		UnpublishVolumeDuration: newHistogramVec("node", "unpublish_volume_duration_seconds", "Duration of NodeUnpublishVolume calls in seconds", volumeLabels),
+		GetVolumeStats:          newCounterVec("node", "get_volume_stats_total", "Total number of NodeGetVolumeStats calls", volumeLabels),
+		GetVolumeStatsDuration:  newHistogramVec("node", "get_volume_stats_duration_seconds", "Duration of NodeGetVolumeStats calls in seconds", volumeLabels),
+	}
+}
+
+type NodeServerMetrics struct {
+	Concurrency *NodeServerConcurrencyMetrics
+	Operations  *NodeServerOperationMetrics
+}
+
+func NewNodeServerMetrics() *NodeServerMetrics {
+	return &NodeServerMetrics{
+		Operations:  NewNodeOperationMetrics(CsiNodeVolumeOperationMetricsLabels),
+		Concurrency: NewNodeConcurrencyMetrics(CsiNodeConcurrencyMetricsLabels),
+	}
+}
+
+// Collectors returns every node metric for the caller to register.
+func (m *NodeServerMetrics) Collectors() []prometheus.Collector {
+	return append(m.Operations.Collectors(), m.Concurrency.Collectors()...)
+}

--- a/pkg/wekafs/nodeserver.go
+++ b/pkg/wekafs/nodeserver.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"go.opentelemetry.io/otel"
@@ -119,6 +120,13 @@ func (ns *NodeServer) NodeGetVolumeStats(ctx context.Context, req *csi.NodeGetVo
 		return nil, status.Errorf(codes.InvalidArgument, "invalid volume ID %s: %v", volumeID, err)
 	}
 
+	start := time.Now()
+	result := "FAILURE"
+	defer func() {
+		driverName := ns.getConfig().GetDriver().name
+		recordOperation(nodeMetrics.Operations.GetVolumeStats, nodeMetrics.Operations.GetVolumeStatsDuration, start, driverName, result)
+	}()
+
 	stats, err := getVolumeStats(volumePath)
 	if err != nil || stats == nil {
 		return &csi.NodeGetVolumeStatsResponse{
@@ -129,6 +137,7 @@ func (ns *NodeServer) NodeGetVolumeStats(ctx context.Context, req *csi.NodeGetVo
 			},
 		}, status.Errorf(codes.Internal, "Failed to get stats for volume %s: %v", volumeID, err)
 	}
+	result = "SUCCESS"
 	// Prepare response
 	return &csi.NodeGetVolumeStatsResponse{
 		Usage: []*csi.VolumeUsage{
@@ -205,17 +214,41 @@ func (ns *NodeServer) acquireSemaphore(ctx context.Context, op string) (error, r
 	ns.initializeSemaphore(ctx, op)
 	sem := ns.semaphores[op]
 
+	// select the concurrency gauge + wait-duration histogram matching this operation
+	var histogram *prometheus.HistogramVec
+	var gauge *prometheus.GaugeVec
+	var driverName string
+	switch op {
+	case "NodePublishVolume":
+		histogram, gauge = nodeMetrics.Concurrency.PublishVolumeWaitDuration, nodeMetrics.Concurrency.PublishVolume
+	case "NodeUnpublishVolume":
+		histogram, gauge = nodeMetrics.Concurrency.UnpublishVolumeWaitDuration, nodeMetrics.Concurrency.UnpublishVolume
+	}
+	driverName = ns.getConfig().GetDriver().name
+
 	logger.Trace().Msg("Acquiring semaphore")
 	start := time.Now()
 	err := sem.Acquire(ctx, 1)
 	elapsed := time.Since(start)
 	if err == nil {
+		if gauge != nil {
+			gauge.WithLabelValues(driverName, "acquired").Inc()
+		}
+		if histogram != nil {
+			histogram.WithLabelValues(driverName, "success").Observe(elapsed.Seconds())
+		}
 		logger.Trace().Dur("acquire_duration", elapsed).Str("op", op).Msg("Successfully acquired semaphore")
 		return nil, func() {
 			elapsed = time.Since(start)
 			logger.Trace().Dur("total_operation_time", elapsed).Str("op", op).Msg("Releasing semaphore")
 			sem.Release(1)
+			if gauge != nil {
+				gauge.WithLabelValues(driverName, "acquired").Dec()
+			}
 		}
+	}
+	if histogram != nil {
+		histogram.WithLabelValues(driverName, "failure").Observe(elapsed.Seconds())
 	}
 	logger.Trace().Dur("acquire_duration", elapsed).Str("op", op).Msg("Failed to acquire semaphore")
 	return err, func() {}
@@ -300,11 +333,14 @@ func (ns *NodeServer) NodePublishVolume(ctx context.Context, req *csi.NodePublis
 	result := "FAILURE"
 
 	logger.Info().Str("volume_id", volumeID).Msg(">>>> Received request")
+	start := time.Now()
 	defer func() {
 		level := zerolog.InfoLevel
 		if result != "SUCCESS" {
 			level = zerolog.ErrorLevel
 		}
+		driverName := ns.getConfig().GetDriver().name
+		recordOperation(nodeMetrics.Operations.PublishVolume, nodeMetrics.Operations.PublishVolumeDuration, start, driverName, result)
 		logger.WithLevel(level).Str("result", result).Msg("<<<< Completed processing request")
 	}()
 
@@ -490,11 +526,14 @@ func (ns *NodeServer) NodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpu
 
 	logger := log.Ctx(ctx)
 	logger.Info().Msg(">>>> Received request")
+	start := time.Now()
 	defer func() {
 		level := zerolog.InfoLevel
 		if result != "SUCCESS" {
 			level = zerolog.ErrorLevel
 		}
+		driverName := ns.getConfig().GetDriver().name
+		recordOperation(nodeMetrics.Operations.UnpublishVolume, nodeMetrics.Operations.UnpublishVolumeDuration, start, driverName, result)
 		logger.WithLevel(level).Str("result", result).Msg("<<<< Completed processing request")
 	}()
 

--- a/pkg/wekafs/volume.go
+++ b/pkg/wekafs/volume.go
@@ -178,6 +178,20 @@ func (v *Volume) isFilesystem() bool {
 	return !v.isOnSnapshot() && !v.hasInnerPath()
 }
 
+// GetBackingType classifies how the volume is physically backed, for use as a metrics label.
+func (v *Volume) GetBackingType() VolumeBackingType {
+	if v.isOnSnapshot() {
+		if v.hasInnerPath() {
+			return VolumeBackingTypeHybrid
+		}
+		return VolumeBackingTypeSnapshot
+	}
+	if v.hasInnerPath() {
+		return VolumeBackingTypeDirectory
+	}
+	return VolumeBackingTypeFilesystem
+}
+
 // isEncrypted returns true if the volume is encrypted or false if it is not. If fetching the encryption status fails, an error is returned
 func (v *Volume) isEncrypted(ctx context.Context) (bool, error) {
 	if v.encrypted != nil {


### PR DESCRIPTION
### TL;DR
Adds Prometheus metrics for controller and node CSI operations: counts, durations, concurrency, and capacity.

### What changed?
- Counter + duration histogram pairs for `CreateVolume`, `DeleteVolume`, `ExpandVolume`, `CreateSnapshot`, `DeleteSnapshot`, `NodePublishVolume`, `NodeUnpublishVolume`, `NodeGetVolumeStats` (e.g. `weka_csi_controller_create_volume_total`, `weka_csi_node_publish_volume_duration_seconds`).
- Cumulative capacity counters for volume create/expand, e.g. `weka_csi_controller_create_volume_total_capacity_bytes`.
- Concurrency gauges and semaphore wait-duration histograms per operation.
- Operations are labeled `backing_type` (`DIRECTORY`, `FILESYSTEM`, `SNAPSHOT`, `HYBRID`, or `UNKNOWN` for failures before the volume type is known).
- Controller pods export only controller metrics, node pods only node metrics.

### How to test?
1. Deploy the driver and perform PVC create/expand/delete, snapshot create/delete, and pod mount/unmount.
2. Query the new metrics on `/metrics` or in Prometheus.

### Why make this change?
Controller and node pods previously exported only Go runtime metrics, with no visibility into CSI operation counts, latency, or concurrency. This gives operators dashboards and alerts on CSI operation health.
