### PR TITLE
feat: add thread-safe ObservedFilesystems and VolumeMetrics indexes for metrics server

### DIFF
--- a/pkg/wekafs/observedfilesystems.go
+++ b/pkg/wekafs/observedfilesystems.go
@@ -1,0 +1,197 @@
+package wekafs
+
+import (
+	"context"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/wekafs/csi-wekafs/pkg/wekafs/apiclient"
+)
+
+// ObservedFilesystem is one filesystem the metrics server is watching, and the API client that can
+// reach it. It is reference counted by the volumes living on it, so the filesystem stops being
+// polled once the last of them goes away.
+type ObservedFilesystem struct {
+	mu        sync.Mutex
+	apiClient *apiclient.ApiClient
+	fsUid     uuid.UUID
+	fsObj     *apiclient.FileSystem
+	// fsObjFetched is when fsObj was last read from the cluster. Staleness is measured from the
+	// fetch, not from when a volume last referenced the filesystem: keying it off the reference
+	// would mean a filesystem with active volumes never refreshed, because referencing it kept
+	// resetting the clock.
+	fsObjFetched    time.Time
+	lastSeen        time.Time
+	lastQuotaUpdate time.Time
+	refCount        int
+}
+
+// GetApiClient returns the API client for this filesystem.
+func (of *ObservedFilesystem) GetApiClient() *apiclient.ApiClient {
+	of.mu.Lock()
+	defer of.mu.Unlock()
+	return of.apiClient
+}
+
+// Uid returns the filesystem's uid.
+func (of *ObservedFilesystem) Uid() uuid.UUID { return of.fsUid }
+
+// LastQuotaUpdate returns when this filesystem's quotas were last refreshed.
+func (of *ObservedFilesystem) LastQuotaUpdate() time.Time {
+	of.mu.Lock()
+	defer of.mu.Unlock()
+	return of.lastQuotaUpdate
+}
+
+// MarkQuotaUpdated records that the filesystem's quotas have just been refreshed.
+func (of *ObservedFilesystem) MarkQuotaUpdated(at time.Time) {
+	of.mu.Lock()
+	defer of.mu.Unlock()
+	of.lastQuotaUpdate = at
+}
+
+// GetFileSystem returns the filesystem object, refetching it when the cached copy is older than
+// maxAge. A zero maxAge always refetches.
+//
+// The lock is deliberately not held across the request: a filesystem lookup can take as long as the
+// cluster takes to answer, and holding it would stall every other caller for that whole time. Two
+// callers arriving together may both fetch; they converge on the same answer.
+func (of *ObservedFilesystem) GetFileSystem(ctx context.Context, maxAge time.Duration) (*apiclient.FileSystem, error) {
+	of.mu.Lock()
+	cached, fetched, client := of.fsObj, of.fsObjFetched, of.apiClient
+	of.mu.Unlock()
+
+	if cached != nil && maxAge > 0 && time.Since(fetched) < maxAge {
+		return cached, nil
+	}
+
+	// Fetch into a fresh object rather than the cached one: GetFileSystemByUid unmarshals into the
+	// value it is given, so passing a nil cached pointer would fail every time and the cache could
+	// never recover once it had been cleared.
+	fresh := &apiclient.FileSystem{}
+	if err := client.GetFileSystemByUid(ctx, of.fsUid, fresh, false); err != nil {
+		return nil, err
+	}
+
+	of.mu.Lock()
+	of.fsObj = fresh
+	of.fsObjFetched = time.Now()
+	of.mu.Unlock()
+	return fresh, nil
+}
+
+// ObservedFilesystems is the set of filesystems currently backing at least one observed volume.
+type ObservedFilesystems struct {
+	mu   sync.RWMutex
+	uids map[uuid.UUID]*ObservedFilesystem
+}
+
+func NewObservedFilesystems() *ObservedFilesystems {
+	return &ObservedFilesystems{uids: make(map[uuid.UUID]*ObservedFilesystem)}
+}
+
+// IncRef records that one more volume lives on this filesystem, adding it to the observed set if it
+// is the first.
+//
+// The lookup and the insert happen under one lock. Splitting them - as the version this was ported
+// from did, reading under a read lock and then inserting under a write lock - lets two goroutines
+// both miss and both insert, so the second overwrites the first and resets a reference count that
+// another volume was already counted in. The filesystem then stops being observed while volumes are
+// still using it.
+func (ofs *ObservedFilesystems) IncRef(fs *apiclient.FileSystem, apiClient *apiclient.ApiClient) {
+	if fs == nil || fs.Uid == uuid.Nil {
+		return
+	}
+	now := time.Now()
+
+	ofs.mu.Lock()
+	defer ofs.mu.Unlock()
+	if existing, ok := ofs.uids[fs.Uid]; ok {
+		existing.mu.Lock()
+		existing.refCount++
+		existing.lastSeen = now
+		existing.mu.Unlock()
+		return
+	}
+	ofs.uids[fs.Uid] = &ObservedFilesystem{
+		apiClient:    apiClient,
+		fsUid:        fs.Uid,
+		fsObj:        fs,
+		fsObjFetched: now,
+		lastSeen:     now,
+		refCount:     1,
+	}
+}
+
+// DecRef records that one fewer volume lives on this filesystem, and reports whether that was the
+// last one - in which case the filesystem has been dropped and the caller should discard anything
+// else it was keeping for it, such as its cached quota map.
+func (ofs *ObservedFilesystems) DecRef(fsUid uuid.UUID) (evicted bool) {
+	if fsUid == uuid.Nil {
+		return false
+	}
+	ofs.mu.Lock()
+	defer ofs.mu.Unlock()
+	of, ok := ofs.uids[fsUid]
+	if !ok {
+		return false
+	}
+	of.mu.Lock()
+	of.refCount--
+	remaining := of.refCount
+	of.mu.Unlock()
+
+	if remaining > 0 {
+		return false
+	}
+	delete(ofs.uids, fsUid)
+	return true
+}
+
+// Get returns one observed filesystem, or nil.
+func (ofs *ObservedFilesystems) Get(fsUid uuid.UUID) *ObservedFilesystem {
+	ofs.mu.RLock()
+	defer ofs.mu.RUnlock()
+	return ofs.uids[fsUid]
+}
+
+// GetApiClient returns the API client that can reach a filesystem, or nil if it is not observed.
+func (ofs *ObservedFilesystems) GetApiClient(fsUid uuid.UUID) *apiclient.ApiClient {
+	of := ofs.Get(fsUid)
+	if of == nil {
+		return nil
+	}
+	return of.GetApiClient()
+}
+
+// All returns the observed filesystems as a snapshot. It deliberately does not hand back the map:
+// the caller would be iterating it after the lock was released, while another goroutine inserts.
+func (ofs *ObservedFilesystems) All() []*ObservedFilesystem {
+	ofs.mu.RLock()
+	defer ofs.mu.RUnlock()
+	out := make([]*ObservedFilesystem, 0, len(ofs.uids))
+	for _, of := range ofs.uids {
+		out = append(out, of)
+	}
+	return out
+}
+
+// ByQuotaUpdateTime returns the observed filesystems least recently refreshed first, so a sweep that
+// cannot get through all of them starts with the ones most in need.
+func (ofs *ObservedFilesystems) ByQuotaUpdateTime() []*ObservedFilesystem {
+	out := ofs.All()
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].LastQuotaUpdate().Before(out[j].LastQuotaUpdate())
+	})
+	return out
+}
+
+// Len reports how many filesystems are being observed.
+func (ofs *ObservedFilesystems) Len() int {
+	ofs.mu.RLock()
+	defer ofs.mu.RUnlock()
+	return len(ofs.uids)
+}

--- a/pkg/wekafs/observedfilesystems_test.go
+++ b/pkg/wekafs/observedfilesystems_test.go
@@ -1,0 +1,173 @@
+package wekafs
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/wekafs/csi-wekafs/pkg/wekafs/apiclient"
+)
+
+func TestObservedFilesystemsRefCounting(t *testing.T) {
+	ofs := NewObservedFilesystems()
+	fs := &apiclient.FileSystem{Uid: uuid.New(), Name: "default"}
+
+	ofs.IncRef(fs, nil)
+	ofs.IncRef(fs, nil)
+	if ofs.Len() != 1 {
+		t.Fatalf("Len() = %d, want 1 - two volumes on one filesystem is still one filesystem", ofs.Len())
+	}
+
+	if evicted := ofs.DecRef(fs.Uid); evicted {
+		t.Error("filesystem was evicted while a volume still referenced it")
+	}
+	if ofs.Len() != 1 {
+		t.Fatalf("Len() = %d, want 1", ofs.Len())
+	}
+
+	if evicted := ofs.DecRef(fs.Uid); !evicted {
+		t.Error("DecRef did not report eviction when the last reference went away")
+	}
+	if ofs.Len() != 0 {
+		t.Errorf("Len() = %d, want 0", ofs.Len())
+	}
+	if got := ofs.Get(fs.Uid); got != nil {
+		t.Errorf("Get returned %v after eviction", got)
+	}
+	// Decrementing an unobserved filesystem is a no-op, not a panic or a negative count.
+	if evicted := ofs.DecRef(fs.Uid); evicted {
+		t.Error("DecRef on an unknown filesystem reported an eviction")
+	}
+	if evicted := ofs.DecRef(uuid.Nil); evicted {
+		t.Error("DecRef on the nil uid reported an eviction")
+	}
+}
+
+func TestObservedFilesystemsIgnoresNil(t *testing.T) {
+	ofs := NewObservedFilesystems()
+	ofs.IncRef(nil, nil)
+	ofs.IncRef(&apiclient.FileSystem{}, nil) // uid is nil
+	if ofs.Len() != 0 {
+		t.Errorf("Len() = %d, want 0 - a filesystem with no uid must not be observed", ofs.Len())
+	}
+}
+
+// The reference count must survive concurrent adds and removes. The version this was ported from
+// looked the filesystem up under a read lock and inserted under a write lock, so two goroutines
+// could both miss and both insert - the second overwriting a count the first had already
+// contributed to, which drops a filesystem that still has volumes on it.
+func TestObservedFilesystemsConcurrentRefCounting(t *testing.T) {
+	ofs := NewObservedFilesystems()
+	fs := &apiclient.FileSystem{Uid: uuid.New(), Name: "default"}
+
+	const refs = 200
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := 0; i < refs; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start // release together, so the miss-then-insert windows overlap
+			ofs.IncRef(fs, nil)
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	if ofs.Len() != 1 {
+		t.Fatalf("Len() = %d, want 1", ofs.Len())
+	}
+
+	// Exactly one of the DecRefs - the last - may report eviction. If IncRef lost increments, an
+	// earlier DecRef evicts while references remain.
+	evictions := 0
+	for i := 0; i < refs; i++ {
+		if ofs.DecRef(fs.Uid) {
+			evictions++
+			if i != refs-1 {
+				t.Fatalf("filesystem evicted after %d of %d DecRefs - IncRef lost increments", i+1, refs)
+			}
+		}
+	}
+	if evictions != 1 {
+		t.Errorf("got %d evictions, want exactly 1", evictions)
+	}
+}
+
+func TestObservedFilesystemsByQuotaUpdateTime(t *testing.T) {
+	ofs := NewObservedFilesystems()
+	oldest := &apiclient.FileSystem{Uid: uuid.New(), Name: "oldest"}
+	middle := &apiclient.FileSystem{Uid: uuid.New(), Name: "middle"}
+	newest := &apiclient.FileSystem{Uid: uuid.New(), Name: "newest"}
+	for _, fs := range []*apiclient.FileSystem{oldest, middle, newest} {
+		ofs.IncRef(fs, nil)
+	}
+
+	now := time.Now()
+	ofs.Get(oldest.Uid).MarkQuotaUpdated(now.Add(-time.Hour))
+	ofs.Get(middle.Uid).MarkQuotaUpdated(now.Add(-time.Minute))
+	ofs.Get(newest.Uid).MarkQuotaUpdated(now)
+
+	got := ofs.ByQuotaUpdateTime()
+	if len(got) != 3 {
+		t.Fatalf("got %d filesystems, want 3", len(got))
+	}
+	// Least recently refreshed first, so a sweep that runs out of time does the neediest ones.
+	want := []uuid.UUID{oldest.Uid, middle.Uid, newest.Uid}
+	for i, uid := range want {
+		if got[i].Uid() != uid {
+			t.Errorf("position %d is %v, want %v - order must be least recently updated first",
+				i, got[i].Uid(), uid)
+		}
+	}
+}
+
+// All must hand back a snapshot: the caller iterates it after the lock is released.
+func TestObservedFilesystemsAllIsASnapshot(t *testing.T) {
+	ofs := NewObservedFilesystems()
+	first := &apiclient.FileSystem{Uid: uuid.New()}
+	ofs.IncRef(first, nil)
+
+	snapshot := ofs.All()
+	ofs.IncRef(&apiclient.FileSystem{Uid: uuid.New()}, nil)
+	ofs.DecRef(first.Uid)
+
+	if len(snapshot) != 1 || snapshot[0].Uid() != first.Uid {
+		t.Errorf("the snapshot changed when the observed set did: %v", snapshot)
+	}
+}
+
+func TestObservedFilesystemsConcurrentAccess(t *testing.T) {
+	ofs := NewObservedFilesystems()
+	filesystems := make([]*apiclient.FileSystem, 6)
+	for i := range filesystems {
+		filesystems[i] = &apiclient.FileSystem{Uid: uuid.New()}
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			for j := 0; j < 300; j++ {
+				fs := filesystems[j%len(filesystems)]
+				ofs.IncRef(fs, nil)
+				_ = ofs.All()
+				_ = ofs.ByQuotaUpdateTime()
+				_ = ofs.GetApiClient(fs.Uid)
+				if of := ofs.Get(fs.Uid); of != nil {
+					of.MarkQuotaUpdated(time.Now())
+					_ = of.LastQuotaUpdate()
+				}
+				ofs.DecRef(fs.Uid)
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	if ofs.Len() != 0 {
+		t.Errorf("Len() = %d, want 0 - every IncRef was matched by a DecRef", ofs.Len())
+	}
+}

--- a/pkg/wekafs/volumemetrics.go
+++ b/pkg/wekafs/volumemetrics.go
@@ -1,0 +1,200 @@
+package wekafs
+
+import (
+	"sync"
+
+	"github.com/google/uuid"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/wekafs/csi-wekafs/pkg/wekafs/apiclient"
+)
+
+// VolumeMetric is everything the metrics server needs about one PersistentVolume: the Kubernetes
+// object, the Weka volume it maps to, the credentials to reach it, and the last statistics read.
+type VolumeMetric struct {
+	persistentVolume *v1.PersistentVolume
+	volume           *Volume
+	metrics          *PvStats
+	secret           *v1.Secret
+	apiClient        *apiclient.ApiClient
+
+	// key is where this volume sits on the cluster, and pvUID identifies it. Both are kept so the
+	// volume can be removed from the by-filesystem index without re-deriving them from the Volume,
+	// and so removing one of several volumes sharing an inode removes only that one.
+	key   volumeKey
+	pvUID types.UID
+}
+
+// volumeKey locates a volume on the cluster. Quotas are fetched per filesystem and keyed by inode,
+// so this is what a quota map entry has to be matched back to.
+type volumeKey struct {
+	filesystemUid uuid.UUID
+	inodeId       uint64
+}
+
+// VolumeMetrics holds the volumes the metrics server is tracking, indexed two ways: by
+// PersistentVolume UID, which is how Kubernetes identifies them, and by filesystem and inode, which
+// is how the Weka API returns quotas.
+//
+// The second index maps to a set of volumes rather than to one, because several PersistentVolumes
+// can point at the same path - static provisioning makes that entirely ordinary - and they share an
+// inode. Keying it to a single volume would let the second silently replace the first, so one of
+// them would stop reporting and removing either would unindex both.
+//
+// One lock guards both indexes. The version this was ported from gave each level of the
+// by-filesystem index its own mutex and then acquired them in opposite orders - the filesystem map
+// before the inode map when adding, the inode map before the filesystem map when removing - which
+// deadlocks if the two run concurrently. Nesting bought nothing: every operation touches both
+// levels anyway.
+type VolumeMetrics struct {
+	mu        sync.RWMutex
+	byPv      map[types.UID]*VolumeMetric
+	byFsInode map[uuid.UUID]map[uint64]map[types.UID]*VolumeMetric
+}
+
+func NewVolumeMetrics() *VolumeMetrics {
+	return &VolumeMetrics{
+		byPv:      make(map[types.UID]*VolumeMetric),
+		byFsInode: make(map[uuid.UUID]map[uint64]map[types.UID]*VolumeMetric),
+	}
+}
+
+// Add starts tracking a volume. A volume whose filesystem or inode is unknown is tracked by PV only:
+// it can still report the capacity Kubernetes knows about, it just cannot be matched to a quota.
+func (vms *VolumeMetrics) Add(pvUID types.UID, key volumeKey, vm *VolumeMetric) {
+	vm.key = key
+
+	vms.mu.Lock()
+	defer vms.mu.Unlock()
+
+	// Replacing an existing entry has to unindex the old one first, in case the volume moved.
+	if existing, ok := vms.byPv[pvUID]; ok {
+		vms.unindexLocked(existing)
+	}
+	vm.pvUID = pvUID
+	vms.byPv[pvUID] = vm
+	if key.filesystemUid == uuid.Nil || key.inodeId == 0 {
+		return
+	}
+	inodes, ok := vms.byFsInode[key.filesystemUid]
+	if !ok {
+		inodes = make(map[uint64]map[types.UID]*VolumeMetric)
+		vms.byFsInode[key.filesystemUid] = inodes
+	}
+	sharing, ok := inodes[key.inodeId]
+	if !ok {
+		sharing = make(map[types.UID]*VolumeMetric)
+		inodes[key.inodeId] = sharing
+	}
+	sharing[pvUID] = vm
+}
+
+// Remove stops tracking a volume, e.g. once its PersistentVolume is gone.
+func (vms *VolumeMetrics) Remove(pvUID types.UID) {
+	vms.mu.Lock()
+	defer vms.mu.Unlock()
+	vm, ok := vms.byPv[pvUID]
+	if !ok {
+		return
+	}
+	vms.unindexLocked(vm)
+	delete(vms.byPv, pvUID)
+}
+
+// unindexLocked drops a volume from the by-filesystem index, and the filesystem's map with it once
+// the last volume on that filesystem is gone.
+// REQUIRES: vms.mu is held for writing.
+func (vms *VolumeMetrics) unindexLocked(vm *VolumeMetric) {
+	inodes, ok := vms.byFsInode[vm.key.filesystemUid]
+	if !ok {
+		return
+	}
+	sharing, ok := inodes[vm.key.inodeId]
+	if !ok {
+		return
+	}
+	// Only this PersistentVolume is removed; any others sharing the inode keep their entry.
+	delete(sharing, vm.pvUID)
+	if len(sharing) == 0 {
+		delete(inodes, vm.key.inodeId)
+	}
+	if len(inodes) == 0 {
+		delete(vms.byFsInode, vm.key.filesystemUid)
+	}
+}
+
+// Get returns the tracked volume for a PersistentVolume, or nil.
+func (vms *VolumeMetrics) Get(pvUID types.UID) *VolumeMetric {
+	vms.mu.RLock()
+	defer vms.mu.RUnlock()
+	return vms.byPv[pvUID]
+}
+
+// Has reports whether a PersistentVolume is being tracked.
+func (vms *VolumeMetrics) Has(pvUID types.UID) bool {
+	vms.mu.RLock()
+	defer vms.mu.RUnlock()
+	_, ok := vms.byPv[pvUID]
+	return ok
+}
+
+// ForFilesystem returns the volumes living on one filesystem, so the quotas fetched for it in one
+// request can be attributed. The slice is freshly built, so the caller may hold it while the tracked
+// set changes underneath.
+func (vms *VolumeMetrics) ForFilesystem(fsUid uuid.UUID) []*VolumeMetric {
+	vms.mu.RLock()
+	defer vms.mu.RUnlock()
+	inodes := vms.byFsInode[fsUid]
+	out := make([]*VolumeMetric, 0, len(inodes))
+	for _, sharing := range inodes {
+		for _, vm := range sharing {
+			out = append(out, vm)
+		}
+	}
+	return out
+}
+
+// ForInode returns every volume at one inode of a filesystem. This is the lookup a quota map entry
+// needs, and it returns a slice because one quota can describe several PersistentVolumes pointing at
+// the same path - each of them has to be updated from it.
+func (vms *VolumeMetrics) ForInode(fsUid uuid.UUID, inodeId uint64) []*VolumeMetric {
+	vms.mu.RLock()
+	defer vms.mu.RUnlock()
+	sharing := vms.byFsInode[fsUid][inodeId]
+	out := make([]*VolumeMetric, 0, len(sharing))
+	for _, vm := range sharing {
+		out = append(out, vm)
+	}
+	return out
+}
+
+// All returns every tracked volume, as a snapshot.
+func (vms *VolumeMetrics) All() []*VolumeMetric {
+	vms.mu.RLock()
+	defer vms.mu.RUnlock()
+	out := make([]*VolumeMetric, 0, len(vms.byPv))
+	for _, vm := range vms.byPv {
+		out = append(out, vm)
+	}
+	return out
+}
+
+// PvUIDs returns the PersistentVolume UIDs currently tracked, as a snapshot, for callers that need
+// to work out which of them have gone away.
+func (vms *VolumeMetrics) PvUIDs() []types.UID {
+	vms.mu.RLock()
+	defer vms.mu.RUnlock()
+	out := make([]types.UID, 0, len(vms.byPv))
+	for uid := range vms.byPv {
+		out = append(out, uid)
+	}
+	return out
+}
+
+// Len reports how many volumes are tracked.
+func (vms *VolumeMetrics) Len() int {
+	vms.mu.RLock()
+	defer vms.mu.RUnlock()
+	return len(vms.byPv)
+}

--- a/pkg/wekafs/volumemetrics_test.go
+++ b/pkg/wekafs/volumemetrics_test.go
@@ -1,0 +1,175 @@
+package wekafs
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/google/uuid"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func TestVolumeMetricsAddRemove(t *testing.T) {
+	vms := NewVolumeMetrics()
+	fs := uuid.New()
+	key := volumeKey{filesystemUid: fs, inodeId: 42}
+	vm := &VolumeMetric{}
+
+	if vms.Len() != 0 || vms.Has("pv-1") {
+		t.Fatal("a new VolumeMetrics is not empty")
+	}
+
+	vms.Add("pv-1", key, vm)
+	if !vms.Has("pv-1") || vms.Get("pv-1") != vm || vms.Len() != 1 {
+		t.Fatal("volume was not tracked by PV uid")
+	}
+	if got := vms.ForInode(fs, 42); len(got) != 1 || got[0] != vm {
+		t.Fatalf("ForInode returned %v, want the tracked volume", got)
+	}
+	if got := vms.ForFilesystem(fs); len(got) != 1 || got[0] != vm {
+		t.Fatalf("ForFilesystem returned %v, want one volume", got)
+	}
+
+	vms.Remove("pv-1")
+	if vms.Has("pv-1") || vms.Len() != 0 {
+		t.Fatal("volume was not removed from the PV index")
+	}
+	if got := vms.ForInode(fs, 42); len(got) != 0 {
+		t.Fatalf("ForInode still returns %v after removal", got)
+	}
+	if got := vms.ForFilesystem(fs); len(got) != 0 {
+		t.Fatalf("ForFilesystem still returns %v after removal", got)
+	}
+}
+
+// A volume whose filesystem or inode is unknown is still tracked by PV - it can report the capacity
+// Kubernetes knows - it just cannot be matched to a quota. The version this was ported from panicked
+// instead, which would have taken the metrics server down over one unresolvable volume.
+func TestVolumeMetricsAddWithoutInode(t *testing.T) {
+	vms := NewVolumeMetrics()
+	vms.Add("pv-1", volumeKey{}, &VolumeMetric{})
+	if !vms.Has("pv-1") {
+		t.Error("volume with no filesystem or inode was not tracked")
+	}
+	if got := vms.ForFilesystem(uuid.Nil); len(got) != 0 {
+		t.Errorf("volume with no filesystem leaked into the by-filesystem index: %v", got)
+	}
+	vms.Remove("pv-1") // must not panic
+}
+
+// Re-adding the same PV at a different location must not leave the old index entry behind.
+func TestVolumeMetricsReAddMoves(t *testing.T) {
+	vms := NewVolumeMetrics()
+	oldFs, newFs := uuid.New(), uuid.New()
+	vms.Add("pv-1", volumeKey{filesystemUid: oldFs, inodeId: 1}, &VolumeMetric{})
+	vm2 := &VolumeMetric{}
+	vms.Add("pv-1", volumeKey{filesystemUid: newFs, inodeId: 2}, vm2)
+
+	if got := vms.ForInode(oldFs, 1); len(got) != 0 {
+		t.Errorf("stale index entry left at the old location: %v", got)
+	}
+	if got := vms.ForInode(newFs, 2); len(got) != 1 || got[0] != vm2 {
+		t.Errorf("ForInode at the new location returned %v, want the new volume", got)
+	}
+	if vms.Len() != 1 {
+		t.Errorf("Len() = %d, want 1 - re-adding the same PV must not double count", vms.Len())
+	}
+}
+
+// Add and Remove ran under mutexes taken in opposite orders in the version this was ported from, so
+// concurrent adds and removes could deadlock. They also raced on the index maps.
+func TestVolumeMetricsConcurrentAddRemove(t *testing.T) {
+	vms := NewVolumeMetrics()
+	filesystems := make([]uuid.UUID, 4)
+	for i := range filesystems {
+		filesystems[i] = uuid.New()
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			for j := 0; j < 300; j++ {
+				fs := filesystems[j%len(filesystems)]
+				// Deliberately let PVs from different goroutines land on the same inode, which
+				// is what static provisioning does.
+				inode := uint64(j%10 + 1)
+				pv := types.UID(fmt.Sprintf("pv-%d-%d", i, j%10))
+				vms.Add(pv, volumeKey{filesystemUid: fs, inodeId: inode}, &VolumeMetric{})
+				_ = vms.ForFilesystem(fs)
+				_ = vms.ForInode(fs, inode)
+				_ = vms.All()
+				_ = vms.PvUIDs()
+				if j%3 == 0 {
+					vms.Remove(pv)
+				}
+			}
+		}(i)
+	}
+	wg.Wait()
+
+	// Every remaining volume must be reachable both ways, i.e. the two indexes agree.
+	for _, uid := range vms.PvUIDs() {
+		vm := vms.Get(uid)
+		if vm == nil {
+			t.Fatalf("%s is listed but not gettable", uid)
+		}
+		if vm.key.filesystemUid == uuid.Nil {
+			continue
+		}
+		found := false
+		for _, other := range vms.ForInode(vm.key.filesystemUid, vm.key.inodeId) {
+			if other == vm {
+				found = true
+			}
+		}
+		if !found {
+			t.Fatalf("%s is in the PV index but not the filesystem index", uid)
+		}
+	}
+}
+
+// Several PersistentVolumes can point at the same path, and so share a filesystem and inode. Each
+// must be reachable from a quota entry, and removing one must not unindex the others.
+func TestVolumeMetricsSharedInode(t *testing.T) {
+	vms := NewVolumeMetrics()
+	fs := uuid.New()
+	key := volumeKey{filesystemUid: fs, inodeId: 7}
+	first, second, third := &VolumeMetric{}, &VolumeMetric{}, &VolumeMetric{}
+
+	vms.Add("pv-a", key, first)
+	vms.Add("pv-b", key, second)
+	vms.Add("pv-c", key, third)
+
+	if got := vms.ForInode(fs, 7); len(got) != 3 {
+		t.Fatalf("ForInode returned %d volumes, want 3 - a quota entry must update every PV "+
+			"pointing at that path", len(got))
+	}
+	if got := vms.ForFilesystem(fs); len(got) != 3 {
+		t.Errorf("ForFilesystem returned %d volumes, want 3", len(got))
+	}
+	if vms.Len() != 3 {
+		t.Errorf("Len() = %d, want 3", vms.Len())
+	}
+
+	vms.Remove("pv-b")
+	got := vms.ForInode(fs, 7)
+	if len(got) != 2 {
+		t.Fatalf("after removing one of three, ForInode returned %d volumes, want 2", len(got))
+	}
+	for _, vm := range got {
+		if vm == second {
+			t.Error("the removed volume is still indexed")
+		}
+	}
+
+	vms.Remove("pv-a")
+	vms.Remove("pv-c")
+	if got := vms.ForInode(fs, 7); len(got) != 0 {
+		t.Errorf("ForInode returned %v after every sharer was removed", got)
+	}
+	if got := vms.ForFilesystem(fs); len(got) != 0 {
+		t.Errorf("ForFilesystem returned %v after every sharer was removed", got)
+	}
+}


### PR DESCRIPTION
### TL;DR
Adds the two thread-safe indexes the metrics server uses to track observed filesystems and volumes, and fixes two concurrency bugs in them.

### What changed?
- A reference-counted set of the filesystems backing tracked volumes, cached and iterable least-recently-refreshed first
- An index of PersistentVolumes by PV UID and by filesystem+inode, since quota responses are keyed the latter way
- Fixed a race that could silently drop a filesystem's reference count, and a lock-ordering bug that could deadlock concurrent add/remove
- Volumes with an unknown filesystem or inode are now tracked by PV UID instead of panicking

### How to test?
Covered only by automated tests (reference counting, concurrent access, shared-inode handling).

### Why make this change?
No user-visible effect on its own — this is internal state-tracking infrastructure for the metrics server shipped in #729. It fixes two real concurrency bugs that would otherwise surface as dropped or inconsistent metrics under load.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New concurrency-sensitive state machinery for metrics; bugs could cause dropped filesystem observation or inconsistent volume/quota indexing under load, though it is not yet wired into production paths in this diff.
> 
> **Overview**
> Introduces **thread-safe in-memory indexes** for the upcoming metrics server: a reference-counted **`ObservedFilesystems`** registry (with cached filesystem metadata, quota refresh timestamps, and least-recently-updated ordering) and a dual **`VolumeMetrics`** index keyed by PV UID and by filesystem+inode for matching Weka quota responses.
> 
> **Concurrency and correctness fixes** versus the prior design: `IncRef` does lookup+insert under one lock to avoid lost reference counts; `VolumeMetrics` uses a single lock instead of nested mutexes with opposite lock order (deadlock); re-`Add` unindexes the old location before writing the new key so moves and in-place updates do not leave stale inode mappings; multiple PVs sharing one inode are indexed as a set; volumes without a resolvable filesystem/inode are tracked by PV only instead of panicking.
> 
> Ships with unit tests covering ref counting, shared inodes, re-add/move, and concurrent access.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44d4df7fe6ebfd709c8353047468b12c82fb08bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->