### PR TITLE
feat: metrics server end to end — binary, image, Helm charts and v2 CI

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -4,7 +4,7 @@
 
 Kubernetes CSI (Container Storage Interface) driver for WekaFS, a high-performance distributed filesystem. Supports native Weka protocol and NFS transport, snapshots, encryption, dynamic/static provisioning, and observability via Prometheus metrics and OpenTelemetry tracing.
 
-**Current version**: 2.8.3
+**Current version**: 2.9.0
 **Language**: Go 1.26
 **Registry**: `quay.io/weka.io/csi-wekafs`
 **GitHub**: `github.com/weka/csi-wekafs`
@@ -15,7 +15,9 @@ Kubernetes CSI (Container Storage Interface) driver for WekaFS, a high-performan
 csi-wekafs/
 ├── cmd/
 │   ├── wekafsplugin/            # Main CSI driver binary entry point
+│   ├── metricsserver/           # Standalone metrics server binary (same code as --csimode=metricsserver)
 │   └── wait-for-leader/         # Leader election gate utility
+├── pkg/bootstrap/               # Process startup shared by the cmd/ binaries (logging, /metrics, tracing)
 ├── pkg/wekafs/                  # Core driver package
 │   ├── apiclient/               # Weka REST API client (auth, filesystem, snapshot, NFS, quota, KMS)
 │   ├── controllerserver.go      # CSI Controller (Create/Delete Volume, Snapshots, Expand)
@@ -30,6 +32,7 @@ csi-wekafs/
 │   ├── driverconfig.go          # Configuration management
 │   ├── gc.go                    # Garbage collection for orphaned data
 │   └── utilities.go             # Helpers (volume IDs, validation)
+├── charts/csi-metricsserver/    # Helm chart for the standalone metrics server Deployment
 ├── charts/csi-wekafsplugin/     # Helm chart for K8s deployment
 │   ├── Chart.yaml
 │   ├── values.yaml              # 100+ configurable options

--- a/.dagger/.gitattributes
+++ b/.dagger/.gitattributes
@@ -1,0 +1,1 @@
+/sdk/** linguist-generated

--- a/.dagger/.gitignore
+++ b/.dagger/.gitignore
@@ -1,0 +1,3 @@
+/.venv
+/**/__pycache__
+/sdk

--- a/.dagger/pyproject.toml
+++ b/.dagger/pyproject.toml
@@ -1,0 +1,15 @@
+[project]
+name = "csi-wekafs"
+version = "0.1.0"
+requires-python = ">=3.12"
+dependencies = [
+    "dagger-io",
+    "pip>=25.1.1",
+]
+
+[build-system]
+requires = ["hatchling==1.25.0"]
+build-backend = "hatchling.build"
+
+[tool.uv.sources]
+dagger-io = { path = "sdk", editable = true }

--- a/.dagger/src/apps/metricsserver.py
+++ b/.dagger/src/apps/metricsserver.py
@@ -1,0 +1,112 @@
+from typing import Optional
+
+import dagger
+from dagger import dag, Container, Directory, Socket, Secret
+
+from containers.builders import build_go
+
+
+async def metricsserver_ubi(src: Directory, sock: Socket, gh_token: Optional[Secret] = None) -> Container:
+    """Returns container suitable for building go applications"""
+    metricsserver = await build_go(src, sock, gh_token, cache_deps=True, program_path="cmd/metricsserver/main.go",
+                                  go_generate=False)
+
+    return await (
+        dag.container()
+        .from_(
+            "registry.access.redhat.com/ubi9/ubi@sha256:9ac75c1a392429b4a087971cdf9190ec42a854a169b6835bc9e25eecaf851258")
+        .with_file("/metricsserver", metricsserver.file("/out-binary"))
+    )
+
+
+async def _calc_metricsserver_version(src: Directory, version: str = "") -> str:
+    if not version:
+        digest = await src.digest()
+        sha = digest.split(":")[-1]
+        version = f"v999.0.0-{sha[:12]}"
+    return version
+
+
+async def publish_metricsserver(src: Directory, sock: Socket, repository: str, version: str = "",
+                               gh_token: Optional[Secret] = None) -> str:
+    """Returns container suitable for building go applications"""
+    metricsserver = await metricsserver_ubi(src, sock, gh_token)
+    # Compute a compact version by hashing combined digests
+    version = await _calc_metricsserver_version(src, version)
+
+    return await metricsserver.publish(f"{repository}:{version}")
+
+
+async def publish_metricsserver_helm_chart(
+        src: Directory,
+        sock: Socket,
+        repository: str,
+        version: str = "",
+        gh_token: Optional[Secret] = None,
+        registry_secret: Optional[dagger.Secret] = None, # file in format of fr3hx7l7h3p9/anton@weka.io:AUTH_TOKEN_FROM https://cloud.oracle.com/identity/domains/my-profile/auth-tokens?region=eu-frankfurt-1
+) -> str:
+    from containers.builders import helm_builder_container
+
+    version = await _calc_metricsserver_version(src, version)
+
+    builder = await (
+        (await helm_builder_container(sock, gh_token))
+        .with_directory("/src", src)
+        .with_workdir("/src")
+    )
+
+    if registry_secret is not None:
+        builder = builder.with_mounted_secret("/registry-secret", registry_secret)
+
+    base_repository = repository.rpartition("/")[0]
+    base_repository = base_repository.rpartition("/")[0] # cutting out helm, then cutting out namespace. very bound to OCI atm and broken for others
+    await (
+        builder.with_exec(["sh", "-ec", f"""
+    helm package charts/csi-metricsserver --version {version} --app-version {version} --destination charts/
+        """])
+        .with_exec(["sh", "-ec", f"""
+        if [ -f /registry-secret ]; then
+            AUTH=$(cat /registry-secret)
+            USERNAME=$(echo $AUTH | cut -d: -f1)
+            PASSWORD=$(echo $AUTH | cut -d: -f2-)
+            echo "Logging in to Helm registry {repository} as $USERNAME"
+            helm registry login {base_repository} -u $USERNAME -p $PASSWORD
+            echo "Pushing Helm chart to {repository}"
+        fi
+        helm push charts/csi-metricsserver-*.tgz oci://{repository}
+"""])
+        .stdout()
+    )
+    return f"{repository}/csi-metricsserver:{version}"
+
+
+async def install_helm_chart(
+        image: str, kubeconfig:
+        dagger.Secret,
+        metricsserver_repo: str,
+        values_file: Optional[dagger.File] = None,
+        cachebuster: Optional[str] = None,
+) -> str:
+    from containers.builders import helm_runner_container
+    repo, _, version = image.rpartition(":")
+
+    # TODO: Add pre-load?
+    cont = await (
+        (await helm_runner_container())
+    )
+    if values_file is not None:
+        cont = cont.with_file("/values.yaml", values_file)
+
+    return await (cont
+                  .with_mounted_secret("/kubeconfig", kubeconfig)
+                  .with_env_variable("KUBECONFIG", "/kubeconfig")
+                  .with_exec(["sh", "-ec", f"""
+        echo {cachebuster} > /dev/null
+        helm upgrade --install metricsserver oci://{repo} --namespace csi-metricsserver-system \
+            --version {version} \
+            --create-namespace \
+            --set image.repository={metricsserver_repo} \
+        {"--values /values.yaml" if values_file is not None else ""}
+         """])
+                  .stdout()
+                  )

--- a/.dagger/src/containers/builders.py
+++ b/.dagger/src/containers/builders.py
@@ -1,0 +1,104 @@
+from typing import Optional
+
+from dagger import dag, Container, Directory, Socket, Secret
+
+
+async def _go_builder_container(sock: Socket, gh_token: Optional[Secret] = None, version: str = "1.24-alpine") -> Container:
+    """
+    Returns a container suitable for building go applications.
+    If gh_token is provided, it will be used to configure git to use the token.
+    If gh_token is not provided, sock is used to configure git to use the ssh key.
+    """
+    cont = (
+        dag.container()
+        .from_(f"golang:{version}")
+        .with_env_variable("GOPRIVATE", "github.com/weka")  # find a way to remove this to be less weka-specific?
+    )
+
+    if gh_token:
+        cont = (
+            cont
+            .with_secret_variable("GH_TOKEN", gh_token)
+            .with_exec(["sh", "-ec", """
+apk add --no-cache git bash
+git config --global url."https://x-access-token:$GH_TOKEN@github.com/".insteadOf "https://github.com/"
+            """])
+        )
+    else:
+        cont = (
+            cont
+            .with_exec(["sh", "-ec", """
+apk add --no-cache git bash
+apk --no-cache add ca-certificates git openssh-client
+git config --global url."git@github.com:".insteadOf "https://github.com/"
+mkdir -p -m 0700 ~/.ssh && ssh-keyscan github.com >> ~/.ssh/known_hosts
+chmod 600 ~/.ssh/known_hosts
+export GIT_SSH_COMMAND="ssh -v"
+            """])
+            .with_unix_socket("/tmp/ssh-agent.sock", sock)
+            .with_env_variable("SSH_AUTH_SOCK", "/tmp/ssh-agent.sock")
+        )
+
+    cont = (
+        cont
+        .with_mounted_cache("/go/pkg/mod", dag.cache_volume("go-cache"))
+        .with_mounted_cache("/root/.cache/go-build", dag.cache_volume("go-cache-root"))
+    )
+    return cont
+
+
+async def helm_builder_container(sock: Socket, gh_token: Optional[Secret] = None) -> Container:
+    cont = await _go_builder_container(sock, gh_token)
+    return (
+        cont
+        .with_exec(["apk", "--no-cache", "add", "helm", "make"])
+    )
+
+async def helm_runner_container() -> Container:
+    return (
+        dag.container()
+        .from_("alpine:latest")
+        .with_exec(["apk", "--no-cache", "add", "helm", "kubectl"])
+    )
+
+
+async def build_go(
+        src: Directory,
+        sock: Socket,
+        gh_token: Optional[Secret] = None,
+        cache_deps: bool = True,
+        program_path: str = "main.go",
+        go_generate: bool = False,
+) -> Container:
+    """returns container suitable for building go applications"""
+
+    cont = (
+        (await _go_builder_container(sock, gh_token))
+        .with_file("/src/go.mod", src.file("go.mod"))
+        .with_file("/src/go.sum", src.file("go.sum"))
+        .with_workdir("/src")
+    )
+
+    if cache_deps:
+        cont = cont.with_exec(["go", "mod", "download"])
+
+    if go_generate:
+        cont = cont.with_exec(["go", "generate", "./..."])
+
+    cont = (cont
+            .with_directory("/src", src)
+            .with_exec(["go", "build", "-o", "/out-binary", program_path])
+            )
+    return await cont
+
+
+async def _uv_base() -> Container:
+    return await (
+        dag.container()
+        .from_("ghcr.io/astral-sh/uv:alpine")
+        .with_exec(["apk", "add", "--no-cache",
+                    "python3",
+                    "py3-pip",
+                    "bash"]
+                   )
+    )

--- a/.dagger/src/csi_wekafs/__init__.py
+++ b/.dagger/src/csi_wekafs/__init__.py
@@ -1,0 +1,16 @@
+"""A generated module for CsiWekafs functions
+
+This module has been generated via dagger init and serves as a reference to
+basic module structure as you get started with Dagger.
+
+Two functions have been pre-created. You can modify, delete, or add to them,
+as needed. They demonstrate usage of arguments and return types using simple
+echo and grep commands. The functions can be called from the dagger CLI or
+from one of the SDKs.
+
+The first line in this comment block is a short description line and the
+rest is a long description with more detail on the module's purpose or usage,
+if appropriate. All modules should have a short description.
+"""
+
+from .main import CsiWekafs as CsiWekafs

--- a/.dagger/src/csi_wekafs/main.py
+++ b/.dagger/src/csi_wekafs/main.py
@@ -1,0 +1,162 @@
+import re
+import logging
+from typing import Dict, List, Annotated, Optional
+
+import dagger
+from dagger import dag, function, object_type, Ignore
+
+from containers.builders import build_go
+from apps.metricsserver import publish_metricsserver, publish_metricsserver_helm_chart, install_helm_chart
+
+CSI_EXCLUDE_LIST = [
+    "node_modules",
+    ".aider*",
+    "**/.git",
+    ".dagger",
+    "bin",
+    "build",
+    "terraform",
+    "*.tgz",
+    "tests",
+]
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+logger.addHandler(logging.StreamHandler())
+
+@object_type
+class CsiWekafs:
+    @function
+    async def build_metricsserver(self,
+                                 csi: Annotated[dagger.Directory, Ignore(CSI_EXCLUDE_LIST)],
+                                 sock: dagger.Socket,
+                                 gh_token: Optional[dagger.Secret] = None,
+                                 ) -> dagger.Container:
+        """Build metrics server Go application"""
+        from apps.metricsserver import metricsserver_ubi
+        return await metricsserver_ubi(csi, sock, gh_token)
+
+    @function
+    async def publish_metricsserver(self,
+                                   csi: Annotated[dagger.Directory, Ignore(CSI_EXCLUDE_LIST)],
+                                   sock: dagger.Socket,
+                                   repository: str = "images.scalar.dev.weka.io:5002/csi-metricsserver",
+                                   version: str = "",
+                                   gh_token: Optional[dagger.Secret] = None,
+                                   ) -> str:
+        """Publish metrics server container to registry"""
+        from apps.metricsserver import publish_metricsserver
+        return await publish_metricsserver(csi, sock, repository, version, gh_token)
+
+    @function
+    async def build_helm_chart(self,
+                              csi: Annotated[dagger.Directory, Ignore(CSI_EXCLUDE_LIST)],
+                              sock: dagger.Socket,
+                              version: str = "",
+                              gh_token: Optional[dagger.Secret] = None,
+                              ) -> dagger.Directory:
+        """Build Helm chart for metrics server"""
+        from containers.builders import helm_builder_container
+        from apps.metricsserver import _calc_metricsserver_version
+        
+        version = await _calc_metricsserver_version(csi, version)
+        
+        return await (
+            (await helm_builder_container(sock, gh_token))
+            .with_directory("/src", csi)
+            .with_workdir("/src")
+            .with_exec(["sh", "-ec", f"""
+        helm package charts/csi-metricsserver --version {version} --destination charts/
+            """])
+            .directory("/src/charts")
+        )
+
+    @function
+    async def publish_helm_chart(self,
+                                csi: Annotated[dagger.Directory, Ignore(CSI_EXCLUDE_LIST)],
+                                sock: dagger.Socket,
+                                repository: str = "images.scalar.dev.weka.io:5002/helm",
+                                version: str = "",
+                                gh_token: Optional[dagger.Secret] = None,
+                                ) -> str:
+        """Publish Helm chart to registry"""
+        from apps.metricsserver import publish_metricsserver_helm_chart
+        return await publish_metricsserver_helm_chart(csi, sock, repository, version, gh_token)
+
+    @function
+    async def build_scalar(self,
+                           csi: Annotated[dagger.Directory, Ignore(CSI_EXCLUDE_LIST)],
+                           sock: dagger.Socket,
+                           repository: str = "images.scalar.dev.weka.io:5002/csi-metricsserver",
+                           helm_repository: str = "images.scalar.dev.weka.io:5002/helm",
+                           version: Optional[str] = None,
+                           gh_token: Optional[dagger.Secret] = None,
+                           registry_secret: Optional[dagger.Secret] = None, # file in format of fr3hx7l7h3p9/anton@weka.io:AUTH_TOKEN_FROM https://cloud.oracle.com/identity/domains/my-profile/auth-tokens?region=eu-frankfurt-1
+                           ) -> str:
+        """Build and publish metrics server to Scalar registry"""
+        from apps.metricsserver import publish_metricsserver, publish_metricsserver_helm_chart
+        _ = await publish_metricsserver(csi, sock,
+                                       repository=repository,
+                                       version=version or "",
+                                       gh_token=gh_token,
+                                       )
+        metricsserver_helm = await publish_metricsserver_helm_chart(csi, sock,
+                                                                   repository=helm_repository,
+                                                                   version=version or "",
+                                                                   gh_token=gh_token,
+                                                                   registry_secret=registry_secret,
+                                                                   )
+        return metricsserver_helm
+
+    @function
+    async def deploy_scalar(self,
+                            csi: Annotated[dagger.Directory, Ignore(CSI_EXCLUDE_LIST)],
+                            sock: dagger.Socket,
+                            kubeconfig: dagger.Secret,
+                            metricsserver_values: Optional[dagger.File]=None,
+                            repository: str = "images.scalar.dev.weka.io:5002/csi-metricsserver",
+                            helm_repository: str = "images.scalar.dev.weka.io:5002/helm",
+                            version: Optional[str] = None,
+                            gh_token: Optional[dagger.Secret] = None,
+                            cachebuster: Optional[str] = None,
+                            ) -> str:
+        """Deploy metrics server using Helm charts"""
+        from apps.metricsserver import install_helm_chart
+        metricsserver_helm = await self.build_scalar(csi, sock, repository, helm_repository, version, gh_token)
+        install = await install_helm_chart(
+            image=metricsserver_helm,
+            kubeconfig=kubeconfig,
+            metricsserver_repo=repository,
+            values_file=metricsserver_values,
+            cachebuster=cachebuster
+        )
+        return install
+
+
+    @function
+    async def publish_quay(self,
+                            csi: Annotated[dagger.Directory, Ignore(CSI_EXCLUDE_LIST)],
+                            sock: dagger.Socket,
+                            registry_secret: dagger.Secret, # file in format of fr3hx7l7h3p9/anton@weka.io:AUTH_TOKEN_FROM https://cloud.oracle.com/identity/domains/my-profile/auth-tokens?region=eu-frankfurt-1
+                            repository: str = "quay.io/weka.io/csi-metricsserver",
+                            helm_repository: str = "quay.io/weka.io/helm",
+                            version: Optional[str] = None,
+                            gh_token: Optional[dagger.Secret] = None,
+                            ) -> str:
+        """Deploy metrics server using Helm charts"""
+        from apps.metricsserver import install_helm_chart
+        metricsserver_helm = await self.build_scalar(csi, sock, repository, helm_repository, version, gh_token, registry_secret=registry_secret)
+        ret = f"published {metricsserver_helm} to {repository}"
+        print(ret)
+        return ret
+
+    @function
+    async def metricsserver_explore(self,
+                                   csi: Annotated[dagger.Directory, Ignore(CSI_EXCLUDE_LIST)],
+                                   ) -> dagger.Container:
+        """Container for exploring CSI metrics server codebase"""
+        return await (
+            dag.container()
+            .from_("ubuntu:24.04")
+            .with_directory("/csi", csi)
+        )

--- a/.dagger/uv.lock
+++ b/.dagger/uv.lock
@@ -1,0 +1,650 @@
+version = 1
+requires-python = ">=3.12"
+
+[[package]]
+name = "anyio"
+version = "4.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "sniffio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/95/7d/4c1bd541d4dffa1b52bd83fb8527089e097a106fc90b467a7313b105f840/anyio-4.9.0.tar.gz", hash = "sha256:673c0c244e15788651a4ff38710fea9675823028a6f08a5eda409e0c9840a028", size = 190949 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a1/ee/48ca1a7c89ffec8b6a0c5d02b89c305671d5ffd8d3c94acf8b8c408575bb/anyio-4.9.0-py3-none-any.whl", hash = "sha256:9f76d541cad6e36af7beb62e978876f3b41e3e04f2c1fbf0884604c0a9c4d93c", size = 100916 },
+]
+
+[[package]]
+name = "attrs"
+version = "25.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/b0/1367933a8532ee6ff8d63537de4f1177af4bff9f3e829baf7331f595bb24/attrs-25.3.0.tar.gz", hash = "sha256:75d7cefc7fb576747b2c81b4442d4d4a1ce0900973527c011d1030fd3bf4af1b", size = 812032 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/06/bb80f5f86020c4551da315d78b3ab75e8228f89f0162f2c3a819e407941a/attrs-25.3.0-py3-none-any.whl", hash = "sha256:427318ce031701fea540783410126f03899a97ffc6f61596ad581ac2e40e3bc3", size = 63815 },
+]
+
+[[package]]
+name = "backoff"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/d7/5bbeb12c44d7c4f2fb5b56abce497eb5ed9f34d85701de869acedd602619/backoff-2.2.1.tar.gz", hash = "sha256:03f829f5bb1923180821643f8753b0502c3b682293992485b0eef2807afa5cba", size = 17001 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/73/b6e24bd22e6720ca8ee9a85a0c4a2971af8497d8f3193fa05390cbd46e09/backoff-2.2.1-py3-none-any.whl", hash = "sha256:63579f9a0628e06278f7e47b7d7d5b6ce20dc65c5e96a6f3ca99a6adca0396e8", size = 15148 },
+]
+
+[[package]]
+name = "beartype"
+version = "0.21.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0d/f9/21e5a9c731e14f08addd53c71fea2e70794e009de5b98e6a2c3d2f3015d6/beartype-0.21.0.tar.gz", hash = "sha256:f9a5078f5ce87261c2d22851d19b050b64f6a805439e8793aecf01ce660d3244", size = 1437066 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/31/87045d1c66ee10a52486c9d2047bc69f00f2689f69401bb1e998afb4b205/beartype-0.21.0-py3-none-any.whl", hash = "sha256:b6a1bd56c72f31b0a496a36cc55df6e2f475db166ad07fa4acc7e74f4c7f34c0", size = 1191340 },
+]
+
+[[package]]
+name = "cattrs"
+version = "25.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/57/2b/561d78f488dcc303da4639e02021311728fb7fda8006dd2835550cddd9ed/cattrs-25.1.1.tar.gz", hash = "sha256:c914b734e0f2d59e5b720d145ee010f1fd9a13ee93900922a2f3f9d593b8382c", size = 435016 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/b0/215274ef0d835bbc1056392a367646648b6084e39d489099959aefcca2af/cattrs-25.1.1-py3-none-any.whl", hash = "sha256:1b40b2d3402af7be79a7e7e097a9b4cd16d4c06e6d526644b0b26a063a1cc064", size = 69386 },
+]
+
+[[package]]
+name = "certifi"
+version = "2025.7.14"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b3/76/52c535bcebe74590f296d6c77c86dabf761c41980e1347a2422e4aa2ae41/certifi-2025.7.14.tar.gz", hash = "sha256:8ea99dbdfaaf2ba2f9bac77b9249ef62ec5218e7c2b2e903378ed5fccf765995", size = 163981 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4f/52/34c6cf5bb9285074dc3531c437b3919e825d976fde097a7a73f79e726d03/certifi-2025.7.14-py3-none-any.whl", hash = "sha256:6b31f564a415d79ee77df69d757bb49a5bb53bd9f756cbbe24394ffd6fc1f4b2", size = 162722 },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/33/89c2ced2b67d1c2a61c19c6751aa8902d46ce3dacb23600a283619f5a12d/charset_normalizer-3.4.2.tar.gz", hash = "sha256:5baececa9ecba31eff645232d59845c07aa030f0c81ee70184a90d35099a0e63", size = 126367 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/a4/37f4d6035c89cac7930395a35cc0f1b872e652eaafb76a6075943754f095/charset_normalizer-3.4.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:0c29de6a1a95f24b9a1aa7aefd27d2487263f00dfd55a77719b530788f75cff7", size = 199936 },
+    { url = "https://files.pythonhosted.org/packages/ee/8a/1a5e33b73e0d9287274f899d967907cd0bf9c343e651755d9307e0dbf2b3/charset_normalizer-3.4.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cddf7bd982eaa998934a91f69d182aec997c6c468898efe6679af88283b498d3", size = 143790 },
+    { url = "https://files.pythonhosted.org/packages/66/52/59521f1d8e6ab1482164fa21409c5ef44da3e9f653c13ba71becdd98dec3/charset_normalizer-3.4.2-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:fcbe676a55d7445b22c10967bceaaf0ee69407fbe0ece4d032b6eb8d4565982a", size = 153924 },
+    { url = "https://files.pythonhosted.org/packages/86/2d/fb55fdf41964ec782febbf33cb64be480a6b8f16ded2dbe8db27a405c09f/charset_normalizer-3.4.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d41c4d287cfc69060fa91cae9683eacffad989f1a10811995fa309df656ec214", size = 146626 },
+    { url = "https://files.pythonhosted.org/packages/8c/73/6ede2ec59bce19b3edf4209d70004253ec5f4e319f9a2e3f2f15601ed5f7/charset_normalizer-3.4.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4e594135de17ab3866138f496755f302b72157d115086d100c3f19370839dd3a", size = 148567 },
+    { url = "https://files.pythonhosted.org/packages/09/14/957d03c6dc343c04904530b6bef4e5efae5ec7d7990a7cbb868e4595ee30/charset_normalizer-3.4.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cf713fe9a71ef6fd5adf7a79670135081cd4431c2943864757f0fa3a65b1fafd", size = 150957 },
+    { url = "https://files.pythonhosted.org/packages/0d/c8/8174d0e5c10ccebdcb1b53cc959591c4c722a3ad92461a273e86b9f5a302/charset_normalizer-3.4.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a370b3e078e418187da8c3674eddb9d983ec09445c99a3a263c2011993522981", size = 145408 },
+    { url = "https://files.pythonhosted.org/packages/58/aa/8904b84bc8084ac19dc52feb4f5952c6df03ffb460a887b42615ee1382e8/charset_normalizer-3.4.2-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:a955b438e62efdf7e0b7b52a64dc5c3396e2634baa62471768a64bc2adb73d5c", size = 153399 },
+    { url = "https://files.pythonhosted.org/packages/c2/26/89ee1f0e264d201cb65cf054aca6038c03b1a0c6b4ae998070392a3ce605/charset_normalizer-3.4.2-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:7222ffd5e4de8e57e03ce2cef95a4c43c98fcb72ad86909abdfc2c17d227fc1b", size = 156815 },
+    { url = "https://files.pythonhosted.org/packages/fd/07/68e95b4b345bad3dbbd3a8681737b4338ff2c9df29856a6d6d23ac4c73cb/charset_normalizer-3.4.2-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:bee093bf902e1d8fc0ac143c88902c3dfc8941f7ea1d6a8dd2bcb786d33db03d", size = 154537 },
+    { url = "https://files.pythonhosted.org/packages/77/1a/5eefc0ce04affb98af07bc05f3bac9094513c0e23b0562d64af46a06aae4/charset_normalizer-3.4.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:dedb8adb91d11846ee08bec4c8236c8549ac721c245678282dcb06b221aab59f", size = 149565 },
+    { url = "https://files.pythonhosted.org/packages/37/a0/2410e5e6032a174c95e0806b1a6585eb21e12f445ebe239fac441995226a/charset_normalizer-3.4.2-cp312-cp312-win32.whl", hash = "sha256:db4c7bf0e07fc3b7d89ac2a5880a6a8062056801b83ff56d8464b70f65482b6c", size = 98357 },
+    { url = "https://files.pythonhosted.org/packages/6c/4f/c02d5c493967af3eda9c771ad4d2bbc8df6f99ddbeb37ceea6e8716a32bc/charset_normalizer-3.4.2-cp312-cp312-win_amd64.whl", hash = "sha256:5a9979887252a82fefd3d3ed2a8e3b937a7a809f65dcb1e068b090e165bbe99e", size = 105776 },
+    { url = "https://files.pythonhosted.org/packages/ea/12/a93df3366ed32db1d907d7593a94f1fe6293903e3e92967bebd6950ed12c/charset_normalizer-3.4.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:926ca93accd5d36ccdabd803392ddc3e03e6d4cd1cf17deff3b989ab8e9dbcf0", size = 199622 },
+    { url = "https://files.pythonhosted.org/packages/04/93/bf204e6f344c39d9937d3c13c8cd5bbfc266472e51fc8c07cb7f64fcd2de/charset_normalizer-3.4.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:eba9904b0f38a143592d9fc0e19e2df0fa2e41c3c3745554761c5f6447eedabf", size = 143435 },
+    { url = "https://files.pythonhosted.org/packages/22/2a/ea8a2095b0bafa6c5b5a55ffdc2f924455233ee7b91c69b7edfcc9e02284/charset_normalizer-3.4.2-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3fddb7e2c84ac87ac3a947cb4e66d143ca5863ef48e4a5ecb83bd48619e4634e", size = 153653 },
+    { url = "https://files.pythonhosted.org/packages/b6/57/1b090ff183d13cef485dfbe272e2fe57622a76694061353c59da52c9a659/charset_normalizer-3.4.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:98f862da73774290f251b9df8d11161b6cf25b599a66baf087c1ffe340e9bfd1", size = 146231 },
+    { url = "https://files.pythonhosted.org/packages/e2/28/ffc026b26f441fc67bd21ab7f03b313ab3fe46714a14b516f931abe1a2d8/charset_normalizer-3.4.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c9379d65defcab82d07b2a9dfbfc2e95bc8fe0ebb1b176a3190230a3ef0e07c", size = 148243 },
+    { url = "https://files.pythonhosted.org/packages/c0/0f/9abe9bd191629c33e69e47c6ef45ef99773320e9ad8e9cb08b8ab4a8d4cb/charset_normalizer-3.4.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e635b87f01ebc977342e2697d05b56632f5f879a4f15955dfe8cef2448b51691", size = 150442 },
+    { url = "https://files.pythonhosted.org/packages/67/7c/a123bbcedca91d5916c056407f89a7f5e8fdfce12ba825d7d6b9954a1a3c/charset_normalizer-3.4.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1c95a1e2902a8b722868587c0e1184ad5c55631de5afc0eb96bc4b0d738092c0", size = 145147 },
+    { url = "https://files.pythonhosted.org/packages/ec/fe/1ac556fa4899d967b83e9893788e86b6af4d83e4726511eaaad035e36595/charset_normalizer-3.4.2-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ef8de666d6179b009dce7bcb2ad4c4a779f113f12caf8dc77f0162c29d20490b", size = 153057 },
+    { url = "https://files.pythonhosted.org/packages/2b/ff/acfc0b0a70b19e3e54febdd5301a98b72fa07635e56f24f60502e954c461/charset_normalizer-3.4.2-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:32fc0341d72e0f73f80acb0a2c94216bd704f4f0bce10aedea38f30502b271ff", size = 156454 },
+    { url = "https://files.pythonhosted.org/packages/92/08/95b458ce9c740d0645feb0e96cea1f5ec946ea9c580a94adfe0b617f3573/charset_normalizer-3.4.2-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:289200a18fa698949d2b39c671c2cc7a24d44096784e76614899a7ccf2574b7b", size = 154174 },
+    { url = "https://files.pythonhosted.org/packages/78/be/8392efc43487ac051eee6c36d5fbd63032d78f7728cb37aebcc98191f1ff/charset_normalizer-3.4.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4a476b06fbcf359ad25d34a057b7219281286ae2477cc5ff5e3f70a246971148", size = 149166 },
+    { url = "https://files.pythonhosted.org/packages/44/96/392abd49b094d30b91d9fbda6a69519e95802250b777841cf3bda8fe136c/charset_normalizer-3.4.2-cp313-cp313-win32.whl", hash = "sha256:aaeeb6a479c7667fbe1099af9617c83aaca22182d6cf8c53966491a0f1b7ffb7", size = 98064 },
+    { url = "https://files.pythonhosted.org/packages/e9/b0/0200da600134e001d91851ddc797809e2fe0ea72de90e09bec5a2fbdaccb/charset_normalizer-3.4.2-cp313-cp313-win_amd64.whl", hash = "sha256:aa6af9e7d59f9c12b33ae4e9450619cf2488e2bbe9b44030905877f0b2324980", size = 105641 },
+    { url = "https://files.pythonhosted.org/packages/20/94/c5790835a017658cbfabd07f3bfb549140c3ac458cfc196323996b10095a/charset_normalizer-3.4.2-py3-none-any.whl", hash = "sha256:7f56930ab0abd1c45cd15be65cc741c28b1c9a34876ce8c17a2fa107810c0af0", size = 52626 },
+]
+
+[[package]]
+name = "csi-wekafs"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "dagger-io" },
+    { name = "pip" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "dagger-io", editable = "sdk" },
+    { name = "pip", specifier = ">=25.1.1" },
+]
+
+[[package]]
+name = "dagger-io"
+version = "0.0.0"
+source = { editable = "sdk" }
+dependencies = [
+    { name = "anyio" },
+    { name = "beartype" },
+    { name = "cattrs" },
+    { name = "gql", extra = ["httpx"] },
+    { name = "opentelemetry-exporter-otlp-proto-http" },
+    { name = "opentelemetry-sdk" },
+    { name = "platformdirs" },
+    { name = "rich" },
+    { name = "typing-extensions" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "anyio", specifier = ">=3.6.2" },
+    { name = "beartype", specifier = ">=0.18.2" },
+    { name = "cattrs", specifier = ">=24.1.0" },
+    { name = "gql", extras = ["httpx"], specifier = ">=3.5.0" },
+    { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.23.0" },
+    { name = "opentelemetry-sdk", specifier = ">=1.23.0" },
+    { name = "platformdirs", specifier = ">=2.6.2" },
+    { name = "rich", specifier = ">=10.11.0" },
+    { name = "typing-extensions", specifier = ">=4.13.0" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "aiohttp", specifier = ">=3.9.3" },
+    { name = "codegen", editable = "sdk/codegen" },
+    { name = "mypy", specifier = ">=1.8.0" },
+    { name = "pytest", specifier = ">=8.0.2" },
+    { name = "pytest-httpx", specifier = ">=0.30.0" },
+    { name = "pytest-mock", specifier = ">=3.12.0" },
+    { name = "pytest-subprocess", specifier = ">=1.5.0" },
+    { name = "ruff", specifier = ">=0.3.4" },
+    { name = "sphinx", specifier = ">=7.2.6" },
+    { name = "sphinx-rtd-theme", specifier = ">=2.0.0" },
+]
+
+[[package]]
+name = "googleapis-common-protos"
+version = "1.70.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/39/24/33db22342cf4a2ea27c9955e6713140fedd51e8b141b5ce5260897020f1a/googleapis_common_protos-1.70.0.tar.gz", hash = "sha256:0e1b44e0ea153e6594f9f394fef15193a68aaaea2d843f83e2742717ca753257", size = 145903 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/86/f1/62a193f0227cf15a920390abe675f386dec35f7ae3ffe6da582d3ade42c7/googleapis_common_protos-1.70.0-py3-none-any.whl", hash = "sha256:b8bfcca8c25a2bb253e0e0b0adaf8c00773e5e6af6fd92397576680b807e0fd8", size = 294530 },
+]
+
+[[package]]
+name = "gql"
+version = "3.5.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "backoff" },
+    { name = "graphql-core" },
+    { name = "yarl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/34/ed/44ffd30b06b3afc8274ee2f38c3c1b61fe4740bf03d92083e43d2c17ac77/gql-3.5.3.tar.gz", hash = "sha256:393b8c049d58e0d2f5461b9d738a2b5f904186a40395500b4a84dd092d56e42b", size = 180504 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/50/2f4e99b216821ac921dbebf91c644ba95818f5d07857acadee17220221f3/gql-3.5.3-py2.py3-none-any.whl", hash = "sha256:e1fcbde2893fcafdd28114ece87ff47f1cc339a31db271fc4e1d528f5a1d4fbc", size = 74348 },
+]
+
+[package.optional-dependencies]
+httpx = [
+    { name = "httpx" },
+]
+
+[[package]]
+name = "graphql-core"
+version = "3.2.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c4/16/7574029da84834349b60ed71614d66ca3afe46e9bf9c7b9562102acb7d4f/graphql_core-3.2.6.tar.gz", hash = "sha256:c08eec22f9e40f0bd61d805907e3b3b1b9a320bc606e23dc145eebca07c8fbab", size = 505353 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/4f/7297663840621022bc73c22d7d9d80dbc78b4db6297f764b545cd5dd462d/graphql_core-3.2.6-py3-none-any.whl", hash = "sha256:78b016718c161a6fb20a7d97bbf107f331cd1afe53e45566c59f776ed7f0b45f", size = 203416 },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515 },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784 },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517 },
+]
+
+[[package]]
+name = "idna"
+version = "3.10"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9", size = 190490 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3", size = 70442 },
+]
+
+[[package]]
+name = "importlib-metadata"
+version = "8.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "zipp" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/76/66/650a33bd90f786193e4de4b3ad86ea60b53c89b669a5c7be931fac31cdb0/importlib_metadata-8.7.0.tar.gz", hash = "sha256:d13b81ad223b890aa16c5471f2ac3056cf76c5f10f82d6f9292f0b415f389000", size = 56641 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/b0/36bd937216ec521246249be3bf9855081de4c5e06a0c9b4219dbeda50373/importlib_metadata-8.7.0-py3-none-any.whl", hash = "sha256:e5dd1551894c77868a30651cef00984d50e1002d06942a7101d34870c5f02afd", size = 27656 },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "3.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/38/71/3b932df36c1a044d397a1f92d1cf91ee0a503d91e470cbd670aa66b07ed0/markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb", size = 74596 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/d7/1ec15b46af6af88f19b8e5ffea08fa375d433c998b8a7639e76935c14f1f/markdown_it_py-3.0.0-py3-none-any.whl", hash = "sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1", size = 87528 },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979 },
+]
+
+[[package]]
+name = "multidict"
+version = "6.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3d/2c/5dad12e82fbdf7470f29bff2171484bf07cb3b16ada60a6589af8f376440/multidict-6.6.3.tar.gz", hash = "sha256:798a9eb12dab0a6c2e29c1de6f3468af5cb2da6053a20dfa3344907eed0937cc", size = 101006 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0e/a0/6b57988ea102da0623ea814160ed78d45a2645e4bbb499c2896d12833a70/multidict-6.6.3-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:056bebbeda16b2e38642d75e9e5310c484b7c24e3841dc0fb943206a72ec89d6", size = 76514 },
+    { url = "https://files.pythonhosted.org/packages/07/7a/d1e92665b0850c6c0508f101f9cf0410c1afa24973e1115fe9c6a185ebf7/multidict-6.6.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:e5f481cccb3c5c5e5de5d00b5141dc589c1047e60d07e85bbd7dea3d4580d63f", size = 45394 },
+    { url = "https://files.pythonhosted.org/packages/52/6f/dd104490e01be6ef8bf9573705d8572f8c2d2c561f06e3826b081d9e6591/multidict-6.6.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:10bea2ee839a759ee368b5a6e47787f399b41e70cf0c20d90dfaf4158dfb4e55", size = 43590 },
+    { url = "https://files.pythonhosted.org/packages/44/fe/06e0e01b1b0611e6581b7fd5a85b43dacc08b6cea3034f902f383b0873e5/multidict-6.6.3-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:2334cfb0fa9549d6ce2c21af2bfbcd3ac4ec3646b1b1581c88e3e2b1779ec92b", size = 237292 },
+    { url = "https://files.pythonhosted.org/packages/ce/71/4f0e558fb77696b89c233c1ee2d92f3e1d5459070a0e89153c9e9e804186/multidict-6.6.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b8fee016722550a2276ca2cb5bb624480e0ed2bd49125b2b73b7010b9090e888", size = 258385 },
+    { url = "https://files.pythonhosted.org/packages/e3/25/cca0e68228addad24903801ed1ab42e21307a1b4b6dd2cf63da5d3ae082a/multidict-6.6.3-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:e5511cb35f5c50a2db21047c875eb42f308c5583edf96bd8ebf7d770a9d68f6d", size = 242328 },
+    { url = "https://files.pythonhosted.org/packages/6e/a3/46f2d420d86bbcb8fe660b26a10a219871a0fbf4d43cb846a4031533f3e0/multidict-6.6.3-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:712b348f7f449948e0a6c4564a21c7db965af900973a67db432d724619b3c680", size = 268057 },
+    { url = "https://files.pythonhosted.org/packages/9e/73/1c743542fe00794a2ec7466abd3f312ccb8fad8dff9f36d42e18fb1ec33e/multidict-6.6.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:e4e15d2138ee2694e038e33b7c3da70e6b0ad8868b9f8094a72e1414aeda9c1a", size = 269341 },
+    { url = "https://files.pythonhosted.org/packages/a4/11/6ec9dcbe2264b92778eeb85407d1df18812248bf3506a5a1754bc035db0c/multidict-6.6.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8df25594989aebff8a130f7899fa03cbfcc5d2b5f4a461cf2518236fe6f15961", size = 256081 },
+    { url = "https://files.pythonhosted.org/packages/9b/2b/631b1e2afeb5f1696846d747d36cda075bfdc0bc7245d6ba5c319278d6c4/multidict-6.6.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:159ca68bfd284a8860f8d8112cf0521113bffd9c17568579e4d13d1f1dc76b65", size = 253581 },
+    { url = "https://files.pythonhosted.org/packages/bf/0e/7e3b93f79efeb6111d3bf9a1a69e555ba1d07ad1c11bceb56b7310d0d7ee/multidict-6.6.3-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:e098c17856a8c9ade81b4810888c5ad1914099657226283cab3062c0540b0643", size = 250750 },
+    { url = "https://files.pythonhosted.org/packages/ad/9e/086846c1d6601948e7de556ee464a2d4c85e33883e749f46b9547d7b0704/multidict-6.6.3-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:67c92ed673049dec52d7ed39f8cf9ebbadf5032c774058b4406d18c8f8fe7063", size = 251548 },
+    { url = "https://files.pythonhosted.org/packages/8c/7b/86ec260118e522f1a31550e87b23542294880c97cfbf6fb18cc67b044c66/multidict-6.6.3-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:bd0578596e3a835ef451784053cfd327d607fc39ea1a14812139339a18a0dbc3", size = 262718 },
+    { url = "https://files.pythonhosted.org/packages/8c/bd/22ce8f47abb0be04692c9fc4638508b8340987b18691aa7775d927b73f72/multidict-6.6.3-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:346055630a2df2115cd23ae271910b4cae40f4e336773550dca4889b12916e75", size = 259603 },
+    { url = "https://files.pythonhosted.org/packages/07/9c/91b7ac1691be95cd1f4a26e36a74b97cda6aa9820632d31aab4410f46ebd/multidict-6.6.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:555ff55a359302b79de97e0468e9ee80637b0de1fce77721639f7cd9440b3a10", size = 251351 },
+    { url = "https://files.pythonhosted.org/packages/6f/5c/4d7adc739884f7a9fbe00d1eac8c034023ef8bad71f2ebe12823ca2e3649/multidict-6.6.3-cp312-cp312-win32.whl", hash = "sha256:73ab034fb8d58ff85c2bcbadc470efc3fafeea8affcf8722855fb94557f14cc5", size = 41860 },
+    { url = "https://files.pythonhosted.org/packages/6a/a3/0fbc7afdf7cb1aa12a086b02959307848eb6bcc8f66fcb66c0cb57e2a2c1/multidict-6.6.3-cp312-cp312-win_amd64.whl", hash = "sha256:04cbcce84f63b9af41bad04a54d4cc4e60e90c35b9e6ccb130be2d75b71f8c17", size = 45982 },
+    { url = "https://files.pythonhosted.org/packages/b8/95/8c825bd70ff9b02462dc18d1295dd08d3e9e4eb66856d292ffa62cfe1920/multidict-6.6.3-cp312-cp312-win_arm64.whl", hash = "sha256:0f1130b896ecb52d2a1e615260f3ea2af55fa7dc3d7c3003ba0c3121a759b18b", size = 43210 },
+    { url = "https://files.pythonhosted.org/packages/52/1d/0bebcbbb4f000751fbd09957257903d6e002943fc668d841a4cf2fb7f872/multidict-6.6.3-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:540d3c06d48507357a7d57721e5094b4f7093399a0106c211f33540fdc374d55", size = 75843 },
+    { url = "https://files.pythonhosted.org/packages/07/8f/cbe241b0434cfe257f65c2b1bcf9e8d5fb52bc708c5061fb29b0fed22bdf/multidict-6.6.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:9c19cea2a690f04247d43f366d03e4eb110a0dc4cd1bbeee4d445435428ed35b", size = 45053 },
+    { url = "https://files.pythonhosted.org/packages/32/d2/0b3b23f9dbad5b270b22a3ac3ea73ed0a50ef2d9a390447061178ed6bdb8/multidict-6.6.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7af039820cfd00effec86bda5d8debef711a3e86a1d3772e85bea0f243a4bd65", size = 43273 },
+    { url = "https://files.pythonhosted.org/packages/fd/fe/6eb68927e823999e3683bc49678eb20374ba9615097d085298fd5b386564/multidict-6.6.3-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:500b84f51654fdc3944e936f2922114349bf8fdcac77c3092b03449f0e5bc2b3", size = 237124 },
+    { url = "https://files.pythonhosted.org/packages/e7/ab/320d8507e7726c460cb77117848b3834ea0d59e769f36fdae495f7669929/multidict-6.6.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f3fc723ab8a5c5ed6c50418e9bfcd8e6dceba6c271cee6728a10a4ed8561520c", size = 256892 },
+    { url = "https://files.pythonhosted.org/packages/76/60/38ee422db515ac69834e60142a1a69111ac96026e76e8e9aa347fd2e4591/multidict-6.6.3-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:94c47ea3ade005b5976789baaed66d4de4480d0a0bf31cef6edaa41c1e7b56a6", size = 240547 },
+    { url = "https://files.pythonhosted.org/packages/27/fb/905224fde2dff042b030c27ad95a7ae744325cf54b890b443d30a789b80e/multidict-6.6.3-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:dbc7cf464cc6d67e83e136c9f55726da3a30176f020a36ead246eceed87f1cd8", size = 266223 },
+    { url = "https://files.pythonhosted.org/packages/76/35/dc38ab361051beae08d1a53965e3e1a418752fc5be4d3fb983c5582d8784/multidict-6.6.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:900eb9f9da25ada070f8ee4a23f884e0ee66fe4e1a38c3af644256a508ad81ca", size = 267262 },
+    { url = "https://files.pythonhosted.org/packages/1f/a3/0a485b7f36e422421b17e2bbb5a81c1af10eac1d4476f2ff92927c730479/multidict-6.6.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7c6df517cf177da5d47ab15407143a89cd1a23f8b335f3a28d57e8b0a3dbb884", size = 254345 },
+    { url = "https://files.pythonhosted.org/packages/b4/59/bcdd52c1dab7c0e0d75ff19cac751fbd5f850d1fc39172ce809a74aa9ea4/multidict-6.6.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4ef421045f13879e21c994b36e728d8e7d126c91a64b9185810ab51d474f27e7", size = 252248 },
+    { url = "https://files.pythonhosted.org/packages/bb/a4/2d96aaa6eae8067ce108d4acee6f45ced5728beda55c0f02ae1072c730d1/multidict-6.6.3-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:6c1e61bb4f80895c081790b6b09fa49e13566df8fbff817da3f85b3a8192e36b", size = 250115 },
+    { url = "https://files.pythonhosted.org/packages/25/d2/ed9f847fa5c7d0677d4f02ea2c163d5e48573de3f57bacf5670e43a5ffaa/multidict-6.6.3-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:e5e8523bb12d7623cd8300dbd91b9e439a46a028cd078ca695eb66ba31adee3c", size = 249649 },
+    { url = "https://files.pythonhosted.org/packages/1f/af/9155850372563fc550803d3f25373308aa70f59b52cff25854086ecb4a79/multidict-6.6.3-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:ef58340cc896219e4e653dade08fea5c55c6df41bcc68122e3be3e9d873d9a7b", size = 261203 },
+    { url = "https://files.pythonhosted.org/packages/36/2f/c6a728f699896252cf309769089568a33c6439626648843f78743660709d/multidict-6.6.3-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:fc9dc435ec8699e7b602b94fe0cd4703e69273a01cbc34409af29e7820f777f1", size = 258051 },
+    { url = "https://files.pythonhosted.org/packages/d0/60/689880776d6b18fa2b70f6cc74ff87dd6c6b9b47bd9cf74c16fecfaa6ad9/multidict-6.6.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9e864486ef4ab07db5e9cb997bad2b681514158d6954dd1958dfb163b83d53e6", size = 249601 },
+    { url = "https://files.pythonhosted.org/packages/75/5e/325b11f2222a549019cf2ef879c1f81f94a0d40ace3ef55cf529915ba6cc/multidict-6.6.3-cp313-cp313-win32.whl", hash = "sha256:5633a82fba8e841bc5c5c06b16e21529573cd654f67fd833650a215520a6210e", size = 41683 },
+    { url = "https://files.pythonhosted.org/packages/b1/ad/cf46e73f5d6e3c775cabd2a05976547f3f18b39bee06260369a42501f053/multidict-6.6.3-cp313-cp313-win_amd64.whl", hash = "sha256:e93089c1570a4ad54c3714a12c2cef549dc9d58e97bcded193d928649cab78e9", size = 45811 },
+    { url = "https://files.pythonhosted.org/packages/c5/c9/2e3fe950db28fb7c62e1a5f46e1e38759b072e2089209bc033c2798bb5ec/multidict-6.6.3-cp313-cp313-win_arm64.whl", hash = "sha256:c60b401f192e79caec61f166da9c924e9f8bc65548d4246842df91651e83d600", size = 43056 },
+    { url = "https://files.pythonhosted.org/packages/3a/58/aaf8114cf34966e084a8cc9517771288adb53465188843d5a19862cb6dc3/multidict-6.6.3-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:02fd8f32d403a6ff13864b0851f1f523d4c988051eea0471d4f1fd8010f11134", size = 82811 },
+    { url = "https://files.pythonhosted.org/packages/71/af/5402e7b58a1f5b987a07ad98f2501fdba2a4f4b4c30cf114e3ce8db64c87/multidict-6.6.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:f3aa090106b1543f3f87b2041eef3c156c8da2aed90c63a2fbed62d875c49c37", size = 48304 },
+    { url = "https://files.pythonhosted.org/packages/39/65/ab3c8cafe21adb45b24a50266fd747147dec7847425bc2a0f6934b3ae9ce/multidict-6.6.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e924fb978615a5e33ff644cc42e6aa241effcf4f3322c09d4f8cebde95aff5f8", size = 46775 },
+    { url = "https://files.pythonhosted.org/packages/49/ba/9fcc1b332f67cc0c0c8079e263bfab6660f87fe4e28a35921771ff3eea0d/multidict-6.6.3-cp313-cp313t-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:b9fe5a0e57c6dbd0e2ce81ca66272282c32cd11d31658ee9553849d91289e1c1", size = 229773 },
+    { url = "https://files.pythonhosted.org/packages/a4/14/0145a251f555f7c754ce2dcbcd012939bbd1f34f066fa5d28a50e722a054/multidict-6.6.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b24576f208793ebae00280c59927c3b7c2a3b1655e443a25f753c4611bc1c373", size = 250083 },
+    { url = "https://files.pythonhosted.org/packages/9e/d4/d5c0bd2bbb173b586c249a151a26d2fb3ec7d53c96e42091c9fef4e1f10c/multidict-6.6.3-cp313-cp313t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:135631cb6c58eac37d7ac0df380294fecdc026b28837fa07c02e459c7fb9c54e", size = 228980 },
+    { url = "https://files.pythonhosted.org/packages/21/32/c9a2d8444a50ec48c4733ccc67254100c10e1c8ae8e40c7a2d2183b59b97/multidict-6.6.3-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:274d416b0df887aef98f19f21578653982cfb8a05b4e187d4a17103322eeaf8f", size = 257776 },
+    { url = "https://files.pythonhosted.org/packages/68/d0/14fa1699f4ef629eae08ad6201c6b476098f5efb051b296f4c26be7a9fdf/multidict-6.6.3-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:e252017a817fad7ce05cafbe5711ed40faeb580e63b16755a3a24e66fa1d87c0", size = 256882 },
+    { url = "https://files.pythonhosted.org/packages/da/88/84a27570fbe303c65607d517a5f147cd2fc046c2d1da02b84b17b9bdc2aa/multidict-6.6.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2e4cc8d848cd4fe1cdee28c13ea79ab0ed37fc2e89dd77bac86a2e7959a8c3bc", size = 247816 },
+    { url = "https://files.pythonhosted.org/packages/1c/60/dca352a0c999ce96a5d8b8ee0b2b9f729dcad2e0b0c195f8286269a2074c/multidict-6.6.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9e236a7094b9c4c1b7585f6b9cca34b9d833cf079f7e4c49e6a4a6ec9bfdc68f", size = 245341 },
+    { url = "https://files.pythonhosted.org/packages/50/ef/433fa3ed06028f03946f3993223dada70fb700f763f70c00079533c34578/multidict-6.6.3-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:e0cb0ab69915c55627c933f0b555a943d98ba71b4d1c57bc0d0a66e2567c7471", size = 235854 },
+    { url = "https://files.pythonhosted.org/packages/1b/1f/487612ab56fbe35715320905215a57fede20de7db40a261759690dc80471/multidict-6.6.3-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:81ef2f64593aba09c5212a3d0f8c906a0d38d710a011f2f42759704d4557d3f2", size = 243432 },
+    { url = "https://files.pythonhosted.org/packages/da/6f/ce8b79de16cd885c6f9052c96a3671373d00c59b3ee635ea93e6e81b8ccf/multidict-6.6.3-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:b9cbc60010de3562545fa198bfc6d3825df430ea96d2cc509c39bd71e2e7d648", size = 252731 },
+    { url = "https://files.pythonhosted.org/packages/bb/fe/a2514a6aba78e5abefa1624ca85ae18f542d95ac5cde2e3815a9fbf369aa/multidict-6.6.3-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:70d974eaaa37211390cd02ef93b7e938de564bbffa866f0b08d07e5e65da783d", size = 247086 },
+    { url = "https://files.pythonhosted.org/packages/8c/22/b788718d63bb3cce752d107a57c85fcd1a212c6c778628567c9713f9345a/multidict-6.6.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:3713303e4a6663c6d01d648a68f2848701001f3390a030edaaf3fc949c90bf7c", size = 243338 },
+    { url = "https://files.pythonhosted.org/packages/22/d6/fdb3d0670819f2228f3f7d9af613d5e652c15d170c83e5f1c94fbc55a25b/multidict-6.6.3-cp313-cp313t-win32.whl", hash = "sha256:639ecc9fe7cd73f2495f62c213e964843826f44505a3e5d82805aa85cac6f89e", size = 47812 },
+    { url = "https://files.pythonhosted.org/packages/b6/d6/a9d2c808f2c489ad199723197419207ecbfbc1776f6e155e1ecea9c883aa/multidict-6.6.3-cp313-cp313t-win_amd64.whl", hash = "sha256:9f97e181f344a0ef3881b573d31de8542cc0dbc559ec68c8f8b5ce2c2e91646d", size = 53011 },
+    { url = "https://files.pythonhosted.org/packages/f2/40/b68001cba8188dd267590a111f9661b6256debc327137667e832bf5d66e8/multidict-6.6.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ce8b7693da41a3c4fde5871c738a81490cea5496c671d74374c8ab889e1834fb", size = 45254 },
+    { url = "https://files.pythonhosted.org/packages/d8/30/9aec301e9772b098c1f5c0ca0279237c9766d94b97802e9888010c64b0ed/multidict-6.6.3-py3-none-any.whl", hash = "sha256:8db10f29c7541fc5da4defd8cd697e1ca429db743fa716325f236079b96f775a", size = 12313 },
+]
+
+[[package]]
+name = "opentelemetry-api"
+version = "1.35.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "importlib-metadata" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/99/c9/4509bfca6bb43220ce7f863c9f791e0d5001c2ec2b5867d48586008b3d96/opentelemetry_api-1.35.0.tar.gz", hash = "sha256:a111b959bcfa5b4d7dffc2fbd6a241aa72dd78dd8e79b5b1662bda896c5d2ffe", size = 64778 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/5a/3f8d078dbf55d18442f6a2ecedf6786d81d7245844b2b20ce2b8ad6f0307/opentelemetry_api-1.35.0-py3-none-any.whl", hash = "sha256:c4ea7e258a244858daf18474625e9cc0149b8ee354f37843415771a40c25ee06", size = 65566 },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-common"
+version = "1.35.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-proto" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/56/d1/887f860529cba7fc3aba2f6a3597fefec010a17bd1b126810724707d9b51/opentelemetry_exporter_otlp_proto_common-1.35.0.tar.gz", hash = "sha256:6f6d8c39f629b9fa5c79ce19a2829dbd93034f8ac51243cdf40ed2196f00d7eb", size = 20299 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/2c/e31dd3c719bff87fa77391eb7f38b1430d22868c52312cba8aad60f280e5/opentelemetry_exporter_otlp_proto_common-1.35.0-py3-none-any.whl", hash = "sha256:863465de697ae81279ede660f3918680b4480ef5f69dcdac04f30722ed7b74cc", size = 18349 },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-http"
+version = "1.35.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-common" },
+    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-sdk" },
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/88/7f/7bdc06e84266a5b4b0fefd9790b3859804bf7682ce2daabcba2e22fdb3b2/opentelemetry_exporter_otlp_proto_http-1.35.0.tar.gz", hash = "sha256:cf940147f91b450ef5f66e9980d40eb187582eed399fa851f4a7a45bb880de79", size = 15908 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/71/f118cd90dc26797077931dd598bde5e0cc652519db166593f962f8fcd022/opentelemetry_exporter_otlp_proto_http-1.35.0-py3-none-any.whl", hash = "sha256:9a001e3df3c7f160fb31056a28ed7faa2de7df68877ae909516102ae36a54e1d", size = 18589 },
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "1.35.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dc/a2/7366e32d9a2bccbb8614942dbea2cf93c209610385ea966cb050334f8df7/opentelemetry_proto-1.35.0.tar.gz", hash = "sha256:532497341bd3e1c074def7c5b00172601b28bb83b48afc41a4b779f26eb4ee05", size = 46151 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/a7/3f05de580da7e8a8b8dff041d3d07a20bf3bb62d3bcc027f8fd669a73ff4/opentelemetry_proto-1.35.0-py3-none-any.whl", hash = "sha256:98fffa803164499f562718384e703be8d7dfbe680192279a0429cb150a2f8809", size = 72536 },
+]
+
+[[package]]
+name = "opentelemetry-sdk"
+version = "1.35.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9a/cf/1eb2ed2ce55e0a9aa95b3007f26f55c7943aeef0a783bb006bdd92b3299e/opentelemetry_sdk-1.35.0.tar.gz", hash = "sha256:2a400b415ab68aaa6f04e8a6a9f6552908fb3090ae2ff78d6ae0c597ac581954", size = 160871 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/01/4f/8e32b757ef3b660511b638ab52d1ed9259b666bdeeceba51a082ce3aea95/opentelemetry_sdk-1.35.0-py3-none-any.whl", hash = "sha256:223d9e5f5678518f4842311bb73966e0b6db5d1e0b74e35074c052cd2487f800", size = 119379 },
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.56b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/32/8e/214fa817f63b9f068519463d8ab46afd5d03b98930c39394a37ae3e741d0/opentelemetry_semantic_conventions-0.56b0.tar.gz", hash = "sha256:c114c2eacc8ff6d3908cb328c811eaf64e6d68623840be9224dc829c4fd6c2ea", size = 124221 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/3f/e80c1b017066a9d999efffe88d1cce66116dcf5cb7f80c41040a83b6e03b/opentelemetry_semantic_conventions-0.56b0-py3-none-any.whl", hash = "sha256:df44492868fd6b482511cc43a942e7194be64e94945f572db24df2e279a001a2", size = 201625 },
+]
+
+[[package]]
+name = "pip"
+version = "25.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/59/de/241caa0ca606f2ec5fe0c1f4261b0465df78d786a38da693864a116c37f4/pip-25.1.1.tar.gz", hash = "sha256:3de45d411d308d5054c2168185d8da7f9a2cd753dbac8acbfa88a8909ecd9077", size = 1940155 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/29/a2/d40fb2460e883eca5199c62cfc2463fd261f760556ae6290f88488c362c0/pip-25.1.1-py3-none-any.whl", hash = "sha256:2913a38a2abf4ea6b64ab507bd9e967f3b53dc1ede74b01b0931e1ce548751af", size = 1825227 },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.3.8"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/8b/3c73abc9c759ecd3f1f7ceff6685840859e8070c4d947c93fae71f6a0bf2/platformdirs-4.3.8.tar.gz", hash = "sha256:3d512d96e16bcb959a814c9f348431070822a6496326a4be0911c40b5a74c2bc", size = 21362 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/39/979e8e21520d4e47a0bbe349e2713c0aac6f3d853d0e5b34d76206c439aa/platformdirs-4.3.8-py3-none-any.whl", hash = "sha256:ff7059bb7eb1179e2685604f4aaf157cfd9535242bd23742eadc3c13542139b4", size = 18567 },
+]
+
+[[package]]
+name = "propcache"
+version = "0.3.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a6/16/43264e4a779dd8588c21a70f0709665ee8f611211bdd2c87d952cfa7c776/propcache-0.3.2.tar.gz", hash = "sha256:20d7d62e4e7ef05f221e0db2856b979540686342e7dd9973b815599c7057e168", size = 44139 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/42/9ca01b0a6f48e81615dca4765a8f1dd2c057e0540f6116a27dc5ee01dfb6/propcache-0.3.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:8de106b6c84506b31c27168582cd3cb3000a6412c16df14a8628e5871ff83c10", size = 73674 },
+    { url = "https://files.pythonhosted.org/packages/af/6e/21293133beb550f9c901bbece755d582bfaf2176bee4774000bd4dd41884/propcache-0.3.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:28710b0d3975117239c76600ea351934ac7b5ff56e60953474342608dbbb6154", size = 43570 },
+    { url = "https://files.pythonhosted.org/packages/0c/c8/0393a0a3a2b8760eb3bde3c147f62b20044f0ddac81e9d6ed7318ec0d852/propcache-0.3.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ce26862344bdf836650ed2487c3d724b00fbfec4233a1013f597b78c1cb73615", size = 43094 },
+    { url = "https://files.pythonhosted.org/packages/37/2c/489afe311a690399d04a3e03b069225670c1d489eb7b044a566511c1c498/propcache-0.3.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bca54bd347a253af2cf4544bbec232ab982f4868de0dd684246b67a51bc6b1db", size = 226958 },
+    { url = "https://files.pythonhosted.org/packages/9d/ca/63b520d2f3d418c968bf596839ae26cf7f87bead026b6192d4da6a08c467/propcache-0.3.2-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:55780d5e9a2ddc59711d727226bb1ba83a22dd32f64ee15594b9392b1f544eb1", size = 234894 },
+    { url = "https://files.pythonhosted.org/packages/11/60/1d0ed6fff455a028d678df30cc28dcee7af77fa2b0e6962ce1df95c9a2a9/propcache-0.3.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:035e631be25d6975ed87ab23153db6a73426a48db688070d925aa27e996fe93c", size = 233672 },
+    { url = "https://files.pythonhosted.org/packages/37/7c/54fd5301ef38505ab235d98827207176a5c9b2aa61939b10a460ca53e123/propcache-0.3.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ee6f22b6eaa39297c751d0e80c0d3a454f112f5c6481214fcf4c092074cecd67", size = 224395 },
+    { url = "https://files.pythonhosted.org/packages/ee/1a/89a40e0846f5de05fdc6779883bf46ba980e6df4d2ff8fb02643de126592/propcache-0.3.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7ca3aee1aa955438c4dba34fc20a9f390e4c79967257d830f137bd5a8a32ed3b", size = 212510 },
+    { url = "https://files.pythonhosted.org/packages/5e/33/ca98368586c9566a6b8d5ef66e30484f8da84c0aac3f2d9aec6d31a11bd5/propcache-0.3.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:7a4f30862869fa2b68380d677cc1c5fcf1e0f2b9ea0cf665812895c75d0ca3b8", size = 222949 },
+    { url = "https://files.pythonhosted.org/packages/ba/11/ace870d0aafe443b33b2f0b7efdb872b7c3abd505bfb4890716ad7865e9d/propcache-0.3.2-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:b77ec3c257d7816d9f3700013639db7491a434644c906a2578a11daf13176251", size = 217258 },
+    { url = "https://files.pythonhosted.org/packages/5b/d2/86fd6f7adffcfc74b42c10a6b7db721d1d9ca1055c45d39a1a8f2a740a21/propcache-0.3.2-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:cab90ac9d3f14b2d5050928483d3d3b8fb6b4018893fc75710e6aa361ecb2474", size = 213036 },
+    { url = "https://files.pythonhosted.org/packages/07/94/2d7d1e328f45ff34a0a284cf5a2847013701e24c2a53117e7c280a4316b3/propcache-0.3.2-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:0b504d29f3c47cf6b9e936c1852246c83d450e8e063d50562115a6be6d3a2535", size = 227684 },
+    { url = "https://files.pythonhosted.org/packages/b7/05/37ae63a0087677e90b1d14710e532ff104d44bc1efa3b3970fff99b891dc/propcache-0.3.2-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:ce2ac2675a6aa41ddb2a0c9cbff53780a617ac3d43e620f8fd77ba1c84dcfc06", size = 234562 },
+    { url = "https://files.pythonhosted.org/packages/a4/7c/3f539fcae630408d0bd8bf3208b9a647ccad10976eda62402a80adf8fc34/propcache-0.3.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:62b4239611205294cc433845b914131b2a1f03500ff3c1ed093ed216b82621e1", size = 222142 },
+    { url = "https://files.pythonhosted.org/packages/7c/d2/34b9eac8c35f79f8a962546b3e97e9d4b990c420ee66ac8255d5d9611648/propcache-0.3.2-cp312-cp312-win32.whl", hash = "sha256:df4a81b9b53449ebc90cc4deefb052c1dd934ba85012aa912c7ea7b7e38b60c1", size = 37711 },
+    { url = "https://files.pythonhosted.org/packages/19/61/d582be5d226cf79071681d1b46b848d6cb03d7b70af7063e33a2787eaa03/propcache-0.3.2-cp312-cp312-win_amd64.whl", hash = "sha256:7046e79b989d7fe457bb755844019e10f693752d169076138abf17f31380800c", size = 41479 },
+    { url = "https://files.pythonhosted.org/packages/dc/d1/8c747fafa558c603c4ca19d8e20b288aa0c7cda74e9402f50f31eb65267e/propcache-0.3.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:ca592ed634a73ca002967458187109265e980422116c0a107cf93d81f95af945", size = 71286 },
+    { url = "https://files.pythonhosted.org/packages/61/99/d606cb7986b60d89c36de8a85d58764323b3a5ff07770a99d8e993b3fa73/propcache-0.3.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:9ecb0aad4020e275652ba3975740f241bd12a61f1a784df044cf7477a02bc252", size = 42425 },
+    { url = "https://files.pythonhosted.org/packages/8c/96/ef98f91bbb42b79e9bb82bdd348b255eb9d65f14dbbe3b1594644c4073f7/propcache-0.3.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7f08f1cc28bd2eade7a8a3d2954ccc673bb02062e3e7da09bc75d843386b342f", size = 41846 },
+    { url = "https://files.pythonhosted.org/packages/5b/ad/3f0f9a705fb630d175146cd7b1d2bf5555c9beaed54e94132b21aac098a6/propcache-0.3.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d1a342c834734edb4be5ecb1e9fb48cb64b1e2320fccbd8c54bf8da8f2a84c33", size = 208871 },
+    { url = "https://files.pythonhosted.org/packages/3a/38/2085cda93d2c8b6ec3e92af2c89489a36a5886b712a34ab25de9fbca7992/propcache-0.3.2-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8a544caaae1ac73f1fecfae70ded3e93728831affebd017d53449e3ac052ac1e", size = 215720 },
+    { url = "https://files.pythonhosted.org/packages/61/c1/d72ea2dc83ac7f2c8e182786ab0fc2c7bd123a1ff9b7975bee671866fe5f/propcache-0.3.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:310d11aa44635298397db47a3ebce7db99a4cc4b9bbdfcf6c98a60c8d5261cf1", size = 215203 },
+    { url = "https://files.pythonhosted.org/packages/af/81/b324c44ae60c56ef12007105f1460d5c304b0626ab0cc6b07c8f2a9aa0b8/propcache-0.3.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4c1396592321ac83157ac03a2023aa6cc4a3cc3cfdecb71090054c09e5a7cce3", size = 206365 },
+    { url = "https://files.pythonhosted.org/packages/09/73/88549128bb89e66d2aff242488f62869014ae092db63ccea53c1cc75a81d/propcache-0.3.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8cabf5b5902272565e78197edb682017d21cf3b550ba0460ee473753f28d23c1", size = 196016 },
+    { url = "https://files.pythonhosted.org/packages/b9/3f/3bdd14e737d145114a5eb83cb172903afba7242f67c5877f9909a20d948d/propcache-0.3.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:0a2f2235ac46a7aa25bdeb03a9e7060f6ecbd213b1f9101c43b3090ffb971ef6", size = 205596 },
+    { url = "https://files.pythonhosted.org/packages/0f/ca/2f4aa819c357d3107c3763d7ef42c03980f9ed5c48c82e01e25945d437c1/propcache-0.3.2-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:92b69e12e34869a6970fd2f3da91669899994b47c98f5d430b781c26f1d9f387", size = 200977 },
+    { url = "https://files.pythonhosted.org/packages/cd/4a/e65276c7477533c59085251ae88505caf6831c0e85ff8b2e31ebcbb949b1/propcache-0.3.2-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:54e02207c79968ebbdffc169591009f4474dde3b4679e16634d34c9363ff56b4", size = 197220 },
+    { url = "https://files.pythonhosted.org/packages/7c/54/fc7152e517cf5578278b242396ce4d4b36795423988ef39bb8cd5bf274c8/propcache-0.3.2-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:4adfb44cb588001f68c5466579d3f1157ca07f7504fc91ec87862e2b8e556b88", size = 210642 },
+    { url = "https://files.pythonhosted.org/packages/b9/80/abeb4a896d2767bf5f1ea7b92eb7be6a5330645bd7fb844049c0e4045d9d/propcache-0.3.2-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:fd3e6019dc1261cd0291ee8919dd91fbab7b169bb76aeef6c716833a3f65d206", size = 212789 },
+    { url = "https://files.pythonhosted.org/packages/b3/db/ea12a49aa7b2b6d68a5da8293dcf50068d48d088100ac016ad92a6a780e6/propcache-0.3.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4c181cad81158d71c41a2bce88edce078458e2dd5ffee7eddd6b05da85079f43", size = 205880 },
+    { url = "https://files.pythonhosted.org/packages/d1/e5/9076a0bbbfb65d1198007059c65639dfd56266cf8e477a9707e4b1999ff4/propcache-0.3.2-cp313-cp313-win32.whl", hash = "sha256:8a08154613f2249519e549de2330cf8e2071c2887309a7b07fb56098f5170a02", size = 37220 },
+    { url = "https://files.pythonhosted.org/packages/d3/f5/b369e026b09a26cd77aa88d8fffd69141d2ae00a2abaaf5380d2603f4b7f/propcache-0.3.2-cp313-cp313-win_amd64.whl", hash = "sha256:e41671f1594fc4ab0a6dec1351864713cb3a279910ae8b58f884a88a0a632c05", size = 40678 },
+    { url = "https://files.pythonhosted.org/packages/a4/3a/6ece377b55544941a08d03581c7bc400a3c8cd3c2865900a68d5de79e21f/propcache-0.3.2-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:9a3cf035bbaf035f109987d9d55dc90e4b0e36e04bbbb95af3055ef17194057b", size = 76560 },
+    { url = "https://files.pythonhosted.org/packages/0c/da/64a2bb16418740fa634b0e9c3d29edff1db07f56d3546ca2d86ddf0305e1/propcache-0.3.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:156c03d07dc1323d8dacaa221fbe028c5c70d16709cdd63502778e6c3ccca1b0", size = 44676 },
+    { url = "https://files.pythonhosted.org/packages/36/7b/f025e06ea51cb72c52fb87e9b395cced02786610b60a3ed51da8af017170/propcache-0.3.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:74413c0ba02ba86f55cf60d18daab219f7e531620c15f1e23d95563f505efe7e", size = 44701 },
+    { url = "https://files.pythonhosted.org/packages/a4/00/faa1b1b7c3b74fc277f8642f32a4c72ba1d7b2de36d7cdfb676db7f4303e/propcache-0.3.2-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f066b437bb3fa39c58ff97ab2ca351db465157d68ed0440abecb21715eb24b28", size = 276934 },
+    { url = "https://files.pythonhosted.org/packages/74/ab/935beb6f1756e0476a4d5938ff44bf0d13a055fed880caf93859b4f1baf4/propcache-0.3.2-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f1304b085c83067914721e7e9d9917d41ad87696bf70f0bc7dee450e9c71ad0a", size = 278316 },
+    { url = "https://files.pythonhosted.org/packages/f8/9d/994a5c1ce4389610838d1caec74bdf0e98b306c70314d46dbe4fcf21a3e2/propcache-0.3.2-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ab50cef01b372763a13333b4e54021bdcb291fc9a8e2ccb9c2df98be51bcde6c", size = 282619 },
+    { url = "https://files.pythonhosted.org/packages/2b/00/a10afce3d1ed0287cef2e09506d3be9822513f2c1e96457ee369adb9a6cd/propcache-0.3.2-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fad3b2a085ec259ad2c2842666b2a0a49dea8463579c606426128925af1ed725", size = 265896 },
+    { url = "https://files.pythonhosted.org/packages/2e/a8/2aa6716ffa566ca57c749edb909ad27884680887d68517e4be41b02299f3/propcache-0.3.2-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:261fa020c1c14deafd54c76b014956e2f86991af198c51139faf41c4d5e83892", size = 252111 },
+    { url = "https://files.pythonhosted.org/packages/36/4f/345ca9183b85ac29c8694b0941f7484bf419c7f0fea2d1e386b4f7893eed/propcache-0.3.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:46d7f8aa79c927e5f987ee3a80205c987717d3659f035c85cf0c3680526bdb44", size = 268334 },
+    { url = "https://files.pythonhosted.org/packages/3e/ca/fcd54f78b59e3f97b3b9715501e3147f5340167733d27db423aa321e7148/propcache-0.3.2-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:6d8f3f0eebf73e3c0ff0e7853f68be638b4043c65a70517bb575eff54edd8dbe", size = 255026 },
+    { url = "https://files.pythonhosted.org/packages/8b/95/8e6a6bbbd78ac89c30c225210a5c687790e532ba4088afb8c0445b77ef37/propcache-0.3.2-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:03c89c1b14a5452cf15403e291c0ccd7751d5b9736ecb2c5bab977ad6c5bcd81", size = 250724 },
+    { url = "https://files.pythonhosted.org/packages/ee/b0/0dd03616142baba28e8b2d14ce5df6631b4673850a3d4f9c0f9dd714a404/propcache-0.3.2-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:0cc17efde71e12bbaad086d679ce575268d70bc123a5a71ea7ad76f70ba30bba", size = 268868 },
+    { url = "https://files.pythonhosted.org/packages/c5/98/2c12407a7e4fbacd94ddd32f3b1e3d5231e77c30ef7162b12a60e2dd5ce3/propcache-0.3.2-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:acdf05d00696bc0447e278bb53cb04ca72354e562cf88ea6f9107df8e7fd9770", size = 271322 },
+    { url = "https://files.pythonhosted.org/packages/35/91/9cb56efbb428b006bb85db28591e40b7736847b8331d43fe335acf95f6c8/propcache-0.3.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:4445542398bd0b5d32df908031cb1b30d43ac848e20470a878b770ec2dcc6330", size = 265778 },
+    { url = "https://files.pythonhosted.org/packages/9a/4c/b0fe775a2bdd01e176b14b574be679d84fc83958335790f7c9a686c1f468/propcache-0.3.2-cp313-cp313t-win32.whl", hash = "sha256:f86e5d7cd03afb3a1db8e9f9f6eff15794e79e791350ac48a8c924e6f439f394", size = 41175 },
+    { url = "https://files.pythonhosted.org/packages/a4/ff/47f08595e3d9b5e149c150f88d9714574f1a7cbd89fe2817158a952674bf/propcache-0.3.2-cp313-cp313t-win_amd64.whl", hash = "sha256:9704bedf6e7cbe3c65eca4379a9b53ee6a83749f047808cbb5044d40d7d72198", size = 44857 },
+    { url = "https://files.pythonhosted.org/packages/cc/35/cc0aaecf278bb4575b8555f2b137de5ab821595ddae9da9d3cd1da4072c7/propcache-0.3.2-py3-none-any.whl", hash = "sha256:98f1ec44fb675f5052cccc8e609c46ed23a35a1cfd18545ad4e29002d858a43f", size = 12663 },
+]
+
+[[package]]
+name = "protobuf"
+version = "6.31.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/f3/b9655a711b32c19720253f6f06326faf90580834e2e83f840472d752bc8b/protobuf-6.31.1.tar.gz", hash = "sha256:d8cac4c982f0b957a4dc73a80e2ea24fab08e679c0de9deb835f4a12d69aca9a", size = 441797 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f3/6f/6ab8e4bf962fd5570d3deaa2d5c38f0a363f57b4501047b5ebeb83ab1125/protobuf-6.31.1-cp310-abi3-win32.whl", hash = "sha256:7fa17d5a29c2e04b7d90e5e32388b8bfd0e7107cd8e616feef7ed3fa6bdab5c9", size = 423603 },
+    { url = "https://files.pythonhosted.org/packages/44/3a/b15c4347dd4bf3a1b0ee882f384623e2063bb5cf9fa9d57990a4f7df2fb6/protobuf-6.31.1-cp310-abi3-win_amd64.whl", hash = "sha256:426f59d2964864a1a366254fa703b8632dcec0790d8862d30034d8245e1cd447", size = 435283 },
+    { url = "https://files.pythonhosted.org/packages/6a/c9/b9689a2a250264a84e66c46d8862ba788ee7a641cdca39bccf64f59284b7/protobuf-6.31.1-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:6f1227473dc43d44ed644425268eb7c2e488ae245d51c6866d19fe158e207402", size = 425604 },
+    { url = "https://files.pythonhosted.org/packages/76/a1/7a5a94032c83375e4fe7e7f56e3976ea6ac90c5e85fac8576409e25c39c3/protobuf-6.31.1-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:a40fc12b84c154884d7d4c4ebd675d5b3b5283e155f324049ae396b95ddebc39", size = 322115 },
+    { url = "https://files.pythonhosted.org/packages/fa/b1/b59d405d64d31999244643d88c45c8241c58f17cc887e73bcb90602327f8/protobuf-6.31.1-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:4ee898bf66f7a8b0bd21bce523814e6fbd8c6add948045ce958b73af7e8878c6", size = 321070 },
+    { url = "https://files.pythonhosted.org/packages/f7/af/ab3c51ab7507a7325e98ffe691d9495ee3d3aa5f589afad65ec920d39821/protobuf-6.31.1-py3-none-any.whl", hash = "sha256:720a6c7e6b77288b85063569baae8536671b39f15cc22037ec7045658d80489e", size = 168724 },
+]
+
+[[package]]
+name = "pygments"
+version = "2.19.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217 },
+]
+
+[[package]]
+name = "requests"
+version = "2.32.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e1/0a/929373653770d8a0d7ea76c37de6e41f11eb07559b103b1c02cafb3f7cf8/requests-2.32.4.tar.gz", hash = "sha256:27d0316682c8a29834d3264820024b62a36942083d52caf2f14c0591336d3422", size = 135258 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/e4/56027c4a6b4ae70ca9de302488c5ca95ad4a39e190093d6c1a8ace08341b/requests-2.32.4-py3-none-any.whl", hash = "sha256:27babd3cda2a6d50b30443204ee89830707d396671944c998b5975b031ac2b2c", size = 64847 },
+]
+
+[[package]]
+name = "rich"
+version = "14.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a1/53/830aa4c3066a8ab0ae9a9955976fb770fe9c6102117c8ec4ab3ea62d89e8/rich-14.0.0.tar.gz", hash = "sha256:82f1bc23a6a21ebca4ae0c45af9bdbc492ed20231dcb63f297d6d1021a9d5725", size = 224078 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0d/9b/63f4c7ebc259242c89b3acafdb37b41d1185c07ff0011164674e9076b491/rich-14.0.0-py3-none-any.whl", hash = "sha256:1c9491e1951aac09caffd42f448ee3d04e58923ffe14993f6e83068dc395d7e0", size = 243229 },
+]
+
+[[package]]
+name = "sniffio"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235 },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.14.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/98/5a/da40306b885cc8c09109dc2e1abd358d5684b1425678151cdaed4731c822/typing_extensions-4.14.1.tar.gz", hash = "sha256:38b39f4aeeab64884ce9f74c94263ef78f3c22467c8724005483154c26648d36", size = 107673 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b5/00/d631e67a838026495268c2f6884f3711a15a9a2a96cd244fdaea53b823fb/typing_extensions-4.14.1-py3-none-any.whl", hash = "sha256:d1e1e3b58374dc93031d6eda2420a48ea44a36c2b4766a4fdeb3710755731d76", size = 43906 },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/15/22/9ee70a2574a4f4599c47dd506532914ce044817c7752a79b6a51286319bc/urllib3-2.5.0.tar.gz", hash = "sha256:3fc47733c7e419d4bc3f6b3dc2b4f890bb743906a30d56ba4a5bfa4bbff92760", size = 393185 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/c2/fe1e52489ae3122415c51f387e221dd0773709bad6c6cdaa599e8a2c5185/urllib3-2.5.0-py3-none-any.whl", hash = "sha256:e6b01673c0fa6a13e374b50871808eb3bf7046c4b125b216f6bf1cc604cff0dc", size = 129795 },
+]
+
+[[package]]
+name = "yarl"
+version = "1.20.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "multidict" },
+    { name = "propcache" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3c/fb/efaa23fa4e45537b827620f04cf8f3cd658b76642205162e072703a5b963/yarl-1.20.1.tar.gz", hash = "sha256:d017a4997ee50c91fd5466cef416231bb82177b93b029906cefc542ce14c35ac", size = 186428 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5f/9a/cb7fad7d73c69f296eda6815e4a2c7ed53fc70c2f136479a91c8e5fbdb6d/yarl-1.20.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:bdcc4cd244e58593a4379fe60fdee5ac0331f8eb70320a24d591a3be197b94a9", size = 133667 },
+    { url = "https://files.pythonhosted.org/packages/67/38/688577a1cb1e656e3971fb66a3492501c5a5df56d99722e57c98249e5b8a/yarl-1.20.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b29a2c385a5f5b9c7d9347e5812b6f7ab267193c62d282a540b4fc528c8a9d2a", size = 91025 },
+    { url = "https://files.pythonhosted.org/packages/50/ec/72991ae51febeb11a42813fc259f0d4c8e0507f2b74b5514618d8b640365/yarl-1.20.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1112ae8154186dfe2de4732197f59c05a83dc814849a5ced892b708033f40dc2", size = 89709 },
+    { url = "https://files.pythonhosted.org/packages/99/da/4d798025490e89426e9f976702e5f9482005c548c579bdae792a4c37769e/yarl-1.20.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:90bbd29c4fe234233f7fa2b9b121fb63c321830e5d05b45153a2ca68f7d310ee", size = 352287 },
+    { url = "https://files.pythonhosted.org/packages/1a/26/54a15c6a567aac1c61b18aa0f4b8aa2e285a52d547d1be8bf48abe2b3991/yarl-1.20.1-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:680e19c7ce3710ac4cd964e90dad99bf9b5029372ba0c7cbfcd55e54d90ea819", size = 345429 },
+    { url = "https://files.pythonhosted.org/packages/d6/95/9dcf2386cb875b234353b93ec43e40219e14900e046bf6ac118f94b1e353/yarl-1.20.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4a979218c1fdb4246a05efc2cc23859d47c89af463a90b99b7c56094daf25a16", size = 365429 },
+    { url = "https://files.pythonhosted.org/packages/91/b2/33a8750f6a4bc224242a635f5f2cff6d6ad5ba651f6edcccf721992c21a0/yarl-1.20.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:255b468adf57b4a7b65d8aad5b5138dce6a0752c139965711bdcb81bc370e1b6", size = 363862 },
+    { url = "https://files.pythonhosted.org/packages/98/28/3ab7acc5b51f4434b181b0cee8f1f4b77a65919700a355fb3617f9488874/yarl-1.20.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a97d67108e79cfe22e2b430d80d7571ae57d19f17cda8bb967057ca8a7bf5bfd", size = 355616 },
+    { url = "https://files.pythonhosted.org/packages/36/a3/f666894aa947a371724ec7cd2e5daa78ee8a777b21509b4252dd7bd15e29/yarl-1.20.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8570d998db4ddbfb9a590b185a0a33dbf8aafb831d07a5257b4ec9948df9cb0a", size = 339954 },
+    { url = "https://files.pythonhosted.org/packages/f1/81/5f466427e09773c04219d3450d7a1256138a010b6c9f0af2d48565e9ad13/yarl-1.20.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:97c75596019baae7c71ccf1d8cc4738bc08134060d0adfcbe5642f778d1dca38", size = 365575 },
+    { url = "https://files.pythonhosted.org/packages/2e/e3/e4b0ad8403e97e6c9972dd587388940a032f030ebec196ab81a3b8e94d31/yarl-1.20.1-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:1c48912653e63aef91ff988c5432832692ac5a1d8f0fb8a33091520b5bbe19ef", size = 365061 },
+    { url = "https://files.pythonhosted.org/packages/ac/99/b8a142e79eb86c926f9f06452eb13ecb1bb5713bd01dc0038faf5452e544/yarl-1.20.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:4c3ae28f3ae1563c50f3d37f064ddb1511ecc1d5584e88c6b7c63cf7702a6d5f", size = 364142 },
+    { url = "https://files.pythonhosted.org/packages/34/f2/08ed34a4a506d82a1a3e5bab99ccd930a040f9b6449e9fd050320e45845c/yarl-1.20.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:c5e9642f27036283550f5f57dc6156c51084b458570b9d0d96100c8bebb186a8", size = 381894 },
+    { url = "https://files.pythonhosted.org/packages/92/f8/9a3fbf0968eac704f681726eff595dce9b49c8a25cd92bf83df209668285/yarl-1.20.1-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:2c26b0c49220d5799f7b22c6838409ee9bc58ee5c95361a4d7831f03cc225b5a", size = 383378 },
+    { url = "https://files.pythonhosted.org/packages/af/85/9363f77bdfa1e4d690957cd39d192c4cacd1c58965df0470a4905253b54f/yarl-1.20.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:564ab3d517e3d01c408c67f2e5247aad4019dcf1969982aba3974b4093279004", size = 374069 },
+    { url = "https://files.pythonhosted.org/packages/35/99/9918c8739ba271dcd935400cff8b32e3cd319eaf02fcd023d5dcd487a7c8/yarl-1.20.1-cp312-cp312-win32.whl", hash = "sha256:daea0d313868da1cf2fac6b2d3a25c6e3a9e879483244be38c8e6a41f1d876a5", size = 81249 },
+    { url = "https://files.pythonhosted.org/packages/eb/83/5d9092950565481b413b31a23e75dd3418ff0a277d6e0abf3729d4d1ce25/yarl-1.20.1-cp312-cp312-win_amd64.whl", hash = "sha256:48ea7d7f9be0487339828a4de0360d7ce0efc06524a48e1810f945c45b813698", size = 86710 },
+    { url = "https://files.pythonhosted.org/packages/8a/e1/2411b6d7f769a07687acee88a062af5833cf1966b7266f3d8dfb3d3dc7d3/yarl-1.20.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:0b5ff0fbb7c9f1b1b5ab53330acbfc5247893069e7716840c8e7d5bb7355038a", size = 131811 },
+    { url = "https://files.pythonhosted.org/packages/b2/27/584394e1cb76fb771371770eccad35de400e7b434ce3142c2dd27392c968/yarl-1.20.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:14f326acd845c2b2e2eb38fb1346c94f7f3b01a4f5c788f8144f9b630bfff9a3", size = 90078 },
+    { url = "https://files.pythonhosted.org/packages/bf/9a/3246ae92d4049099f52d9b0fe3486e3b500e29b7ea872d0f152966fc209d/yarl-1.20.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f60e4ad5db23f0b96e49c018596707c3ae89f5d0bd97f0ad3684bcbad899f1e7", size = 88748 },
+    { url = "https://files.pythonhosted.org/packages/a3/25/35afe384e31115a1a801fbcf84012d7a066d89035befae7c5d4284df1e03/yarl-1.20.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:49bdd1b8e00ce57e68ba51916e4bb04461746e794e7c4d4bbc42ba2f18297691", size = 349595 },
+    { url = "https://files.pythonhosted.org/packages/28/2d/8aca6cb2cabc8f12efcb82749b9cefecbccfc7b0384e56cd71058ccee433/yarl-1.20.1-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:66252d780b45189975abfed839616e8fd2dbacbdc262105ad7742c6ae58f3e31", size = 342616 },
+    { url = "https://files.pythonhosted.org/packages/0b/e9/1312633d16b31acf0098d30440ca855e3492d66623dafb8e25b03d00c3da/yarl-1.20.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:59174e7332f5d153d8f7452a102b103e2e74035ad085f404df2e40e663a22b28", size = 361324 },
+    { url = "https://files.pythonhosted.org/packages/bc/a0/688cc99463f12f7669eec7c8acc71ef56a1521b99eab7cd3abb75af887b0/yarl-1.20.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e3968ec7d92a0c0f9ac34d5ecfd03869ec0cab0697c91a45db3fbbd95fe1b653", size = 359676 },
+    { url = "https://files.pythonhosted.org/packages/af/44/46407d7f7a56e9a85a4c207724c9f2c545c060380718eea9088f222ba697/yarl-1.20.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d1a4fbb50e14396ba3d375f68bfe02215d8e7bc3ec49da8341fe3157f59d2ff5", size = 352614 },
+    { url = "https://files.pythonhosted.org/packages/b1/91/31163295e82b8d5485d31d9cf7754d973d41915cadce070491778d9c9825/yarl-1.20.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:11a62c839c3a8eac2410e951301309426f368388ff2f33799052787035793b02", size = 336766 },
+    { url = "https://files.pythonhosted.org/packages/b4/8e/c41a5bc482121f51c083c4c2bcd16b9e01e1cf8729e380273a952513a21f/yarl-1.20.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:041eaa14f73ff5a8986b4388ac6bb43a77f2ea09bf1913df7a35d4646db69e53", size = 364615 },
+    { url = "https://files.pythonhosted.org/packages/e3/5b/61a3b054238d33d70ea06ebba7e58597891b71c699e247df35cc984ab393/yarl-1.20.1-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:377fae2fef158e8fd9d60b4c8751387b8d1fb121d3d0b8e9b0be07d1b41e83dc", size = 360982 },
+    { url = "https://files.pythonhosted.org/packages/df/a3/6a72fb83f8d478cb201d14927bc8040af901811a88e0ff2da7842dd0ed19/yarl-1.20.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:1c92f4390e407513f619d49319023664643d3339bd5e5a56a3bebe01bc67ec04", size = 369792 },
+    { url = "https://files.pythonhosted.org/packages/7c/af/4cc3c36dfc7c077f8dedb561eb21f69e1e9f2456b91b593882b0b18c19dc/yarl-1.20.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:d25ddcf954df1754ab0f86bb696af765c5bfaba39b74095f27eececa049ef9a4", size = 382049 },
+    { url = "https://files.pythonhosted.org/packages/19/3a/e54e2c4752160115183a66dc9ee75a153f81f3ab2ba4bf79c3c53b33de34/yarl-1.20.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:909313577e9619dcff8c31a0ea2aa0a2a828341d92673015456b3ae492e7317b", size = 384774 },
+    { url = "https://files.pythonhosted.org/packages/9c/20/200ae86dabfca89060ec6447649f219b4cbd94531e425e50d57e5f5ac330/yarl-1.20.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:793fd0580cb9664548c6b83c63b43c477212c0260891ddf86809e1c06c8b08f1", size = 374252 },
+    { url = "https://files.pythonhosted.org/packages/83/75/11ee332f2f516b3d094e89448da73d557687f7d137d5a0f48c40ff211487/yarl-1.20.1-cp313-cp313-win32.whl", hash = "sha256:468f6e40285de5a5b3c44981ca3a319a4b208ccc07d526b20b12aeedcfa654b7", size = 81198 },
+    { url = "https://files.pythonhosted.org/packages/ba/ba/39b1ecbf51620b40ab402b0fc817f0ff750f6d92712b44689c2c215be89d/yarl-1.20.1-cp313-cp313-win_amd64.whl", hash = "sha256:495b4ef2fea40596bfc0affe3837411d6aa3371abcf31aac0ccc4bdd64d4ef5c", size = 86346 },
+    { url = "https://files.pythonhosted.org/packages/43/c7/669c52519dca4c95153c8ad96dd123c79f354a376346b198f438e56ffeb4/yarl-1.20.1-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:f60233b98423aab21d249a30eb27c389c14929f47be8430efa7dbd91493a729d", size = 138826 },
+    { url = "https://files.pythonhosted.org/packages/6a/42/fc0053719b44f6ad04a75d7f05e0e9674d45ef62f2d9ad2c1163e5c05827/yarl-1.20.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:6f3eff4cc3f03d650d8755c6eefc844edde99d641d0dcf4da3ab27141a5f8ddf", size = 93217 },
+    { url = "https://files.pythonhosted.org/packages/4f/7f/fa59c4c27e2a076bba0d959386e26eba77eb52ea4a0aac48e3515c186b4c/yarl-1.20.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:69ff8439d8ba832d6bed88af2c2b3445977eba9a4588b787b32945871c2444e3", size = 92700 },
+    { url = "https://files.pythonhosted.org/packages/2f/d4/062b2f48e7c93481e88eff97a6312dca15ea200e959f23e96d8ab898c5b8/yarl-1.20.1-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3cf34efa60eb81dd2645a2e13e00bb98b76c35ab5061a3989c7a70f78c85006d", size = 347644 },
+    { url = "https://files.pythonhosted.org/packages/89/47/78b7f40d13c8f62b499cc702fdf69e090455518ae544c00a3bf4afc9fc77/yarl-1.20.1-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:8e0fe9364ad0fddab2688ce72cb7a8e61ea42eff3c7caeeb83874a5d479c896c", size = 323452 },
+    { url = "https://files.pythonhosted.org/packages/eb/2b/490d3b2dc66f52987d4ee0d3090a147ea67732ce6b4d61e362c1846d0d32/yarl-1.20.1-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8f64fbf81878ba914562c672024089e3401974a39767747691c65080a67b18c1", size = 346378 },
+    { url = "https://files.pythonhosted.org/packages/66/ad/775da9c8a94ce925d1537f939a4f17d782efef1f973039d821cbe4bcc211/yarl-1.20.1-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f6342d643bf9a1de97e512e45e4b9560a043347e779a173250824f8b254bd5ce", size = 353261 },
+    { url = "https://files.pythonhosted.org/packages/4b/23/0ed0922b47a4f5c6eb9065d5ff1e459747226ddce5c6a4c111e728c9f701/yarl-1.20.1-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:56dac5f452ed25eef0f6e3c6a066c6ab68971d96a9fb441791cad0efba6140d3", size = 335987 },
+    { url = "https://files.pythonhosted.org/packages/3e/49/bc728a7fe7d0e9336e2b78f0958a2d6b288ba89f25a1762407a222bf53c3/yarl-1.20.1-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c7d7f497126d65e2cad8dc5f97d34c27b19199b6414a40cb36b52f41b79014be", size = 329361 },
+    { url = "https://files.pythonhosted.org/packages/93/8f/b811b9d1f617c83c907e7082a76e2b92b655400e61730cd61a1f67178393/yarl-1.20.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:67e708dfb8e78d8a19169818eeb5c7a80717562de9051bf2413aca8e3696bf16", size = 346460 },
+    { url = "https://files.pythonhosted.org/packages/70/fd/af94f04f275f95da2c3b8b5e1d49e3e79f1ed8b6ceb0f1664cbd902773ff/yarl-1.20.1-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:595c07bc79af2494365cc96ddeb772f76272364ef7c80fb892ef9d0649586513", size = 334486 },
+    { url = "https://files.pythonhosted.org/packages/84/65/04c62e82704e7dd0a9b3f61dbaa8447f8507655fd16c51da0637b39b2910/yarl-1.20.1-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:7bdd2f80f4a7df852ab9ab49484a4dee8030023aa536df41f2d922fd57bf023f", size = 342219 },
+    { url = "https://files.pythonhosted.org/packages/91/95/459ca62eb958381b342d94ab9a4b6aec1ddec1f7057c487e926f03c06d30/yarl-1.20.1-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:c03bfebc4ae8d862f853a9757199677ab74ec25424d0ebd68a0027e9c639a390", size = 350693 },
+    { url = "https://files.pythonhosted.org/packages/a6/00/d393e82dd955ad20617abc546a8f1aee40534d599ff555ea053d0ec9bf03/yarl-1.20.1-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:344d1103e9c1523f32a5ed704d576172d2cabed3122ea90b1d4e11fe17c66458", size = 355803 },
+    { url = "https://files.pythonhosted.org/packages/9e/ed/c5fb04869b99b717985e244fd93029c7a8e8febdfcffa06093e32d7d44e7/yarl-1.20.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:88cab98aa4e13e1ade8c141daeedd300a4603b7132819c484841bb7af3edce9e", size = 341709 },
+    { url = "https://files.pythonhosted.org/packages/24/fd/725b8e73ac2a50e78a4534ac43c6addf5c1c2d65380dd48a9169cc6739a9/yarl-1.20.1-cp313-cp313t-win32.whl", hash = "sha256:b121ff6a7cbd4abc28985b6028235491941b9fe8fe226e6fdc539c977ea1739d", size = 86591 },
+    { url = "https://files.pythonhosted.org/packages/94/c3/b2e9f38bc3e11191981d57ea08cab2166e74ea770024a646617c9cddd9f6/yarl-1.20.1-cp313-cp313t-win_amd64.whl", hash = "sha256:541d050a355bbbc27e55d906bc91cb6fe42f96c01413dd0f4ed5a5240513874f", size = 93003 },
+    { url = "https://files.pythonhosted.org/packages/b4/2d/2345fce04cfd4bee161bf1e7d9cdc702e3e16109021035dbb24db654a622/yarl-1.20.1-py3-none-any.whl", hash = "sha256:83b8eb083fe4683c6115795d9fc1cfaf2cbbefb19b3a1cb68f6527460f483a77", size = 46542 },
+]
+
+[[package]]
+name = "zipp"
+version = "3.23.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e3/02/0f2892c661036d50ede074e376733dca2ae7c6eb617489437771209d4180/zipp-3.23.0.tar.gz", hash = "sha256:a07157588a12518c9d4034df3fbbee09c814741a33ff63c05fa29d26a2404166", size = 25547 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2e/54/647ade08bf0db230bfea292f893923872fd20be6ac6f53b2b936ba839d75/zipp-3.23.0-py3-none-any.whl", hash = "sha256:071652d6115ed432f5ce1d34c336c0adfd6a884660d1e9712a256d3d3bd4b14e", size = 10276 },
+]

--- a/.github/workflows/pull-request-v2.yaml
+++ b/.github/workflows/pull-request-v2.yaml
@@ -178,20 +178,20 @@ jobs:
 
 
   publish-docker-image-metricsserver:
-    needs: build-binaries
+    needs: [build-binaries, test-go]
     name: build-docker-metricsserver
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v5
         with:
           ref: ${{ github.event.pull_request.head.ref }} # checkout the correct branch name
           fetch-depth: 0                # fetch the whole repo history
 
       - name: Git Version
         id: auto_version
-        uses: codacy/git-version@2.8.2
+        uses: codacy/git-version@2.8.7
         with:
           prefix: v
           minor-identifier: /feat(ure)*:/
@@ -207,16 +207,16 @@ jobs:
           fi
 
       - name: Download binaries
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           path: ./build
           name: wekafsplugin-binaries-${{ github.sha }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to Quay.io
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
@@ -224,7 +224,7 @@ jobs:
 
       - name: Build and push Docker images
         id: build_and_push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           platforms: linux/amd64,linux/arm64
           context: .
@@ -469,18 +469,18 @@ jobs:
         if: ${{ steps.helm-s3-upload.outputs.link != '' }}
 
   publish-helm-metricsserver:
-    needs: build-binaries
+    needs: [build-binaries, test-go]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v5
         with:
           ref: ${{ github.event.pull_request.head.ref }} # checkout the correct branch name
           fetch-depth: 0                # fetch the whole repo history
 
       - name: Git Version
         id: auto_version
-        uses: codacy/git-version@2.8.2
+        uses: codacy/git-version@2.8.7
         with:
           prefix: v
           minor-identifier: /feat(ure)*:/
@@ -529,7 +529,7 @@ jobs:
             helm-docs -s file -c charts/csi-metricsserver
 
       - name: Set up Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@v5
         with:
           version: v3.10.0
 
@@ -680,14 +680,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v5
         with:
           ref: ${{ github.event.pull_request.head.ref }} # checkout the correct branch name
           fetch-depth: 0                # fetch the whole repo history
 
       - name: Git Version
         id: auto_version
-        uses: codacy/git-version@2.8.2
+        uses: codacy/git-version@2.8.7
         with:
           prefix: v
           minor-identifier: /feat(ure)*:/
@@ -736,7 +736,7 @@ jobs:
             helm-docs -s file -c charts/csi-metricsserver
 
       - name: Set up Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@v5
         with:
           version: v3.10.0
 
@@ -745,14 +745,14 @@ jobs:
           helm plugin install https://github.com/karuppiah7890/helm-schema-gen.git
           helm schema-gen charts/csi-metricsserver/values.yaml >| charts/csi-metricsserver/values.schema.json 
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v7
         with:
           python-version: '3.13'
           check-latest: true
 
       # TEST CHART
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.7.0
+        uses: helm/chart-testing-action@v2.8.0
 
       - name: Run chart-testing (list-changed)
         id: list-changed
@@ -766,7 +766,7 @@ jobs:
         run: ct lint --charts charts/csi-metricsserver --debug --validate-maintainers=false --target-branch ${{ github.event.repository.default_branch }}
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1.12.0
+        uses: helm/kind-action@v1.14.0
 
       - name: Run chart-testing (install)
         id: helm-test

--- a/.github/workflows/pull-request-v2.yaml
+++ b/.github/workflows/pull-request-v2.yaml
@@ -177,6 +177,76 @@ jobs:
             VERSION=${{ steps.version.outputs.version }}
 
 
+  publish-docker-image-metricsserver:
+    needs: build-binaries
+    name: build-docker-metricsserver
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+        with:
+          ref: ${{ github.event.pull_request.head.ref }} # checkout the correct branch name
+          fetch-depth: 0                # fetch the whole repo history
+
+      - name: Git Version
+        id: auto_version
+        uses: codacy/git-version@2.8.2
+        with:
+          prefix: v
+          minor-identifier: /feat(ure)*:/
+          major-identifier: /breaking:/
+
+      - name: Set package version
+        id: version
+        run: |
+          if [[ $INPUT_VERSION ]]; then
+            echo "version=$INPUT_VERSION" >> $GITHUB_OUTPUT
+          else
+            echo "version=${{ steps.auto_version.outputs.version }}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Download binaries
+        uses: actions/download-artifact@v5
+        with:
+          path: ./build
+          name: wekafsplugin-binaries-${{ github.sha }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Quay.io
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          registry: quay.io
+
+      - name: Build and push Docker images
+        id: build_and_push
+        uses: docker/build-push-action@v6
+        with:
+          platforms: linux/amd64,linux/arm64
+          context: .
+          file: Dockerfile-metricsserver-gha
+          push: true
+          pull: true
+          tags: '${{ secrets.DOCKER_REGISTRY_NAME }}/csi-metricsserver:${{ steps.version.outputs.version }}'
+          cache-from: |
+            type=gha,key=metricsserver-amd64
+            type=gha,key=metricsserver-arm64
+          cache-to: |
+            type=gha,mode=max,key=metricsserver-amd64
+            type=gha,mode=max,key=metricsserver-arm64
+          labels: |
+            revision=${{ steps.version.outputs.version }}
+            quay.expires-after=14d
+            version=${{ steps.version.outputs.version }}
+            release=${{ steps.version.outputs.version }}
+          provenance: false
+          build-args: |
+            VERSION=${{ steps.version.outputs.version }}
+
   build-sanity-image:
     if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-tests') && github.event.pull_request.draft == false }}
     needs: [build-binaries, test-go]
@@ -398,6 +468,114 @@ jobs:
           MSG_MINIMAL: commit
         if: ${{ steps.helm-s3-upload.outputs.link != '' }}
 
+  publish-helm-metricsserver:
+    needs: build-binaries
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+        with:
+          ref: ${{ github.event.pull_request.head.ref }} # checkout the correct branch name
+          fetch-depth: 0                # fetch the whole repo history
+
+      - name: Git Version
+        id: auto_version
+        uses: codacy/git-version@2.8.2
+        with:
+          prefix: v
+          minor-identifier: /feat(ure)*:/
+          major-identifier: /breaking:/
+
+      - name: Set package version
+        id: version
+        run: |
+          if [[ $INPUT_VERSION ]]; then
+            echo "version=$INPUT_VERSION" >> $GITHUB_OUTPUT
+          else
+            echo "version=${{ steps.auto_version.outputs.version }}" >> $GITHUB_OUTPUT
+          fi
+
+      # HELM
+      - name: Get Helm chart version
+        id: helm_version
+        run: |
+          out="$(echo "${{ steps.version.outputs.version }}" | sed 's/^v//1')"
+          echo "helm_version=$out" >> $GITHUB_OUTPUT
+
+      - name: Update Helm chart version
+        uses: mikefarah/yq@master
+        with:
+          cmd: |
+            BASEDIR=charts/csi-metricsserver
+            DRIVER_VERSION="$(echo ${{ steps.version.outputs.version }} | sed 's/^v//1')"
+            CHART_VERSION="${{ steps.helm_version.outputs.helm_version }}"
+            APP_VERSION="${{ steps.version.outputs.version }}"
+            yq -i '.version = "'$CHART_VERSION'"' $BASEDIR/Chart.yaml
+            yq -i '.appVersion = "'$APP_VERSION'"' $BASEDIR/Chart.yaml
+            yq -i '.sources[0] = "https://github.com/weka/csi-wekafs/tree/v$CHART_VERSION/charts/csi-metricsserver"' $BASEDIR/Chart.yaml
+            yq -i '.image.tag = "'$APP_VERSION'"' $BASEDIR/values.yaml
+            echo ------------------ values ------------------
+            cat $BASEDIR/values.yaml
+            echo --------------------chart ------------------
+            cat $BASEDIR/Chart.yaml
+
+      - name: helm-docs
+        uses: addnab/docker-run-action@v3
+        with:
+          image: jnorwood/helm-docs:latest
+          options: -v ${{ github.workspace }}:/data
+          run: |
+            cd /data
+            helm-docs -s file -c charts/csi-metricsserver
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.10.0
+
+      - name: update Helm schema
+        run: |
+          helm plugin install https://github.com/karuppiah7890/helm-schema-gen.git
+          helm schema-gen charts/csi-metricsserver/values.yaml >| charts/csi-metricsserver/values.schema.json 
+
+      # UPLOAD CHART TO S3
+      - name: Create Helm package
+        id: helm-package
+        run: |
+          helm package charts/csi-metricsserver
+          FILENAME="csi-metricsserver-${{ steps.helm_version.outputs.helm_version }}.tgz"
+          AWS_REGION=${{ secrets.AWS_ACCESS_SECRET_KEY }}
+          S3_BUCKET_NAME=${{ secrets.S3_BUCKET_NAME }}
+          URL="https://$S3_BUCKET_NAME.s3.$AWS_REGION.amazonaws.com"
+          echo "filename=$FILENAME" >> $GITHUB_OUTPUT
+          echo "url=$URL" >> $GITHUB_OUTPUT
+
+      - name: Install AWS CLI
+        id: install-aws-cli
+        uses: unfor19/install-aws-cli-action@v1
+        with:
+          version: 2
+
+      - name: Upload Helm package to S3
+        id: helm-s3-upload
+        run: |
+          export AWS_ACCESS_KEY_ID="${{ secrets.AWS_ACCESS_KEY_ID }}"
+          export AWS_SECRET_ACCESS_KEY="${{ secrets.AWS_SECRET_ACCESS_KEY}}"
+          export AWS_REGION="${{ secrets.AWS_REGION }}"
+          aws s3 cp ${{ steps.helm-package.outputs.filename }} "s3://${{ vars.AWS_BUCKET }}/"
+          echo "link=https://${{ vars.AWS_BUCKET }}.s3.${AWS_REGION}.amazonaws.com/${{ steps.helm-package.outputs.filename }}" >> $GITHUB_OUTPUT
+
+      - uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_USERNAME: csiBot
+          SLACK_ICON_EMOJI: ":robot_face:"
+          SLACK_TITLE: ":bar_chart: METRICS SERVER: ${{ steps.auto_version.outputs.version }}"
+          SLACK_MESSAGE: "```helm upgrade csi-metricsserver -n csi-metricsserver --create-namespace -i --set pluginConfig.allowInsecureHttps=true ${{ steps.helm-s3-upload.outputs.link }}```"
+          SLACK_FOOTER: "timestamp: ${{ github.event.pull_request.updated_at }}"
+          MSG_MINIMAL: commit
+        if: ${{ steps.helm-s3-upload.outputs.link != '' }}
+
   test-helm-csi:
     needs: publish-docker-image-csi
     runs-on: ubuntu-latest
@@ -480,7 +658,7 @@ jobs:
       - name: Run chart-testing (list-changed)
         id: list-changed
         run: |
-          changed=$(ct list-changed --chart-dirs charts --target-branch ${{ github.event.repository.default_branch }})
+          changed=$(ct list-changed --chart-dirs charts --excluded-charts csi-metricsserver --target-branch ${{ github.event.repository.default_branch }})
           if [[ -n "$changed" ]]; then
             echo "changed=true" >> $GITHUB_OUTPUT
           fi
@@ -496,3 +674,101 @@ jobs:
         run: |
           ct install --print-config --charts charts/csi-wekafsplugin --debug --helm-extra-args "--timeout 60s"
 
+
+  test-helm-metricsserver:
+    needs: publish-docker-image-metricsserver
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+        with:
+          ref: ${{ github.event.pull_request.head.ref }} # checkout the correct branch name
+          fetch-depth: 0                # fetch the whole repo history
+
+      - name: Git Version
+        id: auto_version
+        uses: codacy/git-version@2.8.2
+        with:
+          prefix: v
+          minor-identifier: /feat(ure)*:/
+          major-identifier: /breaking:/
+
+      - name: Set package version
+        id: version
+        run: |
+          if [[ $INPUT_VERSION ]]; then
+            echo "version=$INPUT_VERSION" >> $GITHUB_OUTPUT
+          else
+            echo "version=${{ steps.auto_version.outputs.version }}" >> $GITHUB_OUTPUT
+          fi
+
+      # HELM UPDATE CHART
+      - name: Get Helm chart version
+        id: helm_version
+        run: |
+          out="$(echo "${{ steps.version.outputs.version }}" | sed 's/^v//1')"
+          echo "helm_version=$out" >> $GITHUB_OUTPUT
+
+      - name: Update Helm chart version
+        uses: mikefarah/yq@master
+        with:
+          cmd: |
+            BASEDIR=charts/csi-metricsserver
+            DRIVER_VERSION="$(echo ${{ steps.version.outputs.version }} | sed 's/^v//1')"
+            CHART_VERSION="${{ steps.helm_version.outputs.helm_version }}"
+            APP_VERSION="${{ steps.version.outputs.version }}"
+            yq -i '.version = "'$CHART_VERSION'"' $BASEDIR/Chart.yaml
+            yq -i '.appVersion = "'$APP_VERSION'"' $BASEDIR/Chart.yaml
+            yq -i '.sources[0] = "https://github.com/weka/csi-wekafs/tree/v$CHART_VERSION/charts/csi-metricsserver"' $BASEDIR/Chart.yaml
+            yq -i '.image.tag = "'$APP_VERSION'"' $BASEDIR/values.yaml
+            echo ------------------ values ------------------
+            cat $BASEDIR/values.yaml
+            echo --------------------chart ------------------
+            cat $BASEDIR/Chart.yaml
+
+      - name: helm-docs
+        uses: addnab/docker-run-action@v3
+        with:
+          image: jnorwood/helm-docs:latest
+          options: -v ${{ github.workspace }}:/data
+          run: |
+            cd /data
+            helm-docs -s file -c charts/csi-metricsserver
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.10.0
+
+      - name: update Helm schema
+        run: |
+          helm plugin install https://github.com/karuppiah7890/helm-schema-gen.git
+          helm schema-gen charts/csi-metricsserver/values.yaml >| charts/csi-metricsserver/values.schema.json 
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+          check-latest: true
+
+      # TEST CHART
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.7.0
+
+      - name: Run chart-testing (list-changed)
+        id: list-changed
+        run: |
+          changed=$(ct list-changed --chart-dirs charts --excluded-charts csi-wekafsplugin --target-branch ${{ github.event.repository.default_branch }})
+          if [[ -n "$changed" ]]; then
+            echo "changed=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Run chart-testing (lint)
+        run: ct lint --charts charts/csi-metricsserver --debug --validate-maintainers=false --target-branch ${{ github.event.repository.default_branch }}
+
+      - name: Create kind cluster
+        uses: helm/kind-action@v1.12.0
+
+      - name: Run chart-testing (install)
+        id: helm-test
+        run: |
+          ct install --print-config --charts charts/csi-metricsserver --debug --helm-extra-args "--timeout 60s"

--- a/.github/workflows/push-dev-v2.yaml
+++ b/.github/workflows/push-dev-v2.yaml
@@ -352,14 +352,14 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v5
         with:
           ref: ${{ github.event.pull_request.head.ref }} # checkout the correct branch name
           fetch-depth: 0                # fetch the whole repo history
 
       - name: Git Version
         id: auto_version
-        uses: codacy/git-version@2.8.2
+        uses: codacy/git-version@2.8.7
         with:
           prefix: v
           minor-identifier: /feat(ure)*:/
@@ -375,16 +375,16 @@ jobs:
           fi
 
       - name: Download binaries
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           path: ./build
           name: wekafsplugin-binaries-${{ github.sha }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to Quay.io
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
@@ -392,7 +392,7 @@ jobs:
 
       - name: Build and push Docker images
         id: build_and_push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           platforms: linux/amd64,linux/arm64
           context: .
@@ -420,14 +420,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v5
         with:
           ref: ${{ github.event.pull_request.head.ref }} # checkout the correct branch name
           fetch-depth: 0                # fetch the whole repo history
 
       - name: Git Version
         id: auto_version
-        uses: codacy/git-version@2.8.2
+        uses: codacy/git-version@2.8.7
         with:
           prefix: v
           minor-identifier: /feat(ure)*:/
@@ -459,7 +459,7 @@ jobs:
             APP_VERSION="${{ steps.version.outputs.version }}"
             yq -i '.version = "'$CHART_VERSION'"' $BASEDIR/Chart.yaml
             yq -i '.appVersion = "'$APP_VERSION'"' $BASEDIR/Chart.yaml
-            yq -i '.sources[0] = "https://github.com/weka/csi-wekafs/tree/v$CHART_VERSION/charts/csi-metricsserver"' $BASEDIR/Chart.yaml
+            yq -i '.sources[0] = "https://github.com/weka/csi-wekafs/tree/v'$CHART_VERSION'/charts/csi-metricsserver"' $BASEDIR/Chart.yaml
             yq -i '.image.tag = "'$APP_VERSION'"' $BASEDIR/values.yaml
             echo ------------------ values ------------------
             cat $BASEDIR/values.yaml
@@ -476,7 +476,7 @@ jobs:
             helm-docs -s file -c charts/csi-metricsserver
 
       - name: Set up Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@v5
         with:
           version: v3.10.0
 

--- a/.github/workflows/push-dev-v2.yaml
+++ b/.github/workflows/push-dev-v2.yaml
@@ -328,7 +328,7 @@ jobs:
       - name: Run chart-testing (list-changed)
         id: list-changed
         run: |
-          changed=$(ct list-changed --chart-dirs charts --target-branch ${{ github.event.repository.default_branch }})
+          changed=$(ct list-changed --chart-dirs charts --excluded-charts csi-metricsserver --target-branch ${{ github.event.repository.default_branch }})
           if [[ -n "$changed" ]]; then
             echo "changed=true" >> $GITHUB_OUTPUT
           fi
@@ -345,3 +345,180 @@ jobs:
           ct install --print-config --charts charts/csi-wekafsplugin --debug --helm-extra-args "--timeout 60s"
 
 
+  publish-docker-image-metricsserver:
+    needs: build-binaries
+    name: build-docker-metricsserver
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+        with:
+          ref: ${{ github.event.pull_request.head.ref }} # checkout the correct branch name
+          fetch-depth: 0                # fetch the whole repo history
+
+      - name: Git Version
+        id: auto_version
+        uses: codacy/git-version@2.8.2
+        with:
+          prefix: v
+          minor-identifier: /feat(ure)*:/
+          major-identifier: /breaking:/
+
+      - name: Set package version
+        id: version
+        run: |
+          if [[ $INPUT_VERSION ]]; then
+            echo "version=$INPUT_VERSION" >> $GITHUB_OUTPUT
+          else
+            echo "version=${{ steps.auto_version.outputs.version }}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Download binaries
+        uses: actions/download-artifact@v5
+        with:
+          path: ./build
+          name: wekafsplugin-binaries-${{ github.sha }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Quay.io
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          registry: quay.io
+
+      - name: Build and push Docker images
+        id: build_and_push
+        uses: docker/build-push-action@v6
+        with:
+          platforms: linux/amd64,linux/arm64
+          context: .
+          file: Dockerfile-metricsserver-gha
+          push: true
+          pull: true
+          tags: '${{ secrets.DOCKER_REGISTRY_NAME }}/csi-metricsserver:${{ steps.version.outputs.version }}'
+          cache-from: |
+            type=gha,key=metricsserver-amd64
+            type=gha,key=metricsserver-arm64
+          cache-to: |
+            type=gha,mode=max,key=metricsserver-amd64
+            type=gha,mode=max,key=metricsserver-arm64
+          labels: |
+            revision=${{ steps.version.outputs.version }}
+            quay.expires-after=14d
+            version=${{ steps.version.outputs.version }}
+            release=${{ steps.version.outputs.version }}
+          provenance: false
+          build-args: |
+            VERSION=${{ steps.version.outputs.version }}
+
+  publish-helm-metricsserver:
+    needs: build-binaries
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+        with:
+          ref: ${{ github.event.pull_request.head.ref }} # checkout the correct branch name
+          fetch-depth: 0                # fetch the whole repo history
+
+      - name: Git Version
+        id: auto_version
+        uses: codacy/git-version@2.8.2
+        with:
+          prefix: v
+          minor-identifier: /feat(ure)*:/
+          major-identifier: /breaking:/
+
+      - name: Set package version
+        id: version
+        run: |
+          if [[ $INPUT_VERSION ]]; then
+            echo "version=$INPUT_VERSION" >> $GITHUB_OUTPUT
+          else
+            echo "version=${{ steps.auto_version.outputs.version }}" >> $GITHUB_OUTPUT
+          fi
+
+      # HELM
+      - name: Get Helm chart version
+        id: helm_version
+        run: |
+          out="$(echo "${{ steps.version.outputs.version }}" | sed 's/^v//1')"
+          echo "helm_version=$out" >> $GITHUB_OUTPUT
+
+      - name: Update Helm chart version
+        uses: mikefarah/yq@master
+        with:
+          cmd: |
+            BASEDIR=charts/csi-metricsserver
+            DRIVER_VERSION="$(echo ${{ steps.version.outputs.version }} | sed 's/^v//1')"
+            CHART_VERSION="${{ steps.helm_version.outputs.helm_version }}"
+            APP_VERSION="${{ steps.version.outputs.version }}"
+            yq -i '.version = "'$CHART_VERSION'"' $BASEDIR/Chart.yaml
+            yq -i '.appVersion = "'$APP_VERSION'"' $BASEDIR/Chart.yaml
+            yq -i '.sources[0] = "https://github.com/weka/csi-wekafs/tree/v$CHART_VERSION/charts/csi-metricsserver"' $BASEDIR/Chart.yaml
+            yq -i '.image.tag = "'$APP_VERSION'"' $BASEDIR/values.yaml
+            echo ------------------ values ------------------
+            cat $BASEDIR/values.yaml
+            echo --------------------chart ------------------
+            cat $BASEDIR/Chart.yaml
+
+      - name: helm-docs
+        uses: addnab/docker-run-action@v3
+        with:
+          image: jnorwood/helm-docs:latest
+          options: -v ${{ github.workspace }}:/data
+          run: |
+            cd /data
+            helm-docs -s file -c charts/csi-metricsserver
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.10.0
+
+      - name: update Helm schema
+        run: |
+          helm plugin install https://github.com/karuppiah7890/helm-schema-gen.git
+          helm schema-gen charts/csi-metricsserver/values.yaml >| charts/csi-metricsserver/values.schema.json 
+
+      # UPLOAD CHART TO S3
+      - name: Create Helm package
+        id: helm-package
+        run: |
+          helm package charts/csi-metricsserver
+          FILENAME="csi-metricsserver-${{ steps.helm_version.outputs.helm_version }}.tgz"
+          AWS_REGION=${{ secrets.AWS_ACCESS_SECRET_KEY }}
+          S3_BUCKET_NAME=${{ secrets.S3_BUCKET_NAME }}
+          URL="https://$S3_BUCKET_NAME.s3.$AWS_REGION.amazonaws.com"
+          echo "filename=$FILENAME" >> $GITHUB_OUTPUT
+          echo "url=$URL" >> $GITHUB_OUTPUT
+
+      - name: Install AWS CLI
+        id: install-aws-cli
+        uses: unfor19/install-aws-cli-action@v1
+        with:
+          version: 2
+
+      - name: Upload Helm package to S3
+        id: helm-s3-upload
+        run: |
+          export AWS_ACCESS_KEY_ID="${{ secrets.AWS_ACCESS_KEY_ID }}"
+          export AWS_SECRET_ACCESS_KEY="${{ secrets.AWS_SECRET_ACCESS_KEY}}"
+          export AWS_REGION="${{ secrets.AWS_REGION }}"
+          aws s3 cp ${{ steps.helm-package.outputs.filename }} "s3://${{ vars.AWS_BUCKET }}/"
+          echo "link=https://${{ vars.AWS_BUCKET }}.s3.${AWS_REGION}.amazonaws.com/${{ steps.helm-package.outputs.filename }}" >> $GITHUB_OUTPUT
+
+      - uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_USERNAME: csiBot
+          SLACK_ICON_EMOJI: ":robot_face:"
+          SLACK_TITLE: ":bar_chart: METRICS SERVER: ${{ steps.auto_version.outputs.version }}"
+          SLACK_MESSAGE: "```helm upgrade csi-metricsserver -n csi-metricsserver --create-namespace -i --set pluginConfig.allowInsecureHttps=true ${{ steps.helm-s3-upload.outputs.link }}```"
+          SLACK_FOOTER: "timestamp: ${{ github.event.pull_request.updated_at }}"
+          MSG_MINIMAL: commit
+        if: ${{ steps.helm-s3-upload.outputs.link != '' }}

--- a/.github/workflows/release-v2.yaml
+++ b/.github/workflows/release-v2.yaml
@@ -220,14 +220,14 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v5
         with:
           ref: ${{ github.event.pull_request.head.ref }} # checkout the correct branch name
           fetch-depth: 0                # fetch the whole repo history
 
       - name: Git Version
         id: auto_version
-        uses: codacy/git-version@2.8.2
+        uses: codacy/git-version@2.8.7
         with:
           prefix: v
           minor-identifier: /feat(ure)*:/
@@ -247,16 +247,16 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
       - name: Download binaries
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           path: ./build
           name: wekafsplugin-binaries-${{ github.sha }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to Quay.io
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
@@ -264,7 +264,7 @@ jobs:
 
       - name: Build and push Docker images
         id: build_and_push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           platforms: linux/amd64,linux/arm64
           context: .

--- a/.github/workflows/release-v2.yaml
+++ b/.github/workflows/release-v2.yaml
@@ -213,6 +213,79 @@ jobs:
           build-args: |
             VERSION=${{ steps.version.outputs.version }}
 
+  publish-docker-image-metricsserver:
+    needs: build-binaries
+    name: build-docker-metricsserver
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
+        with:
+          ref: ${{ github.event.pull_request.head.ref }} # checkout the correct branch name
+          fetch-depth: 0                # fetch the whole repo history
+
+      - name: Git Version
+        id: auto_version
+        uses: codacy/git-version@2.8.2
+        with:
+          prefix: v
+          minor-identifier: /feat(ure)*:/
+          major-identifier: /breaking:/
+
+      - name: Set package version
+        id: version
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          INPUT_VERSION: ${{ inputs.releaseTag }}
+        run: |
+          if [[ $INPUT_VERSION ]]; then
+            VERSION=$INPUT_VERSION
+          fi
+
+          VERSION=`echo $VERSION | sed "s|SNAPSHOT|$GITHUB_REF_NAME|"`
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Download binaries
+        uses: actions/download-artifact@v5
+        with:
+          path: ./build
+          name: wekafsplugin-binaries-${{ github.sha }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Quay.io
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+          registry: quay.io
+
+      - name: Build and push Docker images
+        id: build_and_push
+        uses: docker/build-push-action@v6
+        with:
+          platforms: linux/amd64,linux/arm64
+          context: .
+          file: Dockerfile-metricsserver-gha
+          push: true
+          pull: true
+          tags: '${{ secrets.DOCKER_REGISTRY_NAME }}/csi-metricsserver:${{ steps.version.outputs.version }}'
+          cache-from: |
+            type=gha,key=metricsserver-amd64
+            type=gha,key=metricsserver-arm64
+          cache-to: |
+            type=gha,mode=max,key=metricsserver-amd64
+            type=gha,mode=max,key=metricsserver-arm64
+          labels: |
+            revision=${{ steps.version.outputs.version }}
+            version=${{ steps.version.outputs.version }}
+            release=${{ steps.version.outputs.version }}
+          provenance: false
+          build-args: |
+            VERSION=${{ steps.version.outputs.version }}
+
   release:
     needs:
       - build-binaries
@@ -293,6 +366,15 @@ jobs:
             yq -i 'del(.annotations."artifacthub.io/changes")' Chart.yaml
           fi
 
+          cd ../csi-metricsserver
+          yq -i '.version = "'$VERSION_WITHOUT'"' Chart.yaml
+          yq -i '.appVersion = "'$VERSION'"' Chart.yaml
+          yq -i '.image.tag = "'$VERSION'"' values.yaml
+          yq -i '.sources[0] = "'https://github.com/weka/csi-wekafs/tree/$VERSION/charts/csi-metricsserver'"' Chart.yaml
+          yq -i '.annotations."artifacthub.io/prerelease" = "'${{ inputs.preRelease }}'"' Chart.yaml
+          yq -i '.annotations."artifacthub.io/containsSecurityUpdates" = "'${{ inputs.containsSecurityUpdates }}'"' Chart.yaml
+          cd ../csi-wekafsplugin
+
           echo ------------------ values ------------------
           cat values.yaml
           echo --------------------chart ------------------
@@ -333,6 +415,9 @@ jobs:
 
           # release note will taken from here by helm/chart-releaser-action
           cat changelog > charts/csi-wekafsplugin/CHANGELOG.md
+          # chart-releaser discovers every chart under charts/, so the metrics server chart
+          # needs its own release notes or it is published without any
+          cat changelog > charts/csi-metricsserver/CHANGELOG.md
           mv CHANGELOG.md RELEASE.md
 
       - name: Remove the original draft release

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,7 @@ LABEL summary="This image is used by WEKA CSI Plugin and incorporates both Contr
 LABEL description="Container Storage Interface (CSI) plugin for WEKA - the data platform for AI"
 LABEL url="https://www.weka.io"
 COPY --from=go-builder /bin/wekafsplugin /wekafsplugin
+COPY --from=go-builder --chmod=755 /bin/metricsserver /metricsserver
 COPY --from=go-builder /bin/wait-for-leader /wait-for-leader
 COPY --from=go-builder /src/locar /locar
 ARG binary=/bin/wekafsplugin

--- a/Dockerfile-gha
+++ b/Dockerfile-gha
@@ -34,5 +34,6 @@ COPY LICENSE /licenses
 RUN curl -sSL -o /locar https://github.com/weka/locar/releases/download/${LOCAR_VERSION}/locar-${LOCAR_VERSION}-${TARGETOS}-${TARGETARCH} && \
     chmod 655 /locar
 COPY --chmod=755 ./build/${TARGETOS}-${TARGETARCH}/wekafsplugin /wekafsplugin
+COPY --chmod=755 ./build/${TARGETOS}-${TARGETARCH}/metricsserver /metricsserver
 # The controller Deployment gates its sidecars on this, so the image is unusable without it.
 COPY --chmod=755 ./build/${TARGETOS}-${TARGETARCH}/wait-for-leader /wait-for-leader

--- a/Dockerfile-metricsserver
+++ b/Dockerfile-metricsserver
@@ -1,0 +1,44 @@
+ARG UBI_HASH=9.8-1786380870
+FROM golang:1.26-alpine AS go-builder
+ARG TARGETARCH
+ARG TARGETOS
+# https://stackoverflow.com/questions/36279253/go-compiled-binary-wont-run-in-an-alpine-docker-container-on-ubuntu-host
+RUN apk add --no-cache libc6-compat gcc musl-dev
+COPY go.mod /src/go.mod
+COPY go.sum /src/go.sum
+WORKDIR /src
+RUN go mod download
+ARG VERSION
+RUN echo Building metrics server version $VERSION for architecture $TARGETARCH
+# Need to add true in between to avoid "failed to get layer"
+# https://stackoverflow.com/questions/51115856/docker-failed-to-export-image-failed-to-create-image-failed-to-get-layer
+ADD go.mod /src/go.mod
+RUN true
+ADD go.sum /src/go.sum
+RUN true
+ADD pkg /src/pkg
+RUN true
+ADD cmd /src/cmd
+RUN true
+
+# Self-contained, like Dockerfile, rather than copying a binary built by a prior CI job. That keeps
+# `docker build -f Dockerfile-metricsserver .` working on its own, without a build-binaries step to
+# produce ./build/<os>-<arch>/metricsserver first.
+RUN echo Building metrics server
+RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -a -ldflags "-X main.version=$VERSION -extldflags '-static'" -o "/bin/metricsserver" /src/cmd/metricsserver
+
+FROM registry.access.redhat.com/ubi9-minimal:${UBI_HASH}
+LABEL maintainers="WekaIO, LTD"
+LABEL maintainer="csi@weka.io"
+LABEL name="WEKA CSI Metrics Server"
+LABEL vendor="weka.io"
+LABEL summary="This image is used by the WEKA CSI Metrics Server"
+LABEL description="Metrics server for WEKA CSI volumes, exporting per-volume capacity and performance to Prometheus"
+LABEL url="https://www.weka.io"
+
+# The metrics server mounts nothing and shells out to nothing - it only talks to the Kubernetes and
+# WEKA APIs - so it needs none of the filesystem and SELinux tooling the CSI plugin image installs.
+RUN mkdir -p /licenses
+COPY LICENSE /licenses
+COPY --from=go-builder /bin/metricsserver /metricsserver
+ENTRYPOINT ["/metricsserver"]

--- a/Dockerfile-metricsserver-gha
+++ b/Dockerfile-metricsserver-gha
@@ -1,0 +1,29 @@
+#syntax=docker/dockerfile:1.17
+# CI counterpart to Dockerfile-metricsserver, packaging the binary that build-binaries already
+# produced rather than recompiling it. Same split as Dockerfile / Dockerfile-gha.
+ARG UBI_HASH=9.8-1786380870
+FROM registry.access.redhat.com/ubi9-minimal:${UBI_HASH} AS base
+
+LABEL maintainers="WekaIO, LTD"
+LABEL maintainer="csi@weka.io"
+LABEL name="WEKA CSI Metrics Server"
+LABEL vendor="weka.io"
+LABEL summary="This image is used by the WEKA CSI Metrics Server"
+LABEL description="Metrics server for WEKA CSI volumes, exporting per-volume capacity and performance to Prometheus"
+LABEL url="https://www.weka.io"
+
+ENTRYPOINT ["/metricsserver"]
+
+# The metrics server mounts nothing and shells out to nothing - it only talks to the Kubernetes and
+# WEKA APIs - so it needs none of the filesystem and SELinux tooling the CSI plugin image installs.
+RUN microdnf install -y jq procps less
+RUN microdnf clean all && rm -rf /var/cache/dnf
+
+FROM base
+
+ARG TARGETARCH
+ARG TARGETOS
+
+RUN mkdir -p /licenses
+COPY LICENSE /licenses
+COPY --chmod=755 ./build/${TARGETOS}-${TARGETARCH}/metricsserver /metricsserver

--- a/Makefile
+++ b/Makefile
@@ -15,13 +15,14 @@
 CMDS=wekafsplugin
 all: build
 
-.PHONY: build-% build clean build-debug deploy-debug update-charts update-sidecars
+.PHONY: build-% build build-all build-metricsserver push-metricsserver clean build-debug deploy-debug update-charts update-sidecars
 
 # understand what is the version tag
 VERSION ?= $(shell cat charts/csi-wekafsplugin/Chart.yaml | grep appVersion | awk '{print $$2}' | tr -d '"')
 TIMESTAMP := $(shell date +%Y%m%d-%H%M%S)
 DEBUG_VERSION ?= $(VERSION)-debug-$(TIMESTAMP)
 DOCKER_IMAGE_NAME?=csi-wekafs
+METRICSSERVER_IMAGE_NAME?=csi-metricsserver
 DEBUG_IMAGE_NAME?=csi-wekafs-debug
 QUAY_REGISTRY?=quay.io/weka.io
 DEBUG_IMAGE?=$(QUAY_REGISTRY)/$(DEBUG_IMAGE_NAME):$(DEBUG_VERSION)
@@ -31,8 +32,17 @@ $(CMDS:%=build-%): build-%:
 
 build: $(CMDS:%=build-%)
 
+# The metrics server ships as its own image, which is what both Helm charts deploy
+build-metricsserver:
+	docker buildx build --platform linux/amd64 --build-arg VERSION=$(VERSION) -t $(METRICSSERVER_IMAGE_NAME):$(VERSION) -f Dockerfile-metricsserver --label revision=$(VERSION) .
+
+build-all: build build-metricsserver
+
 push: build
 	docker push $(DOCKER_IMAGE_NAME):$(VERSION)
+
+push-metricsserver: build-metricsserver
+	docker push $(METRICSSERVER_IMAGE_NAME):$(VERSION)
 
 clean:
 	-rm -rf bin

--- a/charts/csi-metricsserver/.helmignore
+++ b/charts/csi-metricsserver/.helmignore
@@ -1,0 +1,22 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/csi-metricsserver/Chart.yaml
+++ b/charts/csi-metricsserver/Chart.yaml
@@ -1,0 +1,23 @@
+apiVersion: v2
+name: csi-metricsserver
+description: Helm chart for Deployment of the WekaIO CSI Metrics Server, exporting per-volume WekaFS capacity and performance metrics to Prometheus
+maintainers:
+  - name: WekaIO, Inc.
+    email: csi@weka.io
+    url: https://weka.io
+sources:
+  - https://github.com/weka/csi-wekafs/tree/v2.8.9
+home: https://github.com/weka/csi-wekafs
+icon: https://weka.github.io/csi-wekafs/logo.png
+type: application
+version: 2.8.9
+appVersion: v2.8.9
+keywords: [storage, filesystem, HPC, metrics, prometheus]
+annotations:
+  artifacthub.io/category: "storage"
+  artifacthub.io/prerelease: "false"
+  artifacthub.io/containsSecurityUpdates: "false"
+  artifacthub.io/license: Apache-2.0
+  artifacthub.io/signKey: |
+    fingerprint: BA9F2D31BE9193E01FA17450BCE0A5CF67AC0C59
+    url: https://weka.github.io/csi-wekafs/csi-public.gpg

--- a/charts/csi-metricsserver/README.md
+++ b/charts/csi-metricsserver/README.md
@@ -1,0 +1,123 @@
+# WEKA CSI Metrics Server
+========================
+Helm chart for Deployment of Metrics Server for WEKA CSI Plugin
+This is a standalone application that can be installed on top of the Weka CSI Plugin to provide metrics for Prometheus and Grafana
+Note that WEKA CSI Plugin 3.0 has built-in metrics server, so this chart is not needed for WEKA CSI Plugin 3.0 and up
+
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+[![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/csi-wekafs)](https://artifacthub.io/packages/search?repo=csi-wekafs)
+![Version: 2.8.0-SNAPSHOT.114.sha.d96674b](https://img.shields.io/badge/Version-2.8.0--SNAPSHOT.114.sha.d96674b-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.8.0-SNAPSHOT.114.sha.d96674b](https://img.shields.io/badge/AppVersion-v2.8.0--SNAPSHOT.114.sha.d96674b-informational?style=flat-square)
+
+## Homepage
+https://github.com/weka/csi-wekafs
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| WekaIO, Inc. | <csi@weka.io> | <https://weka.io> |
+
+## Pre-requisite
+- Kubernetes cluster of version 1.18 and up, 1.19 and up recommended
+- Helm v3 must be installed and configured properly
+- Weka system pre-configured and Weka client installed and registered in cluster for each Kubernetes node
+
+## Deployment
+```shell
+helm repo add csi-wekafs https://weka.github.io/csi-wekafs
+helm install csi-wekafsplugin csi-wekafs/csi-wekafsplugin --namespace csi-wekafsplugin --create-namespace [--set selinuxSupport=<off | mixed | enforced>]
+```
+
+> **NOTE:** Since version 3.0.0, WEKA CSI Plugin removes support for legacy volumes without API binding.
+> For further information, refer [Official Weka CSI Plugin documentation](https://docs.weka.io/appendices/weka-csi-plugin)
+
+## Usage
+- [Deploy an Example application](https://github.com/weka/csi-wekafs/blob/master/docs/usage.md)
+- [SELinux Support & Installation Notes](https://github.com/weka/csi-wekafs/blob/master/selinux/README.md)
+
+## Additional Documentation
+- [Official Weka CSI Plugin documentation](https://docs.weka.io/appendices/weka-csi-plugin)
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| dynamicProvisionPath | string | `"csi-volumes"` | Directory in root of file system where dynamic volumes are provisioned |
+| csiDriverName | string | `"csi.weka.io"` | Name of the driver (and provisioner) |
+| csiDriverVersion | string | `"2.8.0-SNAPSHOT.114.sha.d96674b"` | CSI driver version |
+| images.livenessprobesidecar | string | `"registry.k8s.io/sig-storage/livenessprobe:v2.16.0"` | CSI liveness probe sidecar image URL |
+| images.attachersidecar | string | `"registry.k8s.io/sig-storage/csi-attacher:v4.9.0"` | CSI attacher sidecar image URL |
+| images.provisionersidecar | string | `"registry.k8s.io/sig-storage/csi-provisioner:v5.3.0"` | CSI provisioner sidecar image URL |
+| images.registrarsidecar | string | `"registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.14.0"` | CSI registrar sidercar |
+| images.resizersidecar | string | `"registry.k8s.io/sig-storage/csi-resizer:v1.14.0"` | CSI resizer sidecar image URL |
+| images.snapshottersidecar | string | `"registry.k8s.io/sig-storage/csi-snapshotter:v8.3.0"` | CSI snapshotter sidecar image URL |
+| images.csidriver | string | `"quay.io/weka.io/csi-wekafs"` | CSI driver main image URL |
+| images.csidriverTag | string | `"2.8.0-SNAPSHOT.114.sha.d96674b"` | CSI driver tag |
+| imagePullSecret | string | `""` | image pull secret required for image download. Must have permissions to access all images above.    Should be used in case of private registry that requires authentication |
+| globalPluginTolerations | list | `[{"effect":"NoSchedule","key":"node-role.kubernetes.io/master","operator":"Exists"}]` | Tolerations for all CSI driver components |
+| controllerPluginTolerations | list | `[{"effect":"NoSchedule","key":"node-role.kubernetes.io/master","operator":"Exists"}]` | Tolerations for CSI controller component only (by default same as global) |
+| nodePluginTolerations | list | `[{"effect":"NoSchedule","key":"node-role.kubernetes.io/master","operator":"Exists"}]` | Tolerations for CSI node component only (by default same as global) |
+| nodeSelector | object | `{}` | Optional nodeSelector for CSI plugin deployment on certain Kubernetes nodes only    This nodeselector will be applied to all CSI plugin components |
+| affinity | object | `{}` | Optional affinity for CSI plugin deployment    This affinity will be applied to all CSI plugin components |
+| machineConfigLabels | list | `["worker","master"]` | Optional setting for OCP platform only, which machineconfig pools to apply the Weka SELinux policy on    NOTE: by default, the policy will be installed both on workers and control plane nodes |
+| controller.replicas | int | `2` | Controller number of replicas |
+| controller.maxConcurrentRequests | int | `5` | Maximum concurrent requests from sidecars (global) |
+| controller.concurrency | object | `{"createSnapshot":5,"createVolume":5,"deleteSnapshot":5,"deleteVolume":5,"expandVolume":5}` | maximum concurrent operations per operation type |
+| controller.grpcRequestTimeoutSeconds | int | `30` | Return GRPC Unavailable if request waits in queue for that long time (seconds) |
+| controller.configureProvisionerLeaderElection | bool | `true` | Configure provisioner sidecar for leader election |
+| controller.configureResizerLeaderElection | bool | `true` | Configure resizer sidecar for leader election |
+| controller.configureSnapshotterLeaderElection | bool | `true` | Configure snapshotter sidecar for leader election |
+| controller.configureAttacherLeaderElection | bool | `true` | Configure attacher sidecar for leader election |
+| controller.nodeSelector | object | `{}` | optional nodeSelector for controller components only |
+| controller.affinity | object | `{}` | optional affinity for controller components only |
+| controller.labels | object | `{}` | optional labels to add to controller deployment |
+| controller.podLabels | object | `{}` | optional labels to add to controller pods |
+| controller.terminationGracePeriodSeconds | int | `10` | termination grace period for controller pods |
+| node.maxConcurrentRequests | int | `5` | Maximum concurrent requests from sidecars (global) |
+| node.concurrency | object | `{"nodePublishVolume":5,"nodeUnpublishVolume":5}` | maximum concurrent operations per operation type (to avoid API starvation) |
+| node.grpcRequestTimeoutSeconds | int | `30` | Return GRPC Unavailable if request waits in queue for that long time (seconds) |
+| node.nodeSelector | object | `{}` | optional nodeSelector for node components only |
+| node.affinity | object | `{}` | optional affinity for node components only |
+| node.labels | object | `{}` | optional labels to add to node daemonset |
+| node.podLabels | object | `{}` | optional labels to add to node pods |
+| node.terminationGracePeriodSeconds | int | `10` | termination grace period for node pods |
+| logLevel | int | `5` | Log level of CSI plugin |
+| useJsonLogging | bool | `false` | Use JSON structured logging instead of human-readable logging format (for exporting logs to structured log parser) |
+| priorityClassName | string | `""` | Optional CSI Plugin priorityClassName |
+| selinuxSupport | string | `"off"` | Support SELinux labeling for Persistent Volumes, may be either `off`, `mixed`, `enforced` (default off)    In `enforced` mode, CSI node components will only start on nodes having a label `selinuxNodeLabel` below    In `mixed` mode, separate CSI node components will be installed on SELinux-enabled and regular hosts    In `off` mode, only non-SELinux-enabled node components will be run on hosts without label.    WARNING: if SELinux is not enabled, volume provisioning and publishing might fail!    NOTE: SELinux support is enabled automatically on clusters recognized as RedHat OpenShift Container Platform |
+| selinuxNodeLabel | string | `"csi.weka.io/selinux_enabled"` | This label must be set to `"true"` on SELinux-enabled Kubernetes nodes,    e.g., to run the node server in secure mode on SELinux-enabled node, the node must have label    `csi.weka.io/selinux_enabled="true"` |
+| selinuxOcpRetainMachineConfig | bool | `false` | If true, the SELinux policy machine configuration will not be removed when uninstalling the plugin.    This is useful for OpenShift Container Platform clusters, to not cause machine config pool update on plugin reinstall |
+| kubeletPath | string | `"/var/lib/kubelet"` | kubelet path, in cases Kubernetes is installed not in default folder |
+| metrics.enabled | bool | `true` | Enable Prometheus Metrics |
+| metrics.controllerPort | int | `9090` | Metrics port for Controller Server |
+| metrics.provisionerPort | int | `9091` | Provisioner metrics port |
+| metrics.resizerPort | int | `9092` | Resizer metrics port |
+| metrics.snapshotterPort | int | `9093` | Snapshotter metrics port |
+| metrics.nodePort | int | `9094` | Metrics port for Node Serer |
+| metrics.attacherPort | int | `9095` | Attacher metrics port |
+| hostNetwork | bool | `false` | Set to true to use host networking. Will be always set to true when using NFS mount protocol |
+| pluginConfig.fsGroupPolicy | string | `"File"` | WARNING: Changing this value might require uninstall and re-install of the plugin |
+| pluginConfig.allowInsecureHttps | bool | `false` | Allow insecure HTTPS (skip TLS certificate verification) |
+| pluginConfig.objectNaming.volumePrefix | string | `"csivol-"` | Prefix that will be added to names of Weka cluster filesystems / snapshots assocciated with CSI volume,    must not exceed 7 symbols. |
+| pluginConfig.objectNaming.snapshotPrefix | string | `"csisnp-"` | Prefix that will be added to names of Weka cluster snapshots assocciated with CSI snapshot,    must not exceed 7 symbols. |
+| pluginConfig.objectNaming.seedSnapshotPrefix | string | `"csisnp-seed-"` | Prefix that will be added to automatically created "seed" snapshot of empty filesytem,    must not exceed 12 symbols. |
+| pluginConfig.allowedOperations.autoCreateFilesystems | bool | `true` | Allow automatic provisioning of CSI volumes based on distinct Weka filesystem |
+| pluginConfig.allowedOperations.autoExpandFilesystems | bool | `true` | Allow automatic expansion of filesystem on which Weka snapshot-backed CSI volumes,    e.g. in case a required volume capacity exceeds the size of filesystem.    Note: the filesystem is not expanded automatically when a new directory-backed volume is provisioned |
+| pluginConfig.allowedOperations.snapshotDirectoryVolumes | bool | `false` | Create snapshots of directory-backed (dir/v1) volumes. By default disabled.    Note: when enabled, every snapshot of a directory-backed volume creates a full filesystem snapshot (wasteful) |
+| pluginConfig.allowedOperations.snapshotVolumesWithoutQuotaEnforcement | bool | `false` | Allow creation of snapshot-backed volumes even on unsupported Weka cluster versions, off by default    Note: On versions of Weka < v4.2 snapshot-backed volume capacity cannot be enforced |
+| pluginConfig.allowedOperations.allowAsyncObjectDeletion | bool | `true` | Should the CSI plugin wait for object deletion before reporting completion.    If true, the plugin will report success on deletion of volumes while the actual deletion of objects will be done in the background.    If false, the plugin will report success only after the objects are deleted on WEKA cluster.    Usually, async deletion would drastically increase speed of volume deletions, since deletion is performed serially.    However, it may cause objects on Weka cluster to remain if the plugin crashes or is restarted before the deletion is completed. |
+| pluginConfig.mutuallyExclusiveMountOptions[0] | string | `"readcache,writecache,coherent,forcedirect"` |  |
+| pluginConfig.mutuallyExclusiveMountOptions[1] | string | `"sync,async"` |  |
+| pluginConfig.mutuallyExclusiveMountOptions[2] | string | `"ro,rw"` |  |
+| pluginConfig.encryption.allowEncryptionWithoutKms | bool | `false` | Allow encryption of Weka filesystems associated with CSI volumes without using external KMS server.    Should never be run in production, only for testing purposes |
+| pluginConfig.mountProtocol.useNfs | bool | `false` | Use NFS transport for mounting Weka filesystems, off by default |
+| pluginConfig.mountProtocol.allowNfsFailback | bool | `false` | Allow Failback to NFS transport if Weka client fails to mount filesystem using native protocol |
+| pluginConfig.mountProtocol.interfaceGroupName | string | `""` | Specify name of NFS interface group to use for mounting Weka filesystems. If not set, first NFS interface group will be used |
+| pluginConfig.mountProtocol.clientGroupName | string | `""` | Specify existing client group name for NFS configuration. If not set, "WekaCSIPluginClients" group will be created |
+| pluginConfig.mountProtocol.nfsProtocolVersion | string | `"4.1"` | Specify NFS protocol version to use for mounting Weka filesystems. Default is "4.1", consult Weka documentation for supported versions |
+| pluginConfig.skipGarbageCollection | bool | `false` | Skip garbage collection of deleted directory-backed volume contents and only move them to trash. Default false |
+| pluginConfig.manageNodeTopologyLabels | bool | `true` | Allow CSI plugin to manage node topology labels. For Operator-managed clusters, this should be set to false. |
+| pluginConfig.apiTimeoutSeconds | int | `60` | WEKA API timeout, default 60 seconds |
+
+----------------------------------------------
+Autogenerated from chart metadata using [helm-docs v1.14.2](https://github.com/norwoodj/helm-docs/releases/v1.14.2)

--- a/charts/csi-metricsserver/README.md.gotmpl
+++ b/charts/csi-metricsserver/README.md.gotmpl
@@ -1,0 +1,29 @@
+# WEKA CSI Metrics Server
+========================
+{{ template "chart.description" . }}
+
+This is a standalone application that can be installed on top of the Weka CSI Plugin to provide metrics for Prometheus and Grafana
+Note that WEKA CSI Plugin 3.0 has built-in metrics server, so this chart is not needed for WEKA CSI Plugin 3.0 and up
+
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+[![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/csi-wekafs)](https://artifacthub.io/packages/search?repo=csi-wekafs)
+{{ template "chart.badgesSection" . }}
+
+## Homepage
+{{ template "chart.homepage" . }}
+
+{{ template "chart.maintainersSection" . }}
+
+## Pre-requisite
+- Kubernetes cluster of version 1.18 and up, 1.19 and up recommended
+- Helm v3 must be installed and configured properly
+- Weka system pre-configured and Weka client installed and registered in cluster for each Kubernetes node
+- Weka CSI Plugin installed and configured in the cluster.
+
+> **NOTE:** This chart is not needed for WEKA CSI Plugin 3.0 and up, as it has built-in metrics server.
+
+{{ template "chart.requirementsSection" . }}
+
+{{ template "chart.valuesSection" . }}
+
+{{ template "helm-docs.versionFooter" . }}

--- a/charts/csi-metricsserver/ci/ct-values.yaml
+++ b/charts/csi-metricsserver/ci/ct-values.yaml
@@ -1,0 +1,11 @@
+# Values chart-testing installs with, on top of values.yaml.
+#
+# One replica, because ct runs `helm install --wait` and the readiness probe reports leadership:
+# with the default two replicas exactly one is elected, so the standby stays NotReady for as long
+# as the leader holds the lease and the install would sit there until it times out. That is the
+# intended behaviour in a real deployment - a standby is not ready to collect - but it makes the
+# chart look broken to a test that waits for every pod.
+metricsServer:
+  replicas: 1
+  # Nothing scrapes this in kind, and the shorter grace period lets the test tear down promptly
+  terminationGracePeriodSeconds: 5

--- a/charts/csi-metricsserver/templates/metricsserver-clusterrole.yaml
+++ b/charts/csi-metricsserver/templates/metricsserver-clusterrole.yaml
@@ -1,0 +1,17 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Release.Name }}-metrics-server
+  labels:
+    app: {{ .Release.Name }}-metrics-server
+    component: {{ .Release.Name }}-metrics-server
+    release: {{ .Release.Name }}
+# The metrics server only reads. It watches PersistentVolumes to learn which volumes exist, and reads
+# the Secrets they reference to reach the Weka API - so no write verbs are granted on either.
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch"]

--- a/charts/csi-metricsserver/templates/metricsserver-clusterrolebinding.yaml
+++ b/charts/csi-metricsserver/templates/metricsserver-clusterrolebinding.yaml
@@ -1,0 +1,16 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Release.Name }}-metrics-server
+  labels:
+    app: {{ .Release.Name }}-metrics-server
+    component: {{ .Release.Name }}-metrics-server
+    release: {{ .Release.Name }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Release.Name }}-metrics-server
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ .Release.Name }}-metrics-server
+  apiGroup: rbac.authorization.k8s.io

--- a/charts/csi-metricsserver/templates/metricsserver-deployment.yaml
+++ b/charts/csi-metricsserver/templates/metricsserver-deployment.yaml
@@ -51,11 +51,10 @@ spec:
       {{- end }}
       containers:
         - name: wekafs
-          image: "{{ .Values.image.repository }}:{{if not (empty .Values.image.tag)}}{{ .Values.image.tag }}{{else}}{{ .Chart.Version }}{{end}}"
+          image: "{{ .Values.image.repository }}:{{if not (empty .Values.image.tag)}}{{ .Values.image.tag }}{{else}}v{{ .Chart.Version }}{{end}}"
           imagePullPolicy: {{ .Values.image.pullPolicy | default "Always" }}
-          # The image carries both binaries. This chart runs the metrics server one directly rather
-          # than the plugin with --csimode=metricsserver; the mode still exists and behaves
-          # identically, but the dedicated binary is what this deployment is built around.
+          # This image's entrypoint is already /metricsserver; naming it explicitly keeps the command
+          # visible in the pod spec and identical to the in-plugin chart, which runs the same image.
           command:
             - /metricsserver
           args:

--- a/charts/csi-metricsserver/templates/metricsserver-deployment.yaml
+++ b/charts/csi-metricsserver/templates/metricsserver-deployment.yaml
@@ -1,0 +1,152 @@
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: {{ .Release.Name }}-metrics-server
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Release.Name }}-metrics-server
+    component: {{ .Release.Name }}-metrics-server
+    release: {{ .Release.Name }}
+    {{- if .Values.metricsServer.labels }}
+    {{- toYaml .Values.metricsServer.labels | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}-metrics-server
+      component: {{ .Release.Name }}-metrics-server
+      release: {{ .Release.Name }}
+  replicas: {{ .Values.metricsServer.replicas | default 1 }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Release.Name }}-metrics-server
+        component: {{ .Release.Name }}-metrics-server
+        release: {{ .Release.Name }}
+        {{- if .Values.metricsServer.podLabels }}
+        {{- toYaml .Values.metricsServer.podLabels | nindent 8 }}
+        {{- end }}
+    {{- if and .Values.metrics.enabled (not (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1")) }}
+      annotations:
+        prometheus.io/scrape: 'true'
+        prometheus.io/path: '/metrics'
+        prometheus.io/port: '{{ .Values.metrics.metricsServerPort | default 9096 }}'
+    {{- end }}
+    spec:
+      {{- if .Values.metricsServer.affinity }}
+      affinity:
+        {{- toYaml .Values.metricsServer.affinity | nindent 8 }}
+      {{- end }}
+      {{- if .Values.metricsServer.nodeSelector }}
+      nodeSelector:
+        {{- toYaml .Values.metricsServer.nodeSelector | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ .Release.Name }}-metrics-server
+      {{- if .Values.imagePullSecret }}
+      imagePullSecrets:
+        - name: {{ .Values.imagePullSecret }}
+      {{- end }}
+      {{- if .Values.hostNetwork }}
+      hostNetwork: true
+      {{- end }}
+      containers:
+        - name: wekafs
+          image: "{{ .Values.image.repository }}:{{if not (empty .Values.image.tag)}}{{ .Values.image.tag }}{{else}}{{ .Chart.Version }}{{end}}"
+          imagePullPolicy: {{ .Values.image.pullPolicy | default "Always" }}
+          # The image carries both binaries. This chart runs the metrics server one directly rather
+          # than the plugin with --csimode=metricsserver; the mode still exists and behaves
+          # identically, but the dedicated binary is what this deployment is built around.
+          command:
+            - /metricsserver
+          args:
+            - "--drivername=$(CSI_DRIVER_NAME)"
+            - "--nodeid=$(KUBE_NODE_NAME)"
+            - "--v={{ .Values.logLevel | default 5 }}"
+          {{- if .Values.tracingUrl }}
+            - "--tracingurl={{ .Values.tracingUrl }}"
+          {{- end }}
+          {{- if .Values.metrics.enabled }}
+            - "--enablemetrics"
+            - "--metricsport={{ .Values.metrics.metricsServerPort | default 9096 }}"
+          {{- end }}
+          {{- if .Values.pluginConfig.allowInsecureHttps }}
+            - "--allowinsecurehttps"
+          {{- end }}
+          {{- if .Values.useJsonLogging }}
+            - "--usejsonlogging"
+          {{- end }}
+          {{- if .Values.metricsServer.maxConcurrentRequests }}
+            - "--wekametricsfetchconcurrentrequests={{ .Values.metricsServer.maxConcurrentRequests }}"
+          {{- end }}
+          {{- if .Values.metricsServer.metricsFetchIntervalSeconds }}
+            - "--wekametricsfetchintervalseconds={{ .Values.metricsServer.metricsFetchIntervalSeconds }}"
+          {{- end }}
+          {{- if .Values.metricsServer.enableLeaderElection }}
+            - "--enablemetricsserverleaderelection"
+          {{- end }}
+          {{- if .Values.metricsServer.quotaUpdateConcurrentRequests }}
+            - "--wekametricsquotaupdateconcurrentrequests={{ .Values.metricsServer.quotaUpdateConcurrentRequests }}"
+          {{- end }}
+          {{- if .Values.metricsServer.quotaCacheValiditySeconds }}
+            - "--wekametricsquotacachevalidityseconds={{ .Values.metricsServer.quotaCacheValiditySeconds }}"
+          {{- end }}
+          {{- if .Values.metricsServer.enableBatchModeForQuotaUpdates }}
+            - "--fetchquotasinbatchmode"
+          {{- end }}
+          ports:
+            # controller-runtime serves /healthz and /readyz on one bind address, so liveness and
+            # readiness share a single port rather than each having their own.
+            - containerPort: {{ .Values.metricsServer.healthPort | default 8081 }}
+              name: healthz
+              protocol: TCP
+          {{- if .Values.metrics.enabled }}
+            - containerPort: {{ .Values.metrics.metricsServerPort | default 9096 }}
+              name: ms-metrics
+              protocol: TCP
+          {{- end }}
+          livenessProbe:
+            failureThreshold: 5
+            httpGet:
+              path: /healthz
+              port: healthz
+            initialDelaySeconds: 10
+            timeoutSeconds: 3
+            periodSeconds: 2
+          # With leader election on, /readyz reports leadership, so exactly one replica shows Ready
+          # and the standbys are visibly standing by rather than looking identical to the leader.
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /readyz
+              port: healthz
+            initialDelaySeconds: 10
+            timeoutSeconds: 3
+            periodSeconds: 10
+          env:
+            - name: CSI_DRIVER_NAME
+              value: {{ required "Provide CSI Driver Name" .Values.csiDriverName }}
+            - name: KUBE_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: KUBE_NODE_IP_ADDRESS
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: HEALTH_PORT
+              value: "{{ .Values.metricsServer.healthPort | default 8081 }}"
+            {{- if .Values.tracingDeploymentIdentifier }}
+            - name: OTEL_DEPLOYMENT_IDENTIFIER
+              value: {{ .Values.tracingDeploymentIdentifier }}
+            {{- end }}
+          resources:
+            {{- toYaml .Values.metricsServer.resources | nindent 12 }}
+      {{- with .Values.metricsServer.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.metricsServer.terminationGracePeriodSeconds | default 30 }}

--- a/charts/csi-metricsserver/templates/metricsserver-podmonitor.yaml
+++ b/charts/csi-metricsserver/templates/metricsserver-podmonitor.yaml
@@ -1,0 +1,44 @@
+{{- if and .Values.metrics.enabled .Values.metrics.podMonitor.enabled }}
+{{- if .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ .Release.Name }}-metrics-server
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Release.Name }}-metrics-server
+    component: {{ .Release.Name }}-metrics-server
+    release: {{ .Release.Name }}
+    {{- with .Values.metrics.podMonitor.additionalLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}-metrics-server
+      component: {{ .Release.Name }}-metrics-server
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  podMetricsEndpoints:
+    - port: ms-metrics
+      path: /metrics
+      interval: {{ .Values.metrics.podMonitor.interval }}
+      # Metrics carry the timestamp of the measurement they describe, not of the scrape - a quota read
+      # a few minutes ago is reported with that age rather than pretending to be fresh. Prometheus
+      # only keeps those timestamps if told to honor them.
+      honorTimestamps: true
+      metricRelabelings:
+        - action: labeldrop
+          regex: ^job$
+        - action: labeldrop
+          regex: ^instance$
+        - action: labeldrop
+          regex: ^namespace$
+        - action: labeldrop
+          regex: ^endpoint$
+        - action: labeldrop
+          regex: ^container$
+{{- end }}
+{{- end }}

--- a/charts/csi-metricsserver/templates/metricsserver-role.yaml
+++ b/charts/csi-metricsserver/templates/metricsserver-role.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Release.Name }}-metrics-server
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Release.Name }}-metrics-server
+    component: {{ .Release.Name }}-metrics-server
+    release: {{ .Release.Name }}
+# Leases and events are what controller-runtime's leader election needs; both are namespaced.
+rules:
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "create", "update"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch", "update"]

--- a/charts/csi-metricsserver/templates/metricsserver-rolebinding.yaml
+++ b/charts/csi-metricsserver/templates/metricsserver-rolebinding.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Release.Name }}-metrics-server
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Release.Name }}-metrics-server
+    component: {{ .Release.Name }}-metrics-server
+    release: {{ .Release.Name }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Release.Name }}-metrics-server
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: {{ .Release.Name }}-metrics-server
+  apiGroup: rbac.authorization.k8s.io

--- a/charts/csi-metricsserver/templates/metricsserver-security-context-constraint.yaml
+++ b/charts/csi-metricsserver/templates/metricsserver-security-context-constraint.yaml
@@ -1,0 +1,28 @@
+{{- if .Capabilities.APIVersions.Has "security.openshift.io/v1/SecurityContextConstraints" }}
+kind: SecurityContextConstraints
+apiVersion: security.openshift.io/v1
+metadata:
+  name: {{ .Release.Name }}-metrics-server-scc
+
+# The metrics server mounts nothing and runs no privileged operation - it only talks to the
+# Kubernetes and Weka APIs - so unlike the CSI controller and node SCCs this grants neither
+# allowPrivilegedContainer nor allowHostDirVolumePlugin.
+{{- if .Values.hostNetwork }}
+allowHostNetwork: true
+{{- end }}
+volumes:
+  - secret
+  - emptyDir
+readOnlyRootFilesystem: false
+allowHostPorts: true
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+fsGroup:
+  type: RunAsAny
+supplementalGroups:
+  type: RunAsAny
+users:
+  - system:serviceaccount:{{ .Release.Namespace }}:{{ .Release.Name }}-metrics-server
+{{- end }}

--- a/charts/csi-metricsserver/templates/metricsserver-serviceaccount.yaml
+++ b/charts/csi-metricsserver/templates/metricsserver-serviceaccount.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Name }}-metrics-server
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Release.Name }}-metrics-server
+    component: {{ .Release.Name }}-metrics-server
+    release: {{ .Release.Name }}

--- a/charts/csi-metricsserver/values.yaml
+++ b/charts/csi-metricsserver/values.yaml
@@ -5,10 +5,10 @@
 csiDriverName: "csi.weka.io"
 
 image:
-  # -- The metrics server ships inside the CSI plugin image, which carries both binaries
-  repository: quay.io/weka.io/csi-wekafs
+  # -- The metrics server has its own image, built by Dockerfile-metricsserver
+  repository: quay.io/weka.io/csi-metricsserver
   pullPolicy: Always
-  # -- Image tag; defaults to the chart version when empty
+  # -- Image tag; defaults to v<chart version> when empty
   tag: ""
 imagePullSecret: ""
 

--- a/charts/csi-metricsserver/values.yaml
+++ b/charts/csi-metricsserver/values.yaml
@@ -16,7 +16,9 @@ hostNetwork: false
 
 metricsServer:
   # -- Number of replicas for metrics server. More than one is only useful with enableLeaderElection,
-  #    which keeps exactly one of them collecting while the rest stand by
+  #    which keeps exactly one of them collecting while the rest stand by.
+  #    A standby is not free: controller-runtime starts its cache on every replica, so each standby
+  #    holds a full PersistentVolume informer cache and a watch against the API server while idle
   replicas: 2
   # -- optional nodeSelector for metrics server only
   nodeSelector: {}
@@ -52,8 +54,14 @@ metricsServer:
   #    When false, all quota values will be fetched instantaneously, during metrics collection.
   #    Not recommended when having thousands of PVCs
   enableBatchModeForQuotaUpdates: false
-  # -- Port serving both the /healthz liveness probe and the /readyz readiness probe
-  healthPort: 8081
+  # -- Scrape interval for the metrics server. Defaults to the fetch interval rather than the
+  #    chart-wide 30s: the gauges only move once per metricsFetchIntervalSeconds, and with
+  #    honorTimestamps a repeat scrape carries the same timestamp and is discarded as a duplicate
+  scrapeInterval: 60s
+  # -- Port serving both the /healthz liveness probe and the /readyz readiness probe.
+  #    Deliberately not the controller's 8081: under hostNetwork the two share a node's network
+  #    namespace, and whichever bound second would fail
+  healthPort: 9196
   # -- Resources for the metrics server container
   resources:
     limits:
@@ -61,7 +69,9 @@ metricsServer:
       memory: 2Gi
     requests:
       cpu: 0.1
-      memory: 100Mi
+      # Sized for the PersistentVolume informer cache plus in-flight quota fetches; at ~10k volumes
+      # the leader sits well above the 100Mi that looks sufficient when idle
+      memory: 256Mi
 
 # -- Log level of CSI plugin
 logLevel: 6
@@ -69,14 +79,13 @@ logLevel: 6
 useJsonLogging: false
 
 metrics:
-  # -- Enable Prometheus Metrics
-  enabled: true
-  # -- Metrics server metrics port
+  # -- Metrics server metrics port. The metrics server always exports; exporting is its only job,
+  #    so there is no switch to turn it off
   metricsServerPort: 9096
   podMonitor:
     # -- Create a PodMonitor, if the Prometheus Operator CRDs are installed
     enabled: true
-    # -- Scrape interval
+    # -- Scrape interval for charts that do not override it
     interval: 30s
     # -- Additional labels, e.g. the release label your Prometheus selects PodMonitors by
     additionalLabels: {}

--- a/charts/csi-metricsserver/values.yaml
+++ b/charts/csi-metricsserver/values.yaml
@@ -1,0 +1,90 @@
+# Default values for csi-metricsserver.
+
+# -- Name of the CSI driver whose PersistentVolumes to report on. Must match the csiDriverName of the
+#    csi-wekafsplugin release that provisioned them, or no volumes will be discovered.
+csiDriverName: "csi.weka.io"
+
+image:
+  # -- The metrics server ships inside the CSI plugin image, which carries both binaries
+  repository: quay.io/weka.io/csi-wekafs
+  pullPolicy: Always
+  # -- Image tag; defaults to the chart version when empty
+  tag: ""
+imagePullSecret: ""
+
+hostNetwork: false
+
+metricsServer:
+  # -- Number of replicas for metrics server. More than one is only useful with enableLeaderElection,
+  #    which keeps exactly one of them collecting while the rest stand by
+  replicas: 2
+  # -- optional nodeSelector for metrics server only
+  nodeSelector: {}
+  # -- optional affinity for metrics server only
+  affinity: {}
+  # -- optional labels to add to metrics server deployment
+  labels: {}
+  # -- optional labels to add to metrics server pods
+  podLabels: {}
+  # -- tolerations for metrics server only
+  tolerations: {}
+  # -- concurrent requests for WEKA API (excluding quota)
+  maxConcurrentRequests: 50
+  # -- metrics fetch interval in seconds, default is 60 seconds.
+  #    Only expired metrics will be updated, set by quotaCacheValiditySeconds
+  metricsFetchIntervalSeconds: 60
+  # -- termination grace period for metrics server pods
+  terminationGracePeriodSeconds: 10
+  # -- enable leader election for metrics server
+  enableLeaderElection: true
+  # -- number of concurrent requests for metrics server to update quotas
+  quotaUpdateConcurrentRequests: 25
+  # -- the time period for which quotaMap of a certain filesystem should be considered valid. usually should match metricsFetchIntervalSeconds,
+  #    but in deployments with thousands of PVCs this can be increased to reduce the load on the metrics server.
+  #    Metrics in such case will be updated less frequently. But for each metric, a last update time will be recorded
+  quotaCacheValiditySeconds: 300
+  # -- Enable metrics server to fetch metrics from WEKA API using batches (all quotas for a filesystem in one request).
+  #    This is useful for large filesystems with many PVCs, as it reduces the number of requests to WEKA API.
+  #    This is disabled by default.
+  #    The drawback is that in such case, metrics will be reported less frequently, using cached values.
+  #    Report timestamp will be recorded for each metric, so you can see when the last update was.
+  #    This requires Prometheus server to honor timestamps.
+  #    When false, all quota values will be fetched instantaneously, during metrics collection.
+  #    Not recommended when having thousands of PVCs
+  enableBatchModeForQuotaUpdates: false
+  # -- Port serving both the /healthz liveness probe and the /readyz readiness probe
+  healthPort: 8081
+  # -- Resources for the metrics server container
+  resources:
+    limits:
+      cpu: 2
+      memory: 2Gi
+    requests:
+      cpu: 0.1
+      memory: 100Mi
+
+# -- Log level of CSI plugin
+logLevel: 6
+# -- Use JSON structured logging instead of human-readable logging format (for exporting logs to structured log parser)
+useJsonLogging: false
+
+metrics:
+  # -- Enable Prometheus Metrics
+  enabled: true
+  # -- Metrics server metrics port
+  metricsServerPort: 9096
+  podMonitor:
+    # -- Create a PodMonitor, if the Prometheus Operator CRDs are installed
+    enabled: true
+    # -- Scrape interval
+    interval: 30s
+    # -- Additional labels, e.g. the release label your Prometheus selects PodMonitors by
+    additionalLabels: {}
+
+# @ignore
+tracingUrl: ""
+# @ignore
+tracingDeploymentIdentifier: ""
+
+pluginConfig:
+  allowInsecureHttps: false

--- a/charts/csi-wekafsplugin/templates/NOTES.txt
+++ b/charts/csi-wekafsplugin/templates/NOTES.txt
@@ -52,3 +52,12 @@ https://github.com/weka/csi-wekafs/tree/master/examples
 | IS NOT CONSIDERED SECURE, NOT SUPPORTED AND MAY LEAD TO DATA LOSS IN CASE OF A CLUSTER RECOVERY          |
 ------------------------------------------------------------------------------------------------------------
 {{- end }}
+{{- if .Values.metricsServer.enabled }}
+
+-------------------------------------------------- WARNING -------------------------------------------------
+| THE WEKA METRICS SERVER IS DEPLOYED AS PART OF THIS RELEASE.                                             |
+| IT ALSO SHIPS AS A SEPARATE CHART, csi-metricsserver. DO NOT RUN BOTH AGAINST THE SAME WEKA CLUSTER:     |
+| EACH COLLECTOR POLLS EVERY VOLUME'S QUOTA INDEPENDENTLY, SO A SECOND ONE DOUBLES THE WEKA API LOAD       |
+| WITHOUT REPORTING ANY ADDITIONAL DATA.                                                                   |
+------------------------------------------------------------------------------------------------------------
+{{- end }}

--- a/charts/csi-wekafsplugin/templates/metricsserver-clusterrole.yaml
+++ b/charts/csi-wekafsplugin/templates/metricsserver-clusterrole.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.metricsServer.enabled }}
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Release.Name }}-metrics-server
+  labels:
+    app: {{ .Release.Name }}-metrics-server
+    component: {{ .Release.Name }}-metrics-server
+    release: {{ .Release.Name }}
+# The metrics server only reads. It watches PersistentVolumes to learn which volumes exist, and reads
+# the Secrets they reference to reach the Weka API - so no write verbs are granted on either. This is
+# a separate ServiceAccount from the controller's, so enabling it widens what this release can read.
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch"]
+{{- end }}

--- a/charts/csi-wekafsplugin/templates/metricsserver-clusterrolebinding.yaml
+++ b/charts/csi-wekafsplugin/templates/metricsserver-clusterrolebinding.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.metricsServer.enabled }}
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Release.Name }}-metrics-server
+  labels:
+    app: {{ .Release.Name }}-metrics-server
+    component: {{ .Release.Name }}-metrics-server
+    release: {{ .Release.Name }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Release.Name }}-metrics-server
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ .Release.Name }}-metrics-server
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/charts/csi-wekafsplugin/templates/metricsserver-deployment.yaml
+++ b/charts/csi-wekafsplugin/templates/metricsserver-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.metricsServer.enabled }}
 kind: Deployment
 apiVersion: apps/v1
 metadata:
@@ -33,39 +34,48 @@ spec:
         prometheus.io/port: '{{ .Values.metrics.metricsServerPort | default 9096 }}'
     {{- end }}
     spec:
-      {{- if .Values.metricsServer.affinity }}
+      {{- if or .Values.metricsServer.affinity .Values.affinity }}
+      {{- $metricsServerAffinity := dict -}}
+      {{- $_ := include "helm-toolkit.utils.merge" (tuple $metricsServerAffinity .Values.metricsServer.affinity .Values.affinity) }}
       affinity:
-        {{- toYaml .Values.metricsServer.affinity | nindent 8 }}
+        {{- toYaml $metricsServerAffinity | nindent 8 }}
       {{- end }}
-      {{- if .Values.metricsServer.nodeSelector }}
+      {{- if or .Values.nodeSelector .Values.metricsServer.nodeSelector }}
+      {{- $nodeSelector := dict -}}
+      {{- $_ := include "helm-toolkit.utils.merge" (tuple $nodeSelector .Values.metricsServer.nodeSelector .Values.nodeSelector) }}
       nodeSelector:
-        {{- toYaml .Values.metricsServer.nodeSelector | nindent 8 }}
+        {{- toYaml $nodeSelector | nindent 8 }}
       {{- end }}
       serviceAccountName: {{ .Release.Name }}-metrics-server
       {{- if .Values.imagePullSecret }}
       imagePullSecrets:
         - name: {{ .Values.imagePullSecret }}
       {{- end }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName }}
+      {{- end }}
       {{- if .Values.hostNetwork }}
       hostNetwork: true
       {{- end }}
       containers:
-        - name: wekafs
-          image: "{{ .Values.image.repository }}:{{if not (empty .Values.image.tag)}}{{ .Values.image.tag }}{{else}}{{ .Chart.Version }}{{end}}"
-          imagePullPolicy: {{ .Values.image.pullPolicy | default "Always" }}
-          # The image carries both binaries. This chart runs the metrics server one directly rather
-          # than the plugin with --csimode=metricsserver; the mode still exists and behaves
-          # identically, but the dedicated binary is what this deployment is built around.
+        - name: metrics-server
+          image: {{ .Values.images.csidriver }}:v{{ .Values.images.csidriverTag }}
+          imagePullPolicy: Always
+          # The image carries both binaries. This runs the metrics server one directly rather than the
+          # plugin with --csimode=metricsserver; the mode still exists and behaves identically, but the
+          # dedicated binary is what this Deployment is built around.
           command:
             - /metricsserver
           args:
             - "--drivername=$(CSI_DRIVER_NAME)"
             - "--nodeid=$(KUBE_NODE_NAME)"
-            - "--v={{ .Values.logLevel | default 5 }}"
+            - "--v={{ .Values.metricsServer.logLevel | default .Values.logLevel }}"
           {{- if .Values.tracingUrl }}
             - "--tracingurl={{ .Values.tracingUrl }}"
           {{- end }}
-            {{/* Not optional: exporting metrics is this pod's only job. */}}
+            {{/* Deliberately not gated on .Values.metrics.enabled, which turns off metrics for the
+                 CSI sidecars. Exporting metrics is this pod's only job, so a metrics server that
+                 emitted nothing would be a pod with nothing to do. */}}
             - "--enablemetrics"
             - "--metricsport={{ .Values.metrics.metricsServerPort | default 9096 }}"
           {{- if .Values.pluginConfig.allowInsecureHttps }}
@@ -147,3 +157,4 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       terminationGracePeriodSeconds: {{ .Values.metricsServer.terminationGracePeriodSeconds | default 30 }}
+{{- end }}

--- a/charts/csi-wekafsplugin/templates/metricsserver-deployment.yaml
+++ b/charts/csi-wekafsplugin/templates/metricsserver-deployment.yaml
@@ -59,11 +59,10 @@ spec:
       {{- end }}
       containers:
         - name: metrics-server
-          image: {{ .Values.images.csidriver }}:v{{ .Values.images.csidriverTag }}
+          image: {{ .Values.images.csimetricsserver }}:v{{ .Values.images.csimetricsserverTag }}
           imagePullPolicy: Always
-          # The image carries both binaries. This runs the metrics server one directly rather than the
-          # plugin with --csimode=metricsserver; the mode still exists and behaves identically, but the
-          # dedicated binary is what this Deployment is built around.
+          # A separate image from the CSI driver's, carrying only the metrics server. Its entrypoint is
+          # already /metricsserver; naming it explicitly keeps the command visible in the pod spec.
           command:
             - /metricsserver
           args:

--- a/charts/csi-wekafsplugin/templates/metricsserver-podmonitor.yaml
+++ b/charts/csi-wekafsplugin/templates/metricsserver-podmonitor.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.metrics.podMonitor.enabled }}
+{{- if and .Values.metricsServer.enabled .Values.metrics.podMonitor.enabled }}
 {{- if .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" }}
 ---
 apiVersion: monitoring.coreos.com/v1

--- a/charts/csi-wekafsplugin/templates/metricsserver-role.yaml
+++ b/charts/csi-wekafsplugin/templates/metricsserver-role.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.metricsServer.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Release.Name }}-metrics-server
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Release.Name }}-metrics-server
+    component: {{ .Release.Name }}-metrics-server
+    release: {{ .Release.Name }}
+# Leases and events are what controller-runtime's leader election needs; both are namespaced.
+rules:
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "create", "update"]
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "patch", "update"]
+{{- end }}

--- a/charts/csi-wekafsplugin/templates/metricsserver-rolebinding.yaml
+++ b/charts/csi-wekafsplugin/templates/metricsserver-rolebinding.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.metricsServer.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Release.Name }}-metrics-server
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Release.Name }}-metrics-server
+    component: {{ .Release.Name }}-metrics-server
+    release: {{ .Release.Name }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Release.Name }}-metrics-server
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: Role
+  name: {{ .Release.Name }}-metrics-server
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/charts/csi-wekafsplugin/templates/metricsserver-security-context-constraint.yaml
+++ b/charts/csi-wekafsplugin/templates/metricsserver-security-context-constraint.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.metricsServer.enabled }}
+{{- if .Capabilities.APIVersions.Has "security.openshift.io/v1/SecurityContextConstraints" }}
+kind: SecurityContextConstraints
+apiVersion: security.openshift.io/v1
+metadata:
+  name: {{ .Release.Name }}-metrics-server-scc
+
+# The metrics server mounts nothing and runs no privileged operation - it only talks to the
+# Kubernetes and Weka APIs - so unlike the controller and node SCCs this grants neither
+# allowPrivilegedContainer nor allowHostDirVolumePlugin.
+{{- if .Values.hostNetwork }}
+allowHostNetwork: true
+{{- end }}
+volumes:
+  - secret
+  - emptyDir
+readOnlyRootFilesystem: false
+allowHostPorts: true
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+fsGroup:
+  type: RunAsAny
+supplementalGroups:
+  type: RunAsAny
+users:
+  - system:serviceaccount:{{ .Release.Namespace }}:{{ .Release.Name }}-metrics-server
+{{- end }}
+{{- end }}

--- a/charts/csi-wekafsplugin/templates/metricsserver-serviceaccount.yaml
+++ b/charts/csi-wekafsplugin/templates/metricsserver-serviceaccount.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.metricsServer.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Name }}-metrics-server
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Release.Name }}-metrics-server
+    component: {{ .Release.Name }}-metrics-server
+    release: {{ .Release.Name }}
+{{- if .Values.imagePullSecret }}
+imagePullSecrets:
+  - name: {{ .Values.imagePullSecret }}
+{{- end }}
+{{- end }}

--- a/charts/csi-wekafsplugin/values.schema.json
+++ b/charts/csi-wekafsplugin/values.schema.json
@@ -302,6 +302,12 @@
                 "csidriverTag": {
                     "type": "string"
                 },
+                "csimetricsserver": {
+                    "type": "string"
+                },
+                "csimetricsserverTag": {
+                    "type": "string"
+                },
                 "healthmonitorsidecar": {
                     "type": "string"
                 },

--- a/charts/csi-wekafsplugin/values.schema.json
+++ b/charts/csi-wekafsplugin/values.schema.json
@@ -349,6 +349,9 @@
                 "enabled": {
                     "type": "boolean"
                 },
+                "metricsServerPort": {
+                    "type": "integer"
+                },
                 "nodePort": {
                     "type": "integer"
                 },
@@ -374,6 +377,82 @@
                 },
                 "snapshotterPort": {
                     "type": "integer"
+                }
+            }
+        },
+        "metricsServer": {
+            "type": "object",
+            "properties": {
+                "affinity": {
+                    "type": "object"
+                },
+                "enableBatchModeForQuotaUpdates": {
+                    "type": "boolean"
+                },
+                "enableLeaderElection": {
+                    "type": "boolean"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "healthPort": {
+                    "type": "integer"
+                },
+                "labels": {
+                    "type": "object"
+                },
+                "logLevel": {
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "maxConcurrentRequests": {
+                    "type": "integer"
+                },
+                "metricsFetchIntervalSeconds": {
+                    "type": "integer"
+                },
+                "nodeSelector": {
+                    "type": "object"
+                },
+                "podLabels": {
+                    "type": "object"
+                },
+                "quotaCacheValiditySeconds": {
+                    "type": "integer"
+                },
+                "quotaUpdateConcurrentRequests": {
+                    "type": "integer"
+                },
+                "replicas": {
+                    "type": "integer"
+                },
+                "resources": {
+                    "type": "object"
+                },
+                "scrapeInterval": {
+                    "type": "string"
+                },
+                "terminationGracePeriodSeconds": {
+                    "type": "integer"
+                },
+                "tolerations": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "effect": {
+                                "type": "string"
+                            },
+                            "key": {
+                                "type": "string"
+                            },
+                            "operator": {
+                                "type": "string"
+                            }
+                        }
+                    }
                 }
             }
         },

--- a/charts/csi-wekafsplugin/values.yaml
+++ b/charts/csi-wekafsplugin/values.yaml
@@ -25,6 +25,11 @@ images:
   csidriver: quay.io/weka.io/csi-wekafs
   # -- CSI driver tag
   csidriverTag: *csiDriverVersion
+  # -- CSI metrics server image URL. Separate from the driver image: the metrics server ships as its
+  #    own image, built by Dockerfile-metricsserver
+  csimetricsserver: quay.io/weka.io/csi-metricsserver
+  # -- CSI metrics server image tag
+  csimetricsserverTag: *csiDriverVersion
 # -- image pull secret required for image download. Must have permissions to access all images above.
 #    Should be used in case of private registry that requires authentication
 imagePullSecret: ""

--- a/charts/csi-wekafsplugin/values.yaml
+++ b/charts/csi-wekafsplugin/values.yaml
@@ -196,6 +196,74 @@ selinuxSupport: "off"
 # -- This label must be set to `"true"` on SELinux-enabled Kubernetes nodes,
 #    e.g., to run the node server in secure mode on SELinux-enabled node, the node must have label
 #    `csi.weka.io/selinux_enabled="true"`
+metricsServer:
+  # -- Deploy the WEKA metrics server alongside the CSI plugin, reporting per-volume capacity and
+  #    performance to Prometheus.
+  #    NOTE: this grants a separate ServiceAccount cluster-wide read of PersistentVolumes and of the
+  #    Secrets they reference, so that it can query the WEKA cluster for those metrics.
+  #    Off by default: the metrics server also ships as its own csi-metricsserver chart, and running
+  #    both against one WEKA cluster doubles the quota API load for no extra data.
+  enabled: false
+  # -- Number of replicas for metrics server. More than one is only useful with enableLeaderElection,
+  #    which keeps exactly one of them collecting while the rest stand by.
+  #    A standby is not free: controller-runtime starts its cache on every replica, so each standby
+  #    holds a full PersistentVolume informer cache and a watch against the API server while idle
+  replicas: 2
+  # -- optional log level for metrics server only (defaults to the chart-wide logLevel)
+  logLevel: ~
+  # -- optional nodeSelector for metrics server only (merged over the chart-wide nodeSelector)
+  nodeSelector: {}
+  # -- optional affinity for metrics server only (merged over the chart-wide affinity)
+  affinity: {}
+  # -- optional labels to add to metrics server deployment
+  labels: {}
+  # -- optional labels to add to metrics server pods
+  podLabels: {}
+  # -- tolerations for metrics server only (by default same as global)
+  tolerations: *globalPluginTolerations
+  # -- concurrent requests for WEKA API (excluding quota)
+  maxConcurrentRequests: 50
+  # -- metrics fetch interval in seconds, default is 60 seconds.
+  #    Only expired metrics will be updated, set by quotaCacheValiditySeconds
+  metricsFetchIntervalSeconds: 60
+  # -- termination grace period for metrics server pods
+  terminationGracePeriodSeconds: 10
+  # -- enable leader election for metrics server
+  enableLeaderElection: true
+  # -- number of concurrent requests for metrics server to update quotas
+  quotaUpdateConcurrentRequests: 25
+  # -- the time period for which quotaMap of a certain filesystem should be considered valid. usually should match metricsFetchIntervalSeconds,
+  #    but in deployments with thousands of PVCs this can be increased to reduce the load on the metrics server.
+  #    Metrics in such case will be updated less frequently. But for each metric, a last update time will be recorded
+  quotaCacheValiditySeconds: 300
+  # -- Enable metrics server to fetch metrics from WEKA API using batches (all quotas for a filesystem in one request).
+  #    This is useful for large filesystems with many PVCs, as it reduces the number of requests to WEKA API.
+  #    This is disabled by default.
+  #    The drawback is that in such case, metrics will be reported less frequently, using cached values.
+  #    Report timestamp will be recorded for each metric, so you can see when the last update was.
+  #    This requires Prometheus server to honor timestamps.
+  #    When false, all quota values will be fetched instantaneously, during metrics collection.
+  #    Not recommended when having thousands of PVCs
+  enableBatchModeForQuotaUpdates: false
+  # -- Scrape interval for the metrics server. Defaults to the fetch interval rather than the
+  #    chart-wide metrics.podMonitor.interval: the gauges only move once per
+  #    metricsFetchIntervalSeconds, and with honorTimestamps a repeat scrape carries the same
+  #    timestamp and is discarded as a duplicate
+  scrapeInterval: 60s
+  # -- Port serving both the /healthz liveness probe and the /readyz readiness probe.
+  #    Deliberately not the controller's 8081: under hostNetwork the two share a node's network
+  #    namespace, and whichever bound second would fail
+  healthPort: 9196
+  # -- Resources for the metrics server container
+  resources:
+    limits:
+      cpu: 2
+      memory: 2Gi
+    requests:
+      cpu: 0.1
+      # Sized for the PersistentVolume informer cache plus in-flight quota fetches; at ~10k volumes
+      # the leader sits well above the 100Mi that looks sufficient when idle
+      memory: 256Mi
 selinuxNodeLabel: "csi.weka.io/selinux_enabled"
 # -- If true, the SELinux policy machine configuration will not be removed when uninstalling the plugin.
 #    This is useful for OpenShift Container Platform clusters, to not cause machine config pool update on plugin reinstall
@@ -215,6 +283,8 @@ metrics:
   snapshotterPort: 9093
   # -- Metrics port for Node Serer
   nodePort: 9094
+  # -- Metrics port for Metrics Server
+  metricsServerPort: 9096
   # -- PodMonitor resources for the Prometheus Operator. Only rendered when the
   #    monitoring.coreos.com/v1 CRDs are present in the cluster.
   podMonitor:

--- a/cmd/metricsserver/main.go
+++ b/cmd/metricsserver/main.go
@@ -1,0 +1,126 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Command metricsserver runs the Weka CSI metrics server on its own, without the CSI driver.
+//
+// It is the same code the plugin runs under -csimode=metricsserver; this binary exists so the
+// metrics server can be deployed and scaled separately from the driver, with a flag set narrowed to
+// what it actually reads. Everything specific to serving CSI - mounting, the gRPC surface, volume
+// provisioning - is skipped by the mode itself, so this entry point only has to build a config,
+// construct the driver and run it.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"path"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/rs/zerolog/log"
+
+	"github.com/wekafs/csi-wekafs/pkg/bootstrap"
+	"github.com/wekafs/csi-wekafs/pkg/wekafs"
+	"github.com/wekafs/csi-wekafs/pkg/wekafs/apiclient"
+)
+
+// csiMode is fixed rather than a flag: this binary is the metrics server, and any other mode would
+// need the driver machinery that main() below deliberately does not set up.
+const csiMode = wekafs.CsiModeMetricsServer
+
+var (
+	driverName         = flag.String("drivername", "csi.weka.io", "name of the driver whose volumes to report on")
+	nodeID             = flag.String("nodeid", "", "node id")
+	showVersion        = flag.Bool("version", false, "Show version.")
+	enableMetrics      = flag.Bool("enablemetrics", false, "Enable Prometheus metrics endpoint")
+	metricsPort        = flag.String("metricsport", "9090", "HTTP port to expose metrics on")
+	verbosity          = flag.Int("v", 1, "sets log verbosity level")
+	tracingUrl         = flag.String("tracingurl", "", "OpenTelemetry / Jaeger endpoint")
+	allowInsecureHttps = flag.Bool("allowinsecurehttps", false, "Allow insecure HTTPS connection without cert validation")
+	usejsonlogging     = flag.Bool("usejsonlogging", false, "Use structured JSON logging rather than human-readable console log formatting")
+
+	wekaMetricsFetchIntervalSeconds          = flag.Int("wekametricsfetchintervalseconds", 60, "Interval in seconds to fetch metrics from Weka cluster")
+	wekaMetricsFetchConcurrentRequests       = flag.Int("wekametricsfetchconcurrentrequests", 1, "Maximum concurrent requests to fetch metrics from Weka cluster")
+	enableMetricsServerLeaderElection        = flag.Bool("enablemetricsserverleaderelection", false, "Enable leader election for metrics server")
+	wekaMetricsQuotaUpdateConcurrentRequests = flag.Int("wekametricsquotaupdateconcurrentrequests", 5, "Maximum concurrent requests to update quotas for metrics server")
+	wekaMetricsQuotaCacheValiditySeconds     = flag.Int("wekametricsquotacachevalidityseconds", 60, "Duration in seconds for which the quota map is considered valid")
+	fetchQuotasInBatchMode                   = flag.Bool("fetchquotasinbatchmode", false, "Use batch mode for metrics server, fetch all filesystem quotas in one go")
+
+	// Set by the build process
+	version = ""
+)
+
+func main() {
+	flag.Parse()
+	bootstrap.SetupLogging(*usejsonlogging, *verbosity)
+
+	if *showVersion {
+		fmt.Println(path.Base(os.Args[0]), version)
+		return
+	}
+	log.Info().Str("csi_mode", string(csiMode)).Msg("Started Weka CSI metrics server")
+
+	if *enableMetrics {
+		// Only the API client's collectors are registered up front. The controller and node families
+		// belong to modes this binary never runs, and exporting a permanently-zero copy of them would
+		// be misleading; the metrics server's own collectors need the driver and are registered in
+		// handle() once it exists.
+		prometheus.MustRegister(apiclient.Collectors()...)
+		bootstrap.ServeMetrics(*metricsPort)
+	}
+
+	ctx := context.Background()
+	shutdownTracing := bootstrap.SetupTracing(ctx, version, *tracingUrl, csiMode)
+	defer shutdownTracing()
+
+	handle(ctx)
+	os.Exit(0)
+}
+
+func handle(ctx context.Context) {
+	// Only the settings the metrics server reads are set. The rest - mount options, provisioning
+	// prefixes, per-operation concurrency - govern CSI request handling that this process never does,
+	// and NewDriverConfig supplies its own defaults for the metrics knobs left at zero.
+	config := wekafs.NewDriverConfig(wekafs.DriverConfigOptions{
+		Version:            version,
+		AllowInsecureHttps: *allowInsecureHttps,
+		TracingUrl:         *tracingUrl,
+
+		MetricsFetchIntervalSeconds:       *wekaMetricsFetchIntervalSeconds,
+		MetricsFetchConcurrentRequests:    *wekaMetricsFetchConcurrentRequests,
+		EnableMetricsServerLeaderElection: *enableMetricsServerLeaderElection,
+		QuotaFetchConcurrentRequests:      *wekaMetricsQuotaUpdateConcurrentRequests,
+		QuotaCacheValiditySeconds:         *wekaMetricsQuotaCacheValiditySeconds,
+		UseQuotaMapsForMetrics:            *fetchQuotasInBatchMode,
+	})
+
+	// No endpoint and no volume limit: this process serves no gRPC and stages nothing.
+	driver, err := wekafs.NewWekaFsDriver(*driverName, *nodeID, "", 0, version, "", csiMode, false, config)
+	if err != nil {
+		fmt.Printf("Failed to initialize metrics server: %s", err.Error())
+		os.Exit(1)
+	}
+	config.SetDriver(driver)
+
+	if *enableMetrics {
+		if collectors := driver.MetricsServerCollectors(); len(collectors) > 0 {
+			prometheus.MustRegister(collectors...)
+		}
+	}
+
+	driver.Run(ctx)
+}

--- a/cmd/wekafsplugin/main.go
+++ b/cmd/wekafsplugin/main.go
@@ -113,6 +113,7 @@ var (
 	advertiseVolumeHealthSupport         = flag.Bool("advertisevolumehealthsupport", true, "Expose GET_VOLUME and VOLUME_CONDITION, allowing the CSI health monitor to report volume condition and capacity")
 
 	// Metrics server settings
+	enableMetricsServer                      = flag.Bool("enablemetricsserver", false, "Enable the metrics server that reports per-PersistentVolume capacity and performance statistics to Prometheus (requires -enablemetrics and controller/all csimode)")
 	wekaMetricsFetchIntervalSeconds          = flag.Int("wekametricsfetchintervalseconds", 60, "Interval in seconds to fetch metrics from Weka cluster")
 	wekaMetricsFetchConcurrentRequests       = flag.Int("wekametricsfetchconcurrentrequests", 1, "Maximum concurrent requests to fetch metrics from Weka cluster")
 	enableMetricsServerLeaderElection        = flag.Bool("enablemetricsserverleaderelection", false, "Enable leader election for metrics server")
@@ -289,6 +290,7 @@ func handle(ctx context.Context) {
 		SetOwnershipOnDynamicFilesystems:  *setOwnershipOnDynamicFilesystems,
 		KeepThinProvisioningRatioOnExpand: *keepThinProvisioningRatioOnExpand,
 
+		EnableMetricsServer:               *enableMetricsServer,
 		MetricsFetchIntervalSeconds:       *wekaMetricsFetchIntervalSeconds,
 		MetricsFetchConcurrentRequests:    *wekaMetricsFetchConcurrentRequests,
 		EnableMetricsServerLeaderElection: *enableMetricsServerLeaderElection,
@@ -302,6 +304,20 @@ func handle(ctx context.Context) {
 		os.Exit(1)
 	}
 	config.SetDriver(driver)
+
+	// Register the metrics server's own collectors, but only if metrics export is on in the first
+	// place and a metrics server was actually constructed (enablemetricsserver + a csimode with a
+	// controller-runtime manager - see NewWekaFsDriver) - a disabled metrics server must export
+	// nothing. This has to happen here rather than alongside the other collectors above: those are
+	// registered before the driver exists, and the metrics server (if any) is only built once
+	// NewWekaFsDriver runs. Registering after driver.Run(ctx) below would never happen - it blocks for
+	// the process lifetime - but that's fine: prometheus.MustRegister only needs to run before the
+	// first scrape, not before promhttp.Handler() starts serving.
+	if enableMetrics != nil && *enableMetrics {
+		if collectors := driver.MetricsServerCollectors(); len(collectors) > 0 {
+			prometheus.MustRegister(collectors...)
+		}
+	}
 
 	driver.Run(ctx)
 }

--- a/cmd/wekafsplugin/main.go
+++ b/cmd/wekafsplugin/main.go
@@ -51,7 +51,7 @@ var (
 	seedSnapshotPrefix                   = flag.String("seedsnapshotprefix", "csisnp-seed-", "Prefix for empty (seed) snapshot to create on newly provisioned filesystem")
 	allowAutoFsExpansion                 = flag.Bool("allowautofsexpansion", false, "Allow expansion of filesystems used as CSI volumes")
 	allowAutoFsCreation                  = flag.Bool("allowautofscreation", false, "Allow provisioning of CSI volumes as new Weka filesystems")
-	allowSnapshotsOfLegacyVolumes        = flag.Bool("allowsnapshotsoflegacyvolumes", false, "Allow provisioning of CSI volumes or snapshots from legacy volumes")
+	allowSnapshotsOfLegacyVolumes        = flag.Bool("allowsnapshotsofdirectoryvolumes", false, "Allow provisioning of CSI volumes or snapshots from legacy volumes")
 	suppressSnapshotsCapability          = flag.Bool("suppresssnapshotcapability", false, "Do not expose CREATE_DELETE_SNAPSHOT, for testing purposes only")
 	suppressVolumeCloneCapability        = flag.Bool("suppressrvolumeclonecapability", false, "Do not expose CLONE_VOLUME, for testing purposes only")
 	enableMetrics                        = flag.Bool("enablemetrics", false, "Enable Prometheus metrics endpoint")

--- a/cmd/wekafsplugin/main.go
+++ b/cmd/wekafsplugin/main.go
@@ -69,7 +69,7 @@ var (
 	showVersion       = flag.Bool("version", false, "Show version.")
 	dynamicSubPath    = flag.String("dynamic-path", "csi-volumes",
 		"Store dynamically provisioned volumes in subdirectory rather than in root directory of th filesystem")
-	csimodetext                          = flag.String("csimode", "all", "Mode of CSI plugin, either \"controller\", \"node\", \"all\" (default)")
+	csimodetext                          = flag.String("csimode", "all", "Mode of CSI plugin, either \"controller\", \"node\", \"all\" (default), or \"metricsserver\"")
 	selinuxSupport                       = flag.Bool("selinux-support", false, "Enable support for SELinux")
 	newVolumePrefix                      = flag.String("newvolumeprefix", "csivol-", "Prefix for Weka volumes and snapshots that represent a CSI volume")
 	newSnapshotPrefix                    = flag.String("newsnapshotprefix", "csisnp-", "Prefix for Weka snapshots that represent a CSI snapshot")
@@ -112,8 +112,8 @@ var (
 	keepThinProvisioningRatioOnExpand    = flag.Bool("keepthinprovisioningratioonexpand", true, "On filesystem expansion, scale thin-provisioning min-SSD and max-SSD to preserve their ratios to total capacity")
 	advertiseVolumeHealthSupport         = flag.Bool("advertisevolumehealthsupport", true, "Expose GET_VOLUME and VOLUME_CONDITION, allowing the CSI health monitor to report volume condition and capacity")
 
-	// Metrics server settings
-	enableMetricsServer                      = flag.Bool("enablemetricsserver", false, "Enable the metrics server that reports per-PersistentVolume capacity and performance statistics to Prometheus (requires -enablemetrics and controller/all csimode)")
+	// Metrics server settings. These only take effect when csimode is "metricsserver" or "all" -
+	// the metrics server itself is only ever constructed for those modes (see NewWekaFsDriver).
 	wekaMetricsFetchIntervalSeconds          = flag.Int("wekametricsfetchintervalseconds", 60, "Interval in seconds to fetch metrics from Weka cluster")
 	wekaMetricsFetchConcurrentRequests       = flag.Int("wekametricsfetchconcurrentrequests", 1, "Maximum concurrent requests to fetch metrics from Weka cluster")
 	enableMetricsServerLeaderElection        = flag.Bool("enablemetricsserverleaderelection", false, "Enable leader election for metrics server")
@@ -163,7 +163,7 @@ func main() {
 		fmt.Println(baseName, version)
 		return
 	}
-	if csiMode != wekafs.CsiModeAll && csiMode != wekafs.CsiModeController && csiMode != wekafs.CsiModeNode {
+	if csiMode != wekafs.CsiModeAll && csiMode != wekafs.CsiModeController && csiMode != wekafs.CsiModeNode && csiMode != wekafs.CsiModeMetricsServer {
 		log.Panic().Str("requestedCsiMode", string(csiMode)).Msg("Invalid mode specified for CSI driver")
 	}
 	log.Info().Str("csi_mode", string(csiMode)).Bool("selinux_mode", *selinuxSupport).Msg("Started CSI driver")
@@ -290,7 +290,6 @@ func handle(ctx context.Context) {
 		SetOwnershipOnDynamicFilesystems:  *setOwnershipOnDynamicFilesystems,
 		KeepThinProvisioningRatioOnExpand: *keepThinProvisioningRatioOnExpand,
 
-		EnableMetricsServer:               *enableMetricsServer,
 		MetricsFetchIntervalSeconds:       *wekaMetricsFetchIntervalSeconds,
 		MetricsFetchConcurrentRequests:    *wekaMetricsFetchConcurrentRequests,
 		EnableMetricsServerLeaderElection: *enableMetricsServerLeaderElection,
@@ -306,9 +305,9 @@ func handle(ctx context.Context) {
 	config.SetDriver(driver)
 
 	// Register the metrics server's own collectors, but only if metrics export is on in the first
-	// place and a metrics server was actually constructed (enablemetricsserver + a csimode with a
-	// controller-runtime manager - see NewWekaFsDriver) - a disabled metrics server must export
-	// nothing. This has to happen here rather than alongside the other collectors above: those are
+	// place and a metrics server was actually constructed (csimode "metricsserver" or "all" - see
+	// NewWekaFsDriver) - a driver running in another mode must export nothing. This has to happen
+	// here rather than alongside the other collectors above: those are
 	// registered before the driver exists, and the metrics server (if any) is only built once
 	// NewWekaFsDriver runs. Registering after driver.Run(ctx) below would never happen - it blocks for
 	// the process lifetime - but that's fine: prometheus.MustRegister only needs to run before the

--- a/cmd/wekafsplugin/main.go
+++ b/cmd/wekafsplugin/main.go
@@ -111,6 +111,14 @@ var (
 	allowMountOptionOverrides            = flag.Bool("allowmountoptionoverrides", false, "Allow mount option overrides via PVC and pod annotations")
 	keepThinProvisioningRatioOnExpand    = flag.Bool("keepthinprovisioningratioonexpand", true, "On filesystem expansion, scale thin-provisioning min-SSD and max-SSD to preserve their ratios to total capacity")
 	advertiseVolumeHealthSupport         = flag.Bool("advertisevolumehealthsupport", true, "Expose GET_VOLUME and VOLUME_CONDITION, allowing the CSI health monitor to report volume condition and capacity")
+
+	// Metrics server settings
+	wekaMetricsFetchIntervalSeconds          = flag.Int("wekametricsfetchintervalseconds", 60, "Interval in seconds to fetch metrics from Weka cluster")
+	wekaMetricsFetchConcurrentRequests       = flag.Int("wekametricsfetchconcurrentrequests", 1, "Maximum concurrent requests to fetch metrics from Weka cluster")
+	enableMetricsServerLeaderElection        = flag.Bool("enablemetricsserverleaderelection", false, "Enable leader election for metrics server")
+	wekaMetricsQuotaUpdateConcurrentRequests = flag.Int("wekametricsquotaupdateconcurrentrequests", 5, "Maximum concurrent requests to update quotas for metrics server")
+	wekaMetricsQuotaCacheValiditySeconds     = flag.Int("wekametricsquotacachevalidityseconds", 60, "Duration in seconds for which the quota map is considered valid")
+	fetchQuotasInBatchMode                   = flag.Bool("fetchquotasinbatchmode", false, "Use batch mode for metrics server, fetch all filesystem quotas in one go")
 	// Set by the build process
 	version = ""
 )
@@ -280,6 +288,13 @@ func handle(ctx context.Context) {
 		EnforceDirVolTotalCapacity:        *enforceDirVolTotalCapacity,
 		SetOwnershipOnDynamicFilesystems:  *setOwnershipOnDynamicFilesystems,
 		KeepThinProvisioningRatioOnExpand: *keepThinProvisioningRatioOnExpand,
+
+		MetricsFetchIntervalSeconds:       *wekaMetricsFetchIntervalSeconds,
+		MetricsFetchConcurrentRequests:    *wekaMetricsFetchConcurrentRequests,
+		EnableMetricsServerLeaderElection: *enableMetricsServerLeaderElection,
+		QuotaFetchConcurrentRequests:      *wekaMetricsQuotaUpdateConcurrentRequests,
+		QuotaCacheValiditySeconds:         *wekaMetricsQuotaCacheValiditySeconds,
+		UseQuotaMapsForMetrics:            *fetchQuotasInBatchMode,
 	})
 	driver, err := wekafs.NewWekaFsDriver(*driverName, *nodeID, *endpoint, *maxVolumesPerNode, version, *debugPath, csiMode, *selinuxSupport, config)
 	if err != nil {

--- a/cmd/wekafsplugin/main.go
+++ b/cmd/wekafsplugin/main.go
@@ -20,41 +20,16 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"math/rand"
-	"net/http"
 	"os"
-	"os/signal"
 	"path"
-	"strconv"
-	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
-	"go.opentelemetry.io/otel"
-	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 
+	"github.com/wekafs/csi-wekafs/pkg/bootstrap"
 	"github.com/wekafs/csi-wekafs/pkg/wekafs"
 	"github.com/wekafs/csi-wekafs/pkg/wekafs/apiclient"
 )
-
-func init() {
-	rand.Seed(time.Now().UnixNano())
-	zerolog.TimeFieldFormat = zerolog.TimeFormatUnixMs
-	zerolog.CallerMarshalFunc = func(pc uintptr, file string, line int) string {
-		short := file
-		for i := len(file) - 1; i > 0; i-- {
-			if file[i] == '/' {
-				short = file[i+1:]
-				break
-			}
-		}
-		file = short
-		return file + ":" + strconv.Itoa(line)
-	}
-
-}
 
 var (
 	mutuallyExclusiveMountOptionsStrings wekafs.MutuallyExclusiveMountOptsStrings
@@ -124,38 +99,12 @@ var (
 	version = ""
 )
 
-func mapVerbosity(verbosity int) zerolog.Level {
-	verbMap := make(map[int]zerolog.Level)
-
-	verbMap[0] = zerolog.Disabled
-	verbMap[1] = zerolog.PanicLevel
-	verbMap[2] = zerolog.FatalLevel
-	verbMap[3] = zerolog.ErrorLevel
-	verbMap[4] = zerolog.InfoLevel
-	verbMap[5] = zerolog.DebugLevel
-	verbMap[6] = zerolog.TraceLevel
-
-	v := verbosity
-	if v >= len(verbMap) {
-		v = len(verbMap) - 1
-	}
-	return verbMap[v]
-}
-
 func main() {
 	// set mountOptions
 	flag.Var(&mutuallyExclusiveMountOptionsStrings, "mutuallyexclusivemountoptions", "Set list of mount options that cannot be set together")
 
 	flag.Parse()
-	if !*usejsonlogging {
-		log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr, TimeFormat: time.RFC3339Nano}).With().Caller().Logger()
-	}
-	zerolog.SetGlobalLevel(mapVerbosity(*verbosity))
-	// log.Ctx returns a *disabled* logger for a context that carries none, so anything written from
-	// a startup path or a background goroutine - neither of which passes through a gRPC handler that
-	// attaches one - is discarded without a trace. Fall back to the global logger instead, so a
-	// missing context logger costs the request fields rather than the whole line.
-	zerolog.DefaultContextLogger = &log.Logger
+	bootstrap.SetupLogging(*usejsonlogging, *verbosity)
 
 	csiMode = wekafs.GetCsiPluginMode(csimodetext)
 	if *showVersion {
@@ -180,61 +129,12 @@ func main() {
 		if csiMode == wekafs.CsiModeNode || csiMode == wekafs.CsiModeAll {
 			prometheus.MustRegister(wekafs.NodeCollectors()...)
 		}
-		go func() {
-			http.Handle("/metrics", promhttp.Handler())
-			if err := http.ListenAndServe(fmt.Sprintf(":%s", *metricsPort), nil); err != nil {
-				log.Error().Str("metrics_port", *metricsPort).Err(err).Msg("Failed to start metrics service")
-			}
-			log.Debug().Str("metrics_port", *metricsPort).Msg("Started metrics service")
-		}()
+		bootstrap.ServeMetrics(*metricsPort)
 	}
 
 	ctx := context.Background()
-	var tp *sdktrace.TracerProvider
-	var err error
-	var url string
-	if *tracingUrl != "" {
-		url = *tracingUrl
-
-	} else {
-		url = ""
-	}
-	tp, err = wekafs.TracerProvider(version, url, csiMode)
-	if err != nil {
-		log.Error().Err(err).Msg("Failed to set up OpenTelemetry tracerProvider")
-	} else {
-		otel.SetTracerProvider(tp)
-		log.Info().Str("tracing_url", url).Msg("OpenTelemetry tracing initialized")
-		ctx, cancel := context.WithCancel(ctx)
-		c := make(chan os.Signal, 1)
-		signal.Notify(c, os.Interrupt)
-		defer func() {
-			signal.Stop(c)
-			cancel()
-		}()
-		go func() {
-			select {
-			case <-c:
-				cancel()
-			case <-ctx.Done():
-			}
-		}()
-
-		defer func() {
-			if err := tp.ForceFlush(ctx); err != nil {
-				log.Error().Err(err).Msg("Failed to flush traces")
-			} else {
-				log.Info().Msg("Flushed traces successfully")
-			}
-
-			if err := tp.Shutdown(ctx); err != nil {
-				log.Error().Err(err).Msg("Failed to shutdown tracing engine")
-			} else {
-				log.Info().Msg("Tracing engine shut down successfully")
-			}
-
-		}()
-	}
+	shutdownTracing := bootstrap.SetupTracing(ctx, version, *tracingUrl, csiMode)
+	defer shutdownTracing()
 
 	handle(ctx)
 	os.Exit(0)

--- a/dagger-scalar
+++ b/dagger-scalar
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# supressing ugly logs/unsetting OTEL
+unset OTEL_EXPORTER_OTLP_ENDPOINT ANTHROPIC_API_KEY
+export DAGGER_NO_NAG=1
+
+export _EXPERIMENTAL_DAGGER_RUNNER_HOST='kube-pod://dagger-dagger-helm-engine-p42gm?namespace=infra'
+
+exec dagger "$@"
+

--- a/dagger.json
+++ b/dagger.json
@@ -1,0 +1,8 @@
+{
+  "name": "csi-wekafs",
+  "engineVersion": "v0.18.6",
+  "sdk": {
+    "source": "python"
+  },
+  "source": ".dagger"
+}

--- a/pkg/bootstrap/bootstrap.go
+++ b/pkg/bootstrap/bootstrap.go
@@ -1,0 +1,141 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package bootstrap holds the process-level startup shared by the binaries in cmd/ - logging, the
+// Prometheus scrape endpoint and OpenTelemetry tracing. None of it is specific to a CSI mode, so
+// a second entry point (the standalone metrics server) reuses it rather than restating it.
+package bootstrap
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"net/http"
+	"os"
+	"os/signal"
+	"strconv"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"go.opentelemetry.io/otel"
+
+	"github.com/wekafs/csi-wekafs/pkg/wekafs"
+)
+
+func init() {
+	rand.Seed(time.Now().UnixNano())
+	zerolog.TimeFieldFormat = zerolog.TimeFormatUnixMs
+	zerolog.CallerMarshalFunc = func(pc uintptr, file string, line int) string {
+		short := file
+		for i := len(file) - 1; i > 0; i-- {
+			if file[i] == '/' {
+				short = file[i+1:]
+				break
+			}
+		}
+		file = short
+		return file + ":" + strconv.Itoa(line)
+	}
+}
+
+func mapVerbosity(verbosity int) zerolog.Level {
+	verbMap := make(map[int]zerolog.Level)
+
+	verbMap[0] = zerolog.Disabled
+	verbMap[1] = zerolog.PanicLevel
+	verbMap[2] = zerolog.FatalLevel
+	verbMap[3] = zerolog.ErrorLevel
+	verbMap[4] = zerolog.InfoLevel
+	verbMap[5] = zerolog.DebugLevel
+	verbMap[6] = zerolog.TraceLevel
+
+	v := verbosity
+	if v >= len(verbMap) {
+		v = len(verbMap) - 1
+	}
+	return verbMap[v]
+}
+
+// SetupLogging configures the global zerolog logger from the -usejsonlogging and -v flags.
+func SetupLogging(useJsonLogging bool, verbosity int) {
+	if !useJsonLogging {
+		log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr, TimeFormat: time.RFC3339Nano}).With().Caller().Logger()
+	}
+	zerolog.SetGlobalLevel(mapVerbosity(verbosity))
+	// log.Ctx returns a *disabled* logger for a context that carries none, so anything written from
+	// a startup path or a background goroutine - neither of which passes through a gRPC handler that
+	// attaches one - is discarded without a trace. Fall back to the global logger instead, so a
+	// missing context logger costs the request fields rather than the whole line.
+	zerolog.DefaultContextLogger = &log.Logger
+}
+
+// ServeMetrics starts the Prometheus scrape endpoint in the background. Collectors are registered by
+// the caller, which is the only place that knows which role this process serves.
+func ServeMetrics(metricsPort string) {
+	go func() {
+		http.Handle("/metrics", promhttp.Handler())
+		if err := http.ListenAndServe(fmt.Sprintf(":%s", metricsPort), nil); err != nil {
+			log.Error().Str("metrics_port", metricsPort).Err(err).Msg("Failed to start metrics service")
+		}
+		log.Debug().Str("metrics_port", metricsPort).Msg("Started metrics service")
+	}()
+}
+
+// SetupTracing installs the OpenTelemetry tracer provider and returns a function that flushes and
+// shuts it down. Tracing is optional, so a provider that fails to build is logged and skipped; the
+// returned function is always safe to call, letting callers defer it unconditionally.
+func SetupTracing(ctx context.Context, version, tracingUrl string, csiMode wekafs.CsiPluginMode) func() {
+	tp, err := wekafs.TracerProvider(version, tracingUrl, csiMode)
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to set up OpenTelemetry tracerProvider")
+		return func() {}
+	}
+
+	otel.SetTracerProvider(tp)
+	log.Info().Str("tracing_url", tracingUrl).Msg("OpenTelemetry tracing initialized")
+
+	// Interrupting the process cancels the context the flush below runs under, so a Ctrl-C during
+	// shutdown gives up on the traces rather than hanging on an exporter that will never answer.
+	ctx, cancel := context.WithCancel(ctx)
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, os.Interrupt)
+	go func() {
+		select {
+		case <-c:
+			cancel()
+		case <-ctx.Done():
+		}
+	}()
+
+	return func() {
+		if err := tp.ForceFlush(ctx); err != nil {
+			log.Error().Err(err).Msg("Failed to flush traces")
+		} else {
+			log.Info().Msg("Flushed traces successfully")
+		}
+
+		if err := tp.Shutdown(ctx); err != nil {
+			log.Error().Err(err).Msg("Failed to shutdown tracing engine")
+		} else {
+			log.Info().Msg("Tracing engine shut down successfully")
+		}
+
+		signal.Stop(c)
+		cancel()
+	}
+}

--- a/pkg/wekafs/constants.go
+++ b/pkg/wekafs/constants.go
@@ -38,9 +38,10 @@ const (
 
 	LegacySecretPath = "/legacy-volume-access"
 
-	CsiModeNode       CsiPluginMode = "node"
-	CsiModeController CsiPluginMode = "controller"
-	CsiModeAll        CsiPluginMode = "all"
+	CsiModeNode          CsiPluginMode = "node"
+	CsiModeController    CsiPluginMode = "controller"
+	CsiModeAll           CsiPluginMode = "all"
+	CsiModeMetricsServer CsiPluginMode = "metricsserver"
 )
 
 var DefaultVolumePermissions fs.FileMode = 0750

--- a/pkg/wekafs/constants.go
+++ b/pkg/wekafs/constants.go
@@ -44,6 +44,15 @@ const (
 	CsiModeMetricsServer CsiPluginMode = "metricsserver"
 )
 
+// servesCsiGrpc reports whether this mode runs the CSI gRPC surface - the Identity/Controller/Node
+// services, the socket they listen on, and the mounter behind them. Everything that follows from
+// having no gRPC surface (no endpoint to validate, no socket to health-check, no leader-gated gRPC
+// runnable to register) tests this one property, so it is named here rather than restated as a
+// comparison against CsiModeMetricsServer at each site.
+func (mode CsiPluginMode) servesCsiGrpc() bool {
+	return mode != CsiModeMetricsServer
+}
+
 var DefaultVolumePermissions fs.FileMode = 0750
 
 var KnownVolTypes = [...]VolumeType{VolumeTypeDirV1, VolumeTypeUnified}

--- a/pkg/wekafs/driver.go
+++ b/pkg/wekafs/driver.go
@@ -80,7 +80,9 @@ func NewWekaFsDriver(
 		return nil, errors.New("no node id provided")
 	}
 
-	if endpoint == "" {
+	// A mode with no CSI gRPC surface has no endpoint to listen on, and must not be made to invent a
+	// placeholder one just to satisfy this check.
+	if endpoint == "" && csiMode.servesCsiGrpc() {
 		return nil, errors.New("no driver endpoint provided")
 	}
 	if version != "" {
@@ -141,10 +143,10 @@ func (driver *WekaFsDriver) Run(ctx context.Context) {
 		}
 	}
 
-	// The metrics server has no CSI gRPC surface to serve - no volumes to mount, no
-	// Identity/Controller/Node services - so skip building a real mounter and the IdentityServer.
+	// Without a CSI gRPC surface there are no volumes to mount and no Identity service to answer, so
+	// skip building a real mounter and the IdentityServer.
 	var mounter AnyMounter
-	if driver.csiMode != CsiModeMetricsServer {
+	if driver.csiMode.servesCsiGrpc() {
 		mounter = driver.NewMounter(ctx)
 
 		// Create servers
@@ -320,7 +322,9 @@ func (d *WekaFsDriver) initManager(ctx context.Context, leaderElection bool) err
 		}
 	}
 
-	if leaderElection {
+	// This probe reports on the gRPC server, so it belongs only to the modes that run one. A metrics
+	// server has no endpoint to parse or dial; AddToManager registers its own healthz instead.
+	if leaderElection && d.csiMode.servesCsiGrpc() {
 		// Parse socket path from endpoint (format: "unix:///path/to/socket")
 		socketProto, socketPath, err := parseEndpoint(d.endpoint)
 		if err != nil {

--- a/pkg/wekafs/driver.go
+++ b/pkg/wekafs/driver.go
@@ -59,6 +59,7 @@ type WekaFsDriver struct {
 	ids            *identityServer
 	ns             *NodeServer
 	cs             *ControllerServer
+	ms             *MetricsServer
 	api            *ApiStore
 	debugPath      string
 	csiMode        CsiPluginMode
@@ -66,7 +67,6 @@ type WekaFsDriver struct {
 	config         *DriverConfig
 	manager        ctrl.Manager // controller-runtime manager for K8s client access
 	isLeader       atomic.Bool  // tracks current leadership state for health checks
-	metricsServer  *MetricsServer
 }
 
 func NewWekaFsDriver(
@@ -112,13 +112,21 @@ func NewWekaFsDriver(
 	// service is running, and never for a node-only pod, which would otherwise list the same
 	// cluster-wide PVs from every node. Constructing it here rather than lazily in Run() lets main.go
 	// register its Prometheus collectors right after the driver is built, before Run() blocks for the
-	// lifetime of the process. A construction failure must not stop the driver from starting: metrics
-	// are a bonus, not the CSI driver's core job.
+	// lifetime of the process.
+	//
+	// How a failure is handled depends on the mode. A CsiModeMetricsServer pod exists only to export
+	// metrics, so one that came up without a metrics server would sit there looking healthy while
+	// collecting nothing - fail instead, and let the Deployment surface it. Under CsiModeAll the CSI
+	// services are the job and metrics are a bonus, so carry on without them.
 	if csiMode == CsiModeMetricsServer || csiMode == CsiModeAll {
-		if ms, err := NewMetricsServer(driver); err != nil {
+		ms, err := NewMetricsServer(driver)
+		if err != nil {
+			if csiMode == CsiModeMetricsServer {
+				return nil, fmt.Errorf("failed to initialize metrics server: %w", err)
+			}
 			log.Warn().Err(err).Msg("Failed to initialize metrics server, continuing without it")
 		} else {
-			driver.metricsServer = ms
+			driver.ms = ms
 		}
 	}
 
@@ -189,9 +197,12 @@ func (driver *WekaFsDriver) Run(ctx context.Context) {
 	// Metrics-server-only mode has no ControllerServer to bring up a manager for, but it still needs
 	// one for Kubernetes access and (optionally) leader election - the same mechanism controller mode
 	// uses. It never registers a gRPC surface though; see runWithLeaderElection/runWithoutLeaderElection.
+	// Unlike controller mode, there is no useful degraded mode to fall back to here: without a manager
+	// the metrics server has no Kubernetes access, so it would discover no PersistentVolumes and export
+	// nothing at all. Fail rather than idle.
 	if driver.csiMode == CsiModeMetricsServer {
 		if err := driver.initManager(ctx, true); err != nil {
-			log.Warn().Err(err).Msg("Failed to initialize Kubernetes manager, running metrics server without leader election")
+			log.Fatal().Err(err).Msg("Failed to initialize Kubernetes manager, metrics server cannot run")
 		}
 	}
 

--- a/pkg/wekafs/driver.go
+++ b/pkg/wekafs/driver.go
@@ -66,6 +66,7 @@ type WekaFsDriver struct {
 	config         *DriverConfig
 	manager        ctrl.Manager // controller-runtime manager for K8s client access
 	isLeader       atomic.Bool  // tracks current leadership state for health checks
+	metricsServer  *MetricsServer
 }
 
 func NewWekaFsDriver(
@@ -92,7 +93,7 @@ func NewWekaFsDriver(
 	log.Info().Msg(fmt.Sprintf("csiMode: %s", csiMode))
 	config.Log()
 
-	return &WekaFsDriver{
+	driver := &WekaFsDriver{
 		name:              driverName,
 		nodeID:            nodeID,
 		version:           vendorVersion,
@@ -103,7 +104,23 @@ func NewWekaFsDriver(
 		csiMode:           csiMode, // either "controller", "node", "all"
 		selinuxSupport:    selinuxSupport,
 		config:            config,
-	}, nil
+	}
+
+	// The metrics server lists PersistentVolumes cluster-wide through the controller-runtime manager,
+	// so it is only ever constructed for the modes that have one - never for a node-only pod, which
+	// would otherwise list the same cluster-wide PVs from every node. Constructing it here rather than
+	// lazily in Run() lets main.go register its Prometheus collectors right after the driver is built,
+	// before Run() blocks for the lifetime of the process. A construction failure must not stop the
+	// driver from starting: metrics are a bonus, not the CSI driver's core job.
+	if config.enableMetricsServer && (csiMode == CsiModeController || csiMode == CsiModeAll) {
+		if ms, err := NewMetricsServer(driver); err != nil {
+			log.Warn().Err(err).Msg("Failed to initialize metrics server, continuing without it")
+		} else {
+			driver.metricsServer = ms
+		}
+	}
+
+	return driver, nil
 }
 
 func (driver *WekaFsDriver) Run(ctx context.Context) {

--- a/pkg/wekafs/driver.go
+++ b/pkg/wekafs/driver.go
@@ -107,12 +107,14 @@ func NewWekaFsDriver(
 	}
 
 	// The metrics server lists PersistentVolumes cluster-wide through the controller-runtime manager,
-	// so it is only ever constructed for the modes that have one - never for a node-only pod, which
-	// would otherwise list the same cluster-wide PVs from every node. Constructing it here rather than
-	// lazily in Run() lets main.go register its Prometheus collectors right after the driver is built,
-	// before Run() blocks for the lifetime of the process. A construction failure must not stop the
-	// driver from starting: metrics are a bonus, not the CSI driver's core job.
-	if config.enableMetricsServer && (csiMode == CsiModeController || csiMode == CsiModeAll) {
+	// so it is only ever constructed for the modes that run one - CsiModeMetricsServer (its own
+	// Deployment) or CsiModeAll. It must never be constructed merely because the controller or node
+	// service is running, and never for a node-only pod, which would otherwise list the same
+	// cluster-wide PVs from every node. Constructing it here rather than lazily in Run() lets main.go
+	// register its Prometheus collectors right after the driver is built, before Run() blocks for the
+	// lifetime of the process. A construction failure must not stop the driver from starting: metrics
+	// are a bonus, not the CSI driver's core job.
+	if csiMode == CsiModeMetricsServer || csiMode == CsiModeAll {
 		if ms, err := NewMetricsServer(driver); err != nil {
 			log.Warn().Err(err).Msg("Failed to initialize metrics server, continuing without it")
 		} else {
@@ -131,11 +133,16 @@ func (driver *WekaFsDriver) Run(ctx context.Context) {
 		}
 	}
 
-	mounter := driver.NewMounter(ctx)
+	// The metrics server has no CSI gRPC surface to serve - no volumes to mount, no
+	// Identity/Controller/Node services - so skip building a real mounter and the IdentityServer.
+	var mounter AnyMounter
+	if driver.csiMode != CsiModeMetricsServer {
+		mounter = driver.NewMounter(ctx)
 
-	// Create servers
-	log.Info().Msg("Loading IdentityServer")
-	driver.ids = NewIdentityServer(driver.name, driver.version, driver.config)
+		// Create servers
+		log.Info().Msg("Loading IdentityServer")
+		driver.ids = NewIdentityServer(driver.name, driver.version, driver.config)
+	}
 
 	if driver.csiMode == CsiModeController || driver.csiMode == CsiModeAll {
 		log.Info().Msg("Loading ControllerServer")
@@ -179,15 +186,24 @@ func (driver *WekaFsDriver) Run(ctx context.Context) {
 		driver.ns = &NodeServer{}
 	}
 
+	// Metrics-server-only mode has no ControllerServer to bring up a manager for, but it still needs
+	// one for Kubernetes access and (optionally) leader election - the same mechanism controller mode
+	// uses. It never registers a gRPC surface though; see runWithLeaderElection/runWithoutLeaderElection.
+	if driver.csiMode == CsiModeMetricsServer {
+		if err := driver.initManager(ctx, true); err != nil {
+			log.Warn().Err(err).Msg("Failed to initialize Kubernetes manager, running metrics server without leader election")
+		}
+	}
+
 	s := NewNonBlockingGRPCServer(driver.csiMode)
 
 	termContext, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
 	defer stop()
 
-	// Controller mode with manager: use leader election
+	// Controller/metrics-server mode with manager: use leader election
 	// Controller mode without manager (not in K8s): run without leader election
 	// Node-only mode: run without leader election
-	if (driver.csiMode == CsiModeController || driver.csiMode == CsiModeAll) && driver.manager != nil {
+	if (driver.csiMode == CsiModeController || driver.csiMode == CsiModeAll || driver.csiMode == CsiModeMetricsServer) && driver.manager != nil {
 		driver.runWithLeaderElection(ctx, termContext, s)
 	} else {
 		driver.runWithoutLeaderElection(ctx, termContext, s)

--- a/pkg/wekafs/driverconfig.go
+++ b/pkg/wekafs/driverconfig.go
@@ -54,10 +54,9 @@ type DriverConfig struct {
 	allowMountOptionOverrides         bool
 	keepThinProvisioningRatioOnExpand bool
 
-	// Metrics server settings. enableMetricsServer is read by the main driver process (it gates
-	// whether a MetricsServer is constructed at all in NewWekaFsDriver); the rest only matter to the
-	// metrics server lifecycle (see metricsserver.go) once it is running.
-	enableMetricsServer               bool          // master on/off switch for the metrics server; off by default
+	// Metrics server settings. Whether a MetricsServer is constructed at all in NewWekaFsDriver is
+	// gated on csiMode (CsiModeMetricsServer or CsiModeAll), not on any of these; the settings below
+	// only matter to the metrics server lifecycle (see metricsserver.go) once it is running.
 	metricsFetchInterval              time.Duration // how often the PV streamer refreshes its list and re-polls Weka for stats
 	metricsFetchConcurrentRequests    int           // concurrency cap for both PV processing and single-metric fetches
 	enableMetricsServerLeaderElection bool          // gate the metrics server's readiness on holding leadership
@@ -97,7 +96,6 @@ func (dc *DriverConfig) Log() {
 		Bool("set_ownership_on_dynamic_filesystems", dc.setOwnershipOnDynamicFilesystems).
 		Bool("allow_mount_option_overrides", dc.allowMountOptionOverrides).
 		Bool("keep_thin_provisioning_ratio_on_expand", dc.keepThinProvisioningRatioOnExpand).
-		Bool("enable_metrics_server", dc.enableMetricsServer).
 		Dur("metrics_fetch_interval", dc.metricsFetchInterval).
 		Int("metrics_fetch_concurrent_requests", dc.metricsFetchConcurrentRequests).
 		Bool("enable_metrics_server_leader_election", dc.enableMetricsServerLeaderElection).
@@ -164,10 +162,6 @@ type DriverConfigOptions struct {
 	EnforceDirVolTotalCapacity        bool
 	SetOwnershipOnDynamicFilesystems  bool
 	KeepThinProvisioningRatioOnExpand bool
-
-	// EnableMetricsServer is the master on/off switch for the metrics server; it defaults to false
-	// (off), unlike the settings below which only matter once it is on.
-	EnableMetricsServer bool
 
 	// MetricsFetchIntervalSeconds, MetricsFetchConcurrentRequests, QuotaFetchConcurrentRequests and
 	// QuotaCacheValiditySeconds default to sensible non-zero values in NewDriverConfig when left at
@@ -260,7 +254,6 @@ func NewDriverConfig(opts DriverConfigOptions) *DriverConfig {
 		allowMountOptionOverrides:         opts.AllowMountOptionOverrides,
 		keepThinProvisioningRatioOnExpand: opts.KeepThinProvisioningRatioOnExpand,
 
-		enableMetricsServer:               opts.EnableMetricsServer,
 		metricsFetchInterval:              time.Duration(metricsFetchIntervalSeconds) * time.Second,
 		metricsFetchConcurrentRequests:    metricsFetchConcurrentRequests,
 		enableMetricsServerLeaderElection: opts.EnableMetricsServerLeaderElection,

--- a/pkg/wekafs/driverconfig.go
+++ b/pkg/wekafs/driverconfig.go
@@ -53,6 +53,15 @@ type DriverConfig struct {
 	setOwnershipOnDynamicFilesystems  bool
 	allowMountOptionOverrides         bool
 	keepThinProvisioningRatioOnExpand bool
+
+	// Metrics server settings. These only matter to the metrics server lifecycle (see
+	// metricsserver.go); the main driver process reads none of them.
+	metricsFetchInterval              time.Duration // how often the PV streamer refreshes its list and re-polls Weka for stats
+	metricsFetchConcurrentRequests    int           // concurrency cap for both PV processing and single-metric fetches
+	enableMetricsServerLeaderElection bool          // gate the metrics server's readiness on holding leadership
+	quotaFetchConcurrentRequests      int           // concurrency cap for refreshing per-filesystem quota maps
+	quotaCacheValidityDuration        time.Duration // how long a fetched quota map (or single quota) is considered fresh
+	useQuotaMapsForMetrics            bool          // fetch quotas in filesystem-wide batches instead of one request per volume
 }
 
 func (dc *DriverConfig) Log() {
@@ -86,6 +95,12 @@ func (dc *DriverConfig) Log() {
 		Bool("set_ownership_on_dynamic_filesystems", dc.setOwnershipOnDynamicFilesystems).
 		Bool("allow_mount_option_overrides", dc.allowMountOptionOverrides).
 		Bool("keep_thin_provisioning_ratio_on_expand", dc.keepThinProvisioningRatioOnExpand).
+		Dur("metrics_fetch_interval", dc.metricsFetchInterval).
+		Int("metrics_fetch_concurrent_requests", dc.metricsFetchConcurrentRequests).
+		Bool("enable_metrics_server_leader_election", dc.enableMetricsServerLeaderElection).
+		Int("quota_fetch_concurrent_requests", dc.quotaFetchConcurrentRequests).
+		Dur("quota_cache_validity_duration", dc.quotaCacheValidityDuration).
+		Bool("use_quota_maps_for_metrics", dc.useQuotaMapsForMetrics).
 		Msg("Starting driver with the following configuration")
 
 }
@@ -146,7 +161,25 @@ type DriverConfigOptions struct {
 	EnforceDirVolTotalCapacity        bool
 	SetOwnershipOnDynamicFilesystems  bool
 	KeepThinProvisioningRatioOnExpand bool
+
+	// MetricsFetchIntervalSeconds, MetricsFetchConcurrentRequests, QuotaFetchConcurrentRequests and
+	// QuotaCacheValiditySeconds default to sensible non-zero values in NewDriverConfig when left at
+	// zero, since zero would otherwise mean "never" or "unbounded".
+	MetricsFetchIntervalSeconds       int
+	MetricsFetchConcurrentRequests    int
+	EnableMetricsServerLeaderElection bool
+	QuotaFetchConcurrentRequests      int
+	QuotaCacheValiditySeconds         int
+	UseQuotaMapsForMetrics            bool
 }
+
+// Defaults applied by NewDriverConfig when the corresponding metrics server option is left at zero.
+const (
+	defaultMetricsFetchIntervalSeconds    = 60
+	defaultMetricsFetchConcurrentRequests = 1
+	defaultQuotaFetchConcurrentRequests   = 5
+	defaultQuotaCacheValiditySeconds      = 60
+)
 
 func NewDriverConfig(opts DriverConfigOptions) *DriverConfig {
 	var MutuallyExclusiveMountOptions []mutuallyExclusiveMountOptionSet
@@ -165,6 +198,23 @@ func NewDriverConfig(opts DriverConfigOptions) *DriverConfig {
 		"DeleteSnapshot":      opts.MaxDeleteSnapshotReqs,
 		"NodePublishVolume":   opts.MaxNodePublishVolumeReqs,
 		"NodeUnpublishVolume": opts.MaxNodeUnpublishVolumeReqs,
+	}
+
+	metricsFetchIntervalSeconds := opts.MetricsFetchIntervalSeconds
+	if metricsFetchIntervalSeconds == 0 {
+		metricsFetchIntervalSeconds = defaultMetricsFetchIntervalSeconds
+	}
+	metricsFetchConcurrentRequests := opts.MetricsFetchConcurrentRequests
+	if metricsFetchConcurrentRequests == 0 {
+		metricsFetchConcurrentRequests = defaultMetricsFetchConcurrentRequests
+	}
+	quotaFetchConcurrentRequests := opts.QuotaFetchConcurrentRequests
+	if quotaFetchConcurrentRequests == 0 {
+		quotaFetchConcurrentRequests = defaultQuotaFetchConcurrentRequests
+	}
+	quotaCacheValiditySeconds := opts.QuotaCacheValiditySeconds
+	if quotaCacheValiditySeconds == 0 {
+		quotaCacheValiditySeconds = defaultQuotaCacheValiditySeconds
 	}
 
 	return &DriverConfig{
@@ -202,6 +252,13 @@ func NewDriverConfig(opts DriverConfigOptions) *DriverConfig {
 		setOwnershipOnDynamicFilesystems:  opts.SetOwnershipOnDynamicFilesystems,
 		allowMountOptionOverrides:         opts.AllowMountOptionOverrides,
 		keepThinProvisioningRatioOnExpand: opts.KeepThinProvisioningRatioOnExpand,
+
+		metricsFetchInterval:              time.Duration(metricsFetchIntervalSeconds) * time.Second,
+		metricsFetchConcurrentRequests:    metricsFetchConcurrentRequests,
+		enableMetricsServerLeaderElection: opts.EnableMetricsServerLeaderElection,
+		quotaFetchConcurrentRequests:      quotaFetchConcurrentRequests,
+		quotaCacheValidityDuration:        time.Duration(quotaCacheValiditySeconds) * time.Second,
+		useQuotaMapsForMetrics:            opts.UseQuotaMapsForMetrics,
 	}
 }
 

--- a/pkg/wekafs/driverconfig.go
+++ b/pkg/wekafs/driverconfig.go
@@ -54,8 +54,10 @@ type DriverConfig struct {
 	allowMountOptionOverrides         bool
 	keepThinProvisioningRatioOnExpand bool
 
-	// Metrics server settings. These only matter to the metrics server lifecycle (see
-	// metricsserver.go); the main driver process reads none of them.
+	// Metrics server settings. enableMetricsServer is read by the main driver process (it gates
+	// whether a MetricsServer is constructed at all in NewWekaFsDriver); the rest only matter to the
+	// metrics server lifecycle (see metricsserver.go) once it is running.
+	enableMetricsServer               bool          // master on/off switch for the metrics server; off by default
 	metricsFetchInterval              time.Duration // how often the PV streamer refreshes its list and re-polls Weka for stats
 	metricsFetchConcurrentRequests    int           // concurrency cap for both PV processing and single-metric fetches
 	enableMetricsServerLeaderElection bool          // gate the metrics server's readiness on holding leadership
@@ -95,6 +97,7 @@ func (dc *DriverConfig) Log() {
 		Bool("set_ownership_on_dynamic_filesystems", dc.setOwnershipOnDynamicFilesystems).
 		Bool("allow_mount_option_overrides", dc.allowMountOptionOverrides).
 		Bool("keep_thin_provisioning_ratio_on_expand", dc.keepThinProvisioningRatioOnExpand).
+		Bool("enable_metrics_server", dc.enableMetricsServer).
 		Dur("metrics_fetch_interval", dc.metricsFetchInterval).
 		Int("metrics_fetch_concurrent_requests", dc.metricsFetchConcurrentRequests).
 		Bool("enable_metrics_server_leader_election", dc.enableMetricsServerLeaderElection).
@@ -161,6 +164,10 @@ type DriverConfigOptions struct {
 	EnforceDirVolTotalCapacity        bool
 	SetOwnershipOnDynamicFilesystems  bool
 	KeepThinProvisioningRatioOnExpand bool
+
+	// EnableMetricsServer is the master on/off switch for the metrics server; it defaults to false
+	// (off), unlike the settings below which only matter once it is on.
+	EnableMetricsServer bool
 
 	// MetricsFetchIntervalSeconds, MetricsFetchConcurrentRequests, QuotaFetchConcurrentRequests and
 	// QuotaCacheValiditySeconds default to sensible non-zero values in NewDriverConfig when left at
@@ -253,6 +260,7 @@ func NewDriverConfig(opts DriverConfigOptions) *DriverConfig {
 		allowMountOptionOverrides:         opts.AllowMountOptionOverrides,
 		keepThinProvisioningRatioOnExpand: opts.KeepThinProvisioningRatioOnExpand,
 
+		enableMetricsServer:               opts.EnableMetricsServer,
 		metricsFetchInterval:              time.Duration(metricsFetchIntervalSeconds) * time.Second,
 		metricsFetchConcurrentRequests:    metricsFetchConcurrentRequests,
 		enableMetricsServerLeaderElection: opts.EnableMetricsServerLeaderElection,

--- a/pkg/wekafs/leaderelection.go
+++ b/pkg/wekafs/leaderelection.go
@@ -44,11 +44,16 @@ func (driver *WekaFsDriver) runWithLeaderElection(ctx context.Context, termConte
 	}
 
 	// Register the metrics server's health checks and leadership-gated Runnable, same as the health
-	// reconciler above. Nil-guarded since it is only constructed when explicitly enabled and the
-	// driver is running in a mode with Kubernetes access (see NewWekaFsDriver). Must happen before
+	// reconciler above. Nil-guarded since it is only constructed for the modes that run one - under
+	// CsiModeAll it may legitimately be absent (see NewWekaFsDriver). Must happen before
 	// driver.manager.Start below - controller-runtime rejects Add calls once the manager is started.
-	if driver.metricsServer != nil {
-		if err := driver.metricsServer.AddToManager(); err != nil {
+	// A failure is fatal in a dedicated metrics-server pod, whose only job this is, and tolerated under
+	// CsiModeAll, where the CSI services carry on without metrics (same split as in NewWekaFsDriver).
+	if driver.ms != nil {
+		if err := driver.ms.AddToManager(); err != nil {
+			if driver.csiMode == CsiModeMetricsServer {
+				log.Fatal().Err(err).Msg("Failed to register metrics server, nothing left for this pod to run")
+			}
 			log.Error().Err(err).Msg("Failed to register metrics server, metrics will not be available")
 		}
 	}
@@ -148,13 +153,8 @@ func (driver *WekaFsDriver) runWithoutLeaderElection(ctx context.Context, termCo
 		os.Exit(1)
 	}()
 
-	// The metrics server has no CSI gRPC surface to serve. Without a manager it has no Kubernetes
-	// access either, so there is nothing useful left to do here beyond staying alive until terminated.
-	if driver.csiMode == CsiModeMetricsServer {
-		<-runCtx.Done()
-		return
-	}
-
+	// CsiModeMetricsServer never reaches here: Run() treats a failed manager init as fatal in that mode,
+	// so the manager is always present and the driver takes the leader-election path instead.
 	s.Start(driver.endpoint, driver.ids, driver.cs, driver.ns)
 	s.Wait()
 }

--- a/pkg/wekafs/leaderelection.go
+++ b/pkg/wekafs/leaderelection.go
@@ -53,41 +53,46 @@ func (driver *WekaFsDriver) runWithLeaderElection(ctx context.Context, termConte
 		}
 	}
 
-	// Add runnable that starts gRPC server when we become leader
-	err := driver.manager.Add(manager.RunnableFunc(func(ctx context.Context) error {
-		// This only runs when we are the leader
-		log.Info().Msg("Became leader - starting gRPC server")
+	// The metrics server has no CSI gRPC surface - no Identity/Controller/Node services - so a
+	// metrics-server-only pod never registers the leader-gated gRPC runnable below; its work is
+	// driven entirely by the metrics server Runnable registered above.
+	if driver.csiMode != CsiModeMetricsServer {
+		// Add runnable that starts gRPC server when we become leader
+		err := driver.manager.Add(manager.RunnableFunc(func(ctx context.Context) error {
+			// This only runs when we are the leader
+			log.Info().Msg("Became leader - starting gRPC server")
 
-		s.Start(driver.endpoint, driver.ids, driver.cs, driver.ns)
+			s.Start(driver.endpoint, driver.ids, driver.cs, driver.ns)
 
-		// Mark as leader for health checks
-		driver.isLeader.Store(true)
+			// Mark as leader for health checks
+			driver.isLeader.Store(true)
 
-		// Signal to sidecars that we are the leader
-		if err := createLeaderReadyFile(); err != nil {
-			log.Error().Err(err).Msg("Failed to create leader ready file")
+			// Signal to sidecars that we are the leader
+			if err := createLeaderReadyFile(); err != nil {
+				log.Error().Err(err).Msg("Failed to create leader ready file")
+			}
+
+			// Wait for context cancellation (leadership lost or shutdown)
+			<-ctx.Done()
+
+			log.Info().Msg("Leadership lost or shutdown - stopping gRPC server")
+
+			// Mark as not leader for health checks
+			driver.isLeader.Store(false)
+
+			// Remove leader ready file before stopping gRPC
+			if err := removeLeaderReadyFile(); err != nil {
+				log.Error().Err(err).Msg("Failed to remove leader ready file")
+			}
+
+			s.Stop() // GracefulStop blocks until in-flight RPCs complete
+			// Lease is held until this function returns (LeaderElectionReleaseOnCancel: true)
+
+			return nil
+		}))
+		if err != nil {
+			log.Fatal().Err(err).Msg("Failed to add gRPC runnable to manager")
 		}
-
-		// Wait for context cancellation (leadership lost or shutdown)
-		<-ctx.Done()
-
-		log.Info().Msg("Leadership lost or shutdown - stopping gRPC server")
-
-		// Mark as not leader for health checks
-		driver.isLeader.Store(false)
-
-		// Remove leader ready file before stopping gRPC
-		if err := removeLeaderReadyFile(); err != nil {
-			log.Error().Err(err).Msg("Failed to remove leader ready file")
-		}
-
-		s.Stop() // GracefulStop blocks until in-flight RPCs complete
-		// Lease is held until this function returns (LeaderElectionReleaseOnCancel: true)
-
-		return nil
-	}))
-	if err != nil {
-		log.Fatal().Err(err).Msg("Failed to add gRPC runnable to manager")
 	}
 
 	// Handle termination signal
@@ -142,6 +147,13 @@ func (driver *WekaFsDriver) runWithoutLeaderElection(ctx context.Context, termCo
 		log.Info().Msg("Server stopped")
 		os.Exit(1)
 	}()
+
+	// The metrics server has no CSI gRPC surface to serve. Without a manager it has no Kubernetes
+	// access either, so there is nothing useful left to do here beyond staying alive until terminated.
+	if driver.csiMode == CsiModeMetricsServer {
+		<-runCtx.Done()
+		return
+	}
 
 	s.Start(driver.endpoint, driver.ids, driver.cs, driver.ns)
 	s.Wait()

--- a/pkg/wekafs/leaderelection.go
+++ b/pkg/wekafs/leaderelection.go
@@ -58,10 +58,9 @@ func (driver *WekaFsDriver) runWithLeaderElection(ctx context.Context, termConte
 		}
 	}
 
-	// The metrics server has no CSI gRPC surface - no Identity/Controller/Node services - so a
-	// metrics-server-only pod never registers the leader-gated gRPC runnable below; its work is
-	// driven entirely by the metrics server Runnable registered above.
-	if driver.csiMode != CsiModeMetricsServer {
+	// A mode with no CSI gRPC surface never registers the leader-gated gRPC runnable below; a
+	// metrics-server pod's work is driven entirely by the Runnable registered above.
+	if driver.csiMode.servesCsiGrpc() {
 		// Add runnable that starts gRPC server when we become leader
 		err := driver.manager.Add(manager.RunnableFunc(func(ctx context.Context) error {
 			// This only runs when we are the leader

--- a/pkg/wekafs/leaderelection.go
+++ b/pkg/wekafs/leaderelection.go
@@ -43,6 +43,16 @@ func (driver *WekaFsDriver) runWithLeaderElection(ctx context.Context, termConte
 		}
 	}
 
+	// Register the metrics server's health checks and leadership-gated Runnable, same as the health
+	// reconciler above. Nil-guarded since it is only constructed when explicitly enabled and the
+	// driver is running in a mode with Kubernetes access (see NewWekaFsDriver). Must happen before
+	// driver.manager.Start below - controller-runtime rejects Add calls once the manager is started.
+	if driver.metricsServer != nil {
+		if err := driver.metricsServer.AddToManager(); err != nil {
+			log.Error().Err(err).Msg("Failed to register metrics server, metrics will not be available")
+		}
+	}
+
 	// Add runnable that starts gRPC server when we become leader
 	err := driver.manager.Add(manager.RunnableFunc(func(ctx context.Context) error {
 		// This only runs when we are the leader

--- a/pkg/wekafs/metricsserver.go
+++ b/pkg/wekafs/metricsserver.go
@@ -1,0 +1,671 @@
+/*
+Copyright 2019-2025 Weka.io LTD and The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package wekafs
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"os"
+	"slices"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"go.opentelemetry.io/otel"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	"github.com/wekafs/csi-wekafs/pkg/wekafs/apiclient"
+)
+
+const (
+	// VolumeMetricsBufferSize sizes volumeMetricsChan, the queue of freshly fetched per-volume
+	// statistics awaiting a report to Prometheus. Sized generously so a slow reporter (part 2) does
+	// not immediately back-pressure the fetchers.
+	VolumeMetricsBufferSize = 10000
+	// MetricsServerVolumeLimit bounds how many PersistentVolumes a single streaming cycle will hand
+	// off for processing, so one runaway cluster cannot grow the tracked set without limit. It can be
+	// overridden via the MAXIMUM_PERSISTENT_VOLUME_COUNT environment variable.
+	MetricsServerVolumeLimit = 100000
+)
+
+// SecretsStore caches the Kubernetes Secrets the metrics server has read, keyed by
+// "namespace/name", so that streaming the same PersistentVolumes on every cycle does not mean
+// re-reading their Secret from the apiserver every time.
+type SecretsStore struct {
+	secrets map[string]*v1.Secret
+	sync.Mutex
+}
+
+func NewSecretsStore() *SecretsStore {
+	return &SecretsStore{
+		secrets: make(map[string]*v1.Secret),
+	}
+}
+
+// secretCacheKey is the SecretsStore lookup key for a Secret reference.
+func secretCacheKey(secretNamespace, secretName string) string {
+	return secretNamespace + "/" + secretName
+}
+
+// MetricsServer discovers this driver's PersistentVolumes and keeps a live set of the volumes
+// worth polling for capacity and performance statistics.
+//
+// This is the lifecycle and PersistentVolume discovery half of the metrics server: construction,
+// the controller-runtime manager it rides on, and the streamer/processor pair that keeps
+// volumeMetrics and observedFilesystems in sync with what Kubernetes has. Fetching statistics from
+// Weka, refreshing quota maps, and reporting to Prometheus are a separate piece built on top of
+// this one.
+type MetricsServer struct {
+	nodeID            string
+	api               *ApiStore
+	config            *DriverConfig
+	driver            *WekaFsDriver
+	secrets           *SecretsStore
+	volumeMetrics     *VolumeMetrics
+	prometheusMetrics *PrometheusMetrics
+
+	// running guards Start/Stop against being invoked more than once concurrently, and against Stop
+	// running before Start (or twice). It is an atomic.Bool rather than a field read and written
+	// under an ad hoc lock, so the two can race safely.
+	running atomic.Bool
+
+	// persistentVolumesChan carries PersistentVolumes from PersistentVolumeStreamer to
+	// PersistentVolumeStreamProcessor.
+	persistentVolumesChan chan *v1.PersistentVolume
+	// volumeMetricsChan carries freshly fetched statistics to the (not yet ported) Prometheus
+	// reporter. It is declared here because Stop needs something to close, but nothing in this file
+	// writes to it - that arrives with the metrics-fetch half of the metrics server.
+	volumeMetricsChan chan *VolumeMetric
+
+	quotaMaps           *QuotaMapsPerFilesystem
+	observedFilesystems *ObservedFilesystems // tracks observed filesystem UIDs, their reference counts, and API clients
+
+	// wg tracks the leader-elected Runnable started in Start, so Wait blocks for exactly as long as
+	// that Runnable's context remains live (i.e. until leadership is lost or the manager shuts down).
+	wg sync.WaitGroup
+
+	// capacityFetchRunning will guard the periodic single-metrics fetch loop (part 2) against
+	// overlapping invocations. Declared now, alongside `running`, as an atomic.Bool rather than a
+	// plain bool: both fields are read and written from more than one goroutine.
+	capacityFetchRunning atomic.Bool
+}
+
+// getBackgroundTasksWg returns the WaitGroup tracking the metrics server's background work.
+func (ms *MetricsServer) getBackgroundTasksWg() *sync.WaitGroup {
+	return &ms.wg
+}
+
+// getMounter satisfies AnyServer. The metrics server never mounts a filesystem directly - it only
+// ever talks to the Weka API - so this returns nil rather than panicking. Volume.MountUnderlyingFS
+// already turns a nil mounter into a clean error (see volume.go), so a volume whose inode cannot be
+// resolved through the API on a metrics-server-driven cluster simply reports "inode unknown"
+// instead of crashing the process.
+func (ms *MetricsServer) getMounter() AnyMounter {
+	return nil
+}
+
+// getMounterByTransport mirrors getMounter: the metrics server has no mounter for any transport.
+func (ms *MetricsServer) getMounterByTransport(ctx context.Context, transport DataTransport) AnyMounter {
+	return nil
+}
+
+func (ms *MetricsServer) getApiStore() *ApiStore {
+	return ms.api
+}
+
+func (ms *MetricsServer) getConfig() *DriverConfig {
+	return ms.config
+}
+
+func (ms *MetricsServer) isInDevMode() bool {
+	return ms.getConfig().isInDevMode()
+}
+
+func (ms *MetricsServer) getDefaultMountOptions() MountOptions {
+	return getDefaultMountOptions().MergedWith(NewMountOptionsFromString(NodeServerAdditionalMountOptions), ms.getConfig().mutuallyExclusiveOptions)
+}
+
+func (ms *MetricsServer) getNodeId() string {
+	return ms.driver.nodeID
+}
+
+// NewMetricsServer initializes a new MetricsServer for driver. It returns an error rather than
+// panicking when driver is nil, since a construction failure here should be handled by the caller
+// like any other startup error, not crash the process.
+func NewMetricsServer(driver *WekaFsDriver) (*MetricsServer, error) {
+	if driver == nil {
+		return nil, errors.New("cannot create MetricsServer: driver is nil")
+	}
+	ret := &MetricsServer{
+		nodeID:                driver.nodeID,
+		api:                   driver.api,
+		config:                driver.config,
+		driver:                driver,
+		secrets:               NewSecretsStore(),
+		volumeMetrics:         NewVolumeMetrics(),
+		prometheusMetrics:     NewPrometheusMetrics(),
+		persistentVolumesChan: make(chan *v1.PersistentVolume, driver.config.metricsFetchConcurrentRequests),
+		quotaMaps:             NewQuotaMapsPerFilesystem(),
+	}
+	ret.observedFilesystems = NewObservedFilesystems()
+
+	ret.prometheusMetrics.server.FetchMetricsFrequencySeconds.Set(ret.getConfig().metricsFetchInterval.Seconds())
+	ret.prometheusMetrics.server.QuotaCacheValiditySeconds.Set(ret.getConfig().quotaCacheValidityDuration.Seconds())
+
+	return ret, nil
+}
+
+// initManager wires the metrics server's health and readiness checks into the controller-runtime
+// manager. It returns an error instead of killing the process, so Start can decide how to react.
+func (ms *MetricsServer) initManager(ctx context.Context) error {
+	if ms.driver.manager == nil {
+		return errors.New("metrics server has no controller-runtime manager, cannot start")
+	}
+
+	logger := log.Ctx(ctx).With().Str("component", "MetricsServer").Logger()
+	if err := ms.driver.manager.AddReadyzCheck("leader", func(req *http.Request) error {
+		if !ms.getConfig().enableMetricsServerLeaderElection {
+			return nil // if leader election is not enabled, we are always ready
+		}
+		select {
+		case <-ms.driver.manager.Elected():
+			return nil // we are the leader
+		default:
+			return fmt.Errorf("not the leader yet")
+		}
+	}); err != nil {
+		logger.Error().Err(err).Msg("Failed to add readiness check for leader election")
+		return fmt.Errorf("failed to add readiness check for leader election: %w", err)
+	}
+	if err := ms.driver.manager.AddHealthzCheck("alwaysReady", healthz.Ping); err != nil {
+		logger.Error().Err(err).Msg("Failed to add health check")
+		return fmt.Errorf("failed to add health check: %w", err)
+	}
+	return nil
+}
+
+// PersistentVolumeStreamer periodically lists this driver's PersistentVolumes and streams the
+// eligible ones to persistentVolumesChan for PersistentVolumeStreamProcessor to pick up, then prunes
+// tracked volumes that disappeared from the list.
+func (ms *MetricsServer) PersistentVolumeStreamer(ctx context.Context) {
+	component := "PersistentVolumeStreamer"
+	ctx, span := otel.Tracer(TracerName).Start(ctx, component)
+	defer span.End()
+	ctx = log.With().Str("trace_id", span.SpanContext().TraceID().String()).Str("span_id", span.SpanContext().SpanID().String()).Str("component", component).Logger().WithContext(ctx)
+	logger := log.Ctx(ctx)
+
+	out := ms.persistentVolumesChan
+
+	for {
+		cycleStart := time.Now()
+		logger.Info().Msg("Fetching existing persistent volumes")
+		pvList := &v1.PersistentVolumeList{}
+
+		volumeLimit := MetricsServerVolumeLimit
+		// override the maximum count of PersistentVolumes to fetch from environment variable if set
+		if maxCountStr := os.Getenv("MAXIMUM_PERSISTENT_VOLUME_COUNT"); maxCountStr != "" {
+			if maxCount, err := strconv.ParseInt(maxCountStr, 10, 64); err == nil {
+				volumeLimit = int(maxCount)
+			}
+		}
+
+		err := ms.driver.manager.GetClient().List(ctx, pvList)
+		if err != nil {
+			logger.Error().Err(err).Msg("Failed to fetch PersistentVolumes, no statistics will be available, will retry in 10 seconds")
+			ms.prometheusMetrics.server.FetchPvBatchOperationFailureCount.Inc()
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(10 * time.Second):
+			}
+			continue
+		}
+
+		d := time.Since(cycleStart).Seconds()
+		ms.prometheusMetrics.server.FetchPvBatchOperationsInvokeCount.Inc()
+		ms.prometheusMetrics.server.FetchPvBatchOperationsDurationSeconds.Add(d)
+		ms.prometheusMetrics.server.FetchPvBatchOperationsDurationHistogram.Observe(d)
+		ms.prometheusMetrics.server.MonitoredPersistentVolumesGauge.Set(float64(ms.volumeMetrics.Len()))
+
+		logger.Info().Int("pv_count", len(pvList.Items)).Msg("Fetched list of PersistentVolumes, streaming them for processing")
+
+		// Always sort the response so we get the volumes in same order for processing (especially if trimmed)
+		slices.SortFunc(pvList.Items, func(a, b v1.PersistentVolume) int {
+			if a.GetUID() < b.GetUID() {
+				return -1
+			}
+			return 1
+		})
+
+		items := make([]*v1.PersistentVolume, 0, len(pvList.Items))
+		for i := range pvList.Items {
+			pv := &pvList.Items[i]
+			if err := ms.ensurePersistentVolumeValid(pv); err != nil {
+				logger.Trace().Str("pv_name", pv.Name).Err(err).Msg("Skipping processing a PersistentVolume, not valid")
+				continue
+			}
+			items = append(items, pv)
+		}
+
+		// Limit the number of PersistentVolumes to the specified limit, having already sorted them so
+		// the same volumes are streamed in the same order every cycle.
+		if len(items) > volumeLimit {
+			logger.Info().Int("pv_count", len(items)).Int("limit", volumeLimit).Msg("Trimming PersistentVolumes list to the limit")
+			items = items[:volumeLimit]
+		}
+		ms.prometheusMetrics.server.StreamPvBatchSize.Set(float64(len(pvList.Items)))
+		ms.prometheusMetrics.server.FetchPvBatchSize.Set(float64(len(items)))
+
+		for _, pv := range items {
+			select {
+			case <-ctx.Done():
+				return
+			case out <- pv:
+				ms.prometheusMetrics.server.StreamPvOperationsCount.Inc()
+			}
+		}
+
+		// after all PVs are already streamed, prune old volumes (those that are not in the current
+		// list but were measured before)
+		ms.pruneOldVolumes(ctx, items)
+
+		interval := ms.getConfig().metricsFetchInterval
+		logger.Info().Int("pv_count_total", len(pvList.Items)).Int("pv_count_eligible", len(items)).Dur("wait_duration", interval).Msg("Sent all volumes to processing, waiting for next fetch")
+
+		// refresh list of volumes every metricsFetchInterval, but wake up early on shutdown
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(interval):
+		}
+	}
+}
+
+// pruneOldVolumes removes tracked volumes whose PersistentVolume is no longer in pvList.
+func (ms *MetricsServer) pruneOldVolumes(ctx context.Context, pvList []*v1.PersistentVolume) {
+	component := "pruneOldVolumes"
+	ctx, span := otel.Tracer(TracerName).Start(ctx, component)
+	defer span.End()
+	ctx = log.With().Str("trace_id", span.SpanContext().TraceID().String()).Str("span_id", span.SpanContext().SpanID().String()).Str("component", component).Logger().WithContext(ctx)
+	logger := log.Ctx(ctx)
+	logger.Debug().Msg("Pruning stale volumes from metrics collection")
+
+	startTime := time.Now()
+	var pruneCount float64
+	defer func() {
+		dur := time.Since(startTime).Seconds()
+		ms.prometheusMetrics.server.PruneVolumesBatchInvokeCount.Inc()
+		ms.prometheusMetrics.server.PruneVolumesBatchSize.Set(pruneCount)
+		ms.prometheusMetrics.server.PruneVolumesBatchDurationSeconds.Add(dur)
+		ms.prometheusMetrics.server.PruneVolumesBatchDurationHistogram.Observe(dur)
+		if pruneCount > 0 {
+			logger.Info().Int("pruned_volumes", int(pruneCount)).Msg("Pruned stale PersistentVolumes from metrics collection")
+		}
+	}()
+
+	currentUIDs := make(map[types.UID]struct{}, len(pvList))
+	for _, pv := range pvList {
+		currentUIDs[pv.UID] = struct{}{}
+	}
+	// Remove metrics for UIDs not present in the current PV list
+	for _, uid := range ms.volumeMetrics.PvUIDs() {
+		if _, exists := currentUIDs[uid]; exists {
+			continue
+		}
+		if !ms.volumeMetrics.Has(uid) {
+			continue // already pruned by another goroutine
+		}
+		pruneCount++
+		ms.pruneVolumeMetric(ctx, uid)
+	}
+}
+
+// pruneVolumeMetric stops tracking one PersistentVolume: it drops it from volumeMetrics and, if
+// that was the last volume on its filesystem, releases the filesystem from observedFilesystems and
+// forgets its cached quota map.
+//
+// Unlike the version this was ported from, this does not re-resolve the volume's filesystem through
+// the Weka API to find what to release - the filesystem and inode a volume was tracked under are
+// already known (VolumeMetrics.Add recorded them), so releasing it needs no API call and cannot fail
+// because the cluster happens to be unreachable at prune time.
+func (ms *MetricsServer) pruneVolumeMetric(ctx context.Context, pvUID types.UID) {
+	ctx, span := otel.Tracer(TracerName).Start(ctx, "pruneVolumeMetric")
+	defer span.End()
+	ctx = log.With().Str("trace_id", span.SpanContext().TraceID().String()).Str("span_id", span.SpanContext().SpanID().String()).Logger().WithContext(ctx)
+	logger := log.Ctx(ctx)
+
+	vm := ms.volumeMetrics.Get(pvUID)
+	if vm == nil {
+		return // nothing to remove, if it was already removed by another goroutine
+	}
+	defer ms.prometheusMetrics.server.PersistentVolumeRemovalsCount.Inc()
+
+	ms.volumeMetrics.Remove(pvUID)
+	if ms.observedFilesystems.DecRef(vm.key.filesystemUid) {
+		ms.quotaMaps.Forget(vm.key.filesystemUid)
+	}
+	// Reporting - e.g. deleting the Prometheus label values for this volume - belongs to the metrics
+	// fetch/report half of the metrics server, not to PersistentVolume discovery, so it is not done
+	// here.
+	logger.Info().Str("pv_uid", string(pvUID)).Msg("Removed persistent volume from metric collection")
+}
+
+// PersistentVolumeStreamProcessor reads PersistentVolumes off persistentVolumesChan and processes up
+// to metricsFetchConcurrentRequests of them at once.
+func (ms *MetricsServer) PersistentVolumeStreamProcessor(ctx context.Context) {
+	component := "PersistentVolumeStreamProcessor"
+	ctx, span := otel.Tracer(TracerName).Start(ctx, component)
+	defer span.End()
+	ctx = log.With().Str("trace_id", span.SpanContext().TraceID().String()).Str("span_id", span.SpanContext().SpanID().String()).Str("component", component).Logger().WithContext(ctx)
+	logger := log.Ctx(ctx)
+
+	logger.Info().Msg("Starting processing of PersistentVolumes")
+	sem := make(chan struct{}, ms.getConfig().metricsFetchConcurrentRequests)
+	sampledLogger := logger.Sample(&zerolog.BasicSampler{N: 100})
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case pv, ok := <-ms.persistentVolumesChan:
+			if !ok || pv == nil {
+				return
+			}
+			sem <- struct{}{} // acquire semaphore
+			go func(pv *v1.PersistentVolume) {
+				defer func() { <-sem }() // release semaphore
+				ms.processSinglePersistentVolume(ctx, pv)
+				ms.prometheusMetrics.server.FetchPvBatchOperationsSuccessCount.Inc()
+				sampledLogger.Info().Str("pv_name", pv.Name).Msg("Processing persistent volume completed. This is sampled log")
+			}(pv)
+		}
+	}
+}
+
+// processSinglePersistentVolume resolves one PersistentVolume into a tracked VolumeMetric: it reads
+// the volume's Secret, builds an API client from it, resolves the backing filesystem and the
+// volume's inode, and adds it to volumeMetrics. Any failure along the way simply skips the volume -
+// it will be retried the next time PersistentVolumeStreamer cycles.
+func (ms *MetricsServer) processSinglePersistentVolume(ctx context.Context, pv *v1.PersistentVolume) {
+	component := "processSinglePersistentVolume"
+	ctx, span := otel.Tracer(TracerName).Start(ctx, component)
+	defer span.End()
+	ctx = log.With().Str("trace_id", span.SpanContext().TraceID().String()).Str("span_id", span.SpanContext().SpanID().String()).Str("component", component).Logger().WithContext(ctx)
+	logger := log.Ctx(ctx)
+
+	startTime := time.Now()
+	defer func() {
+		dur := time.Since(startTime)
+		ms.prometheusMetrics.server.ProcessPvOperationsCount.Inc()
+		ms.prometheusMetrics.server.ProcessPvOperationsDurationSeconds.Add(dur.Seconds())
+		ms.prometheusMetrics.server.ProcessPvOperationsDurationHistogram.Observe(dur.Seconds())
+	}()
+
+	// if volume was marked for deletion, do nothing - it will be pruned once it drops out of the list
+	if pv.DeletionTimestamp != nil {
+		return
+	}
+
+	// Check if the PersistentVolume is already being processed
+	if vm := ms.volumeMetrics.Get(pv.UID); vm != nil {
+		vm.persistentVolume = pv // Update the PersistentVolume reference in the existing VolumeMetric
+		return
+	}
+
+	logger.Debug().Str("pv_name", pv.Name).Str("phase", string(pv.Status.Phase)).Msg("Received a PersistentVolume for processing")
+
+	// ensurePersistentVolumeValid (run by the streamer before this volume was ever queued) already
+	// guarantees CSI and NodePublishSecretRef are set; guarded again here since nothing enforces that
+	// this is only ever called after that check.
+	if pv.Spec.CSI == nil || pv.Spec.CSI.NodePublishSecretRef == nil {
+		logger.Trace().Str("pv_name", pv.Name).Msg("PersistentVolume has no NodePublishSecretRef, skipping")
+		return
+	}
+
+	secret, err := ms.fetchSecret(ctx, pv.Spec.CSI.NodePublishSecretRef.Name, pv.Spec.CSI.NodePublishSecretRef.Namespace)
+	if err != nil {
+		logger.Error().Err(err).Str("pv_name", pv.Name).Msg("Failed to fetch secret for PersistentVolume, skipping")
+		return
+	}
+	secretData := make(map[string]string, len(secret.Data))
+	for key, value := range secret.Data {
+		secretData[key] = string(value)
+	}
+	if endpoints := os.Getenv("OVERRIDE_API_ENDPOINTS"); endpoints != "" {
+		// Override API endpoints from environment variable if set
+		secretData["endpoints"] = endpoints
+	}
+	apiClient, err := ms.getApiStore().fromSecrets(ctx, secretData, ms.nodeID)
+	if err != nil {
+		logger.Error().Err(err).Str("pv_name", pv.Name).Msg("Failed to create API client from secret, skipping PersistentVolume")
+		return
+	}
+
+	volume, err := NewVolumeFromId(ctx, pv.Spec.CSI.VolumeHandle, apiClient, ms)
+	if err != nil {
+		logger.Error().Err(err).Str("pv_name", pv.Name).Msg("Failed to create Volume from ID")
+		return
+	}
+
+	fsObj, err := volume.apiClient.CachedGetFileSystemByName(ctx, volume.FilesystemName, ms.getConfig().quotaCacheValidityDuration)
+	if err != nil {
+		logger.Error().Err(err).Str("pv_name", pv.Name).Msg("Failed to get filesystem object for volume, skipping PersistentVolume")
+		return
+	}
+
+	// we still want to validate the object; by-UID is faster than by-name
+	volume.fileSystemObject = fsObj
+	ensuredFsObj := &apiclient.FileSystem{}
+	if err := volume.apiClient.GetFileSystemByUid(ctx, fsObj.Uid, ensuredFsObj, false); err != nil {
+		logger.Error().Err(err).Str("pv_name", pv.Name).Msg("Failed to get filesystem object for volume, skipping PersistentVolume")
+		return
+	}
+	volume.fileSystemObject = ensuredFsObj
+
+	// Prepopulate the inode id so metrics can be matched to a quota later without resolving it
+	// again. A volume whose inode cannot be resolved is still tracked, with an unknown inode: it
+	// reports the capacity Kubernetes knows about, and tracking it is what stops the streamer
+	// rediscovering and reprocessing it - at four API calls a time - on every cycle.
+	inodeId, err := volume.getInodeId(ctx)
+	if err != nil {
+		logger.Trace().Err(err).Str("pv_name", pv.Name).Msg("Failed to resolve inode ID for volume, tracking it without one")
+		inodeId = 0
+	}
+
+	// The reference is taken only once the volume is definitely going to be tracked, since it is
+	// released when the volume is pruned. Taking it earlier and then returning would leave a
+	// reference nothing ever drops, and the filesystem would be polled forever.
+	ms.observedFilesystems.IncRef(ensuredFsObj, apiClient)
+
+	metric := &VolumeMetric{
+		persistentVolume: pv,
+		volume:           volume,
+		metrics:          nil,
+		secret:           secret,
+		apiClient:        apiClient,
+	}
+	ms.volumeMetrics.Add(pv.UID, volumeKey{filesystemUid: ensuredFsObj.Uid, inodeId: inodeId}, metric)
+	ms.prometheusMetrics.server.PersistentVolumeAdditionsCount.Inc()
+	logger.Debug().Str("pv_name", pv.Name).Dur("duration", time.Since(startTime)).Msg("Added PersistentVolume for metrics processing")
+}
+
+// ensurePersistentVolumeValid reports why a PersistentVolume is not a candidate for metrics
+// collection, or nil if it is.
+func (ms *MetricsServer) ensurePersistentVolumeValid(pv *v1.PersistentVolume) error {
+	// Filter for Weka CSI volumes of current driver only
+	if pv.Spec.CSI == nil {
+		return errors.New("pv is not a CSI volume")
+	}
+	if pv.Spec.CSI.NodePublishSecretRef == nil {
+		return errors.New("pv is not valid, NodePublishSecretRef is not provided")
+	}
+	if pv.Spec.CSI.Driver != ms.driver.name {
+		return errors.New("pv is not a WEKA CSI volume or not belonging to this driver")
+	}
+	if len(pv.Spec.Capacity) == 0 {
+		return errors.New("pv has a zero capacity, half-baked volume possible")
+	}
+	if len(pv.Spec.CSI.VolumeAttributes) == 0 {
+		return errors.New("pv is missing volumeAttributes")
+	}
+	if !slices.Contains(KnownVolTypes[:], VolumeType(pv.Spec.CSI.VolumeAttributes["volumeType"])) {
+		return errors.New("pv is missing volumeType or has an unsupported volumeType")
+	}
+	if pv.Status.Phase != v1.VolumeBound && pv.Status.Phase != v1.VolumeReleased {
+		return fmt.Errorf("pv is not in a valid phase: %s", pv.Status.Phase)
+	}
+	return nil // Valid PersistentVolume
+}
+
+// fetchSecret retrieves a Kubernetes Secret by name and namespace, caching it for future use. The
+// apiserver read (through the manager's uncached API reader, so no Secret informer is started) is
+// deliberately made without holding ms.secrets' lock, so one slow read cannot stall lookups of a
+// different, already-cached Secret.
+func (ms *MetricsServer) fetchSecret(ctx context.Context, secretName, secretNamespace string) (*v1.Secret, error) {
+	component := "fetchSecret"
+	ctx, span := otel.Tracer(TracerName).Start(ctx, component)
+	defer span.End()
+	ctx = log.With().Str("trace_id", span.SpanContext().TraceID().String()).Str("span_id", span.SpanContext().SpanID().String()).Str("component", component).Logger().WithContext(ctx)
+	logger := log.Ctx(ctx).With().Str("secret_name", secretName).Str("secret_namespace", secretNamespace).Logger()
+
+	if secretName == "" || secretNamespace == "" {
+		return nil, errors.New("secret name and namespace must be provided")
+	}
+	key := secretCacheKey(secretNamespace, secretName)
+
+	ms.secrets.Lock()
+	secret, exists := ms.secrets.secrets[key]
+	ms.secrets.Unlock()
+	if exists {
+		logger.Trace().Msg("Using a secret from cache")
+		return secret, nil
+	}
+
+	logger.Debug().Msg("Fetching Secret")
+	fetched := &v1.Secret{}
+	// Deliberately an uncached read: going through the manager's cached client would start an
+	// informer that mirrors every Secret in the cluster into this process's memory.
+	nsName := types.NamespacedName{Name: secretName, Namespace: secretNamespace}
+	if err := ms.driver.manager.GetAPIReader().Get(ctx, nsName, fetched); err != nil {
+		return nil, fmt.Errorf("failed to fetch secret %s/%s: %w", secretNamespace, secretName, err)
+	}
+
+	ms.secrets.Lock()
+	ms.secrets.secrets[key] = fetched
+	ms.secrets.Unlock()
+	return fetched, nil
+}
+
+// InvalidateSecret removes a Secret from the cache. Call this after getting an authentication error
+// from an API client built from it - likely because the Secret was rotated - so the next volume that
+// needs it re-reads the current contents instead of the stale, cached ones.
+func (ms *MetricsServer) InvalidateSecret(ctx context.Context, secretName, secretNamespace string) {
+	if secretName == "" || secretNamespace == "" {
+		return
+	}
+	key := secretCacheKey(secretNamespace, secretName)
+	ms.secrets.Lock()
+	defer ms.secrets.Unlock()
+	delete(ms.secrets.secrets, key)
+}
+
+// Start brings the metrics server up: it wires health/readiness checks into the controller-runtime
+// manager, then registers a Runnable that only does its work while this pod holds leadership (or
+// unconditionally, if leader election is disabled for the manager itself), and starts the manager.
+//
+// Only the PersistentVolume discovery goroutines are started here. Fetching statistics from Weka,
+// refreshing quota maps, and reporting to Prometheus are a separate piece not yet wired in.
+func (ms *MetricsServer) Start(ctx context.Context) {
+	component := "StartMetricsServer"
+	ctx, span := otel.Tracer(TracerName).Start(ctx, component)
+	defer span.End()
+	ctx = log.With().Str("trace_id", span.SpanContext().TraceID().String()).Str("span_id", span.SpanContext().SpanID().String()).Logger().WithContext(ctx)
+	logger := log.Ctx(ctx)
+
+	if !ms.running.CompareAndSwap(false, true) {
+		logger.Info().Msg("MetricsServer is already running")
+		return
+	}
+
+	logger.Info().Msg("Starting MetricsServer")
+
+	if err := ms.initManager(ctx); err != nil {
+		logger.Error().Err(err).Msg("Failed to initialize MetricsServer manager, cannot start")
+		ms.running.Store(false)
+		return
+	}
+
+	// give the manager's cache a moment to sync before the first PersistentVolume fetch
+	time.Sleep(1 * time.Second)
+	logger.Info().Msg("started manager, starting to fetch PersistentVolumes")
+
+	ms.wg.Add(1)
+	err := ms.driver.manager.Add(manager.RunnableFunc(func(ctx context.Context) error {
+		defer ms.wg.Done()
+		logger.Info().Msg("Leader elected, starting MetricsServer processors")
+
+		go ms.PersistentVolumeStreamer(ctx)
+		go ms.PersistentVolumeStreamProcessor(ctx)
+		// The metrics-fetch, quota-map-refresh, and Prometheus-reporting loops are a separate piece
+		// of the metrics server and are deliberately not started here.
+
+		<-ctx.Done()
+		logger.Info().Msg("Leadership lost or shutdown, stopping...")
+		return nil
+	}))
+	if err != nil {
+		logger.Error().Err(err).Msg("Failed to add Runnable to manager")
+		ms.wg.Done()
+		ms.running.Store(false)
+		return
+	}
+
+	go func() {
+		if err := ms.driver.manager.Start(ctx); err != nil {
+			logger.Error().Err(err).Msg("MetricsServer manager exited with error")
+		}
+	}()
+}
+
+// Wait blocks until the metrics server's leader-elected work has stopped, i.e. until leadership is
+// lost or the manager shuts down.
+func (ms *MetricsServer) Wait() {
+	ms.wg.Wait()
+}
+
+// Stop tears down the metrics server's channels. It is safe to call on a nil receiver, and safe to
+// call more than once or before Start - both are no-ops.
+func (ms *MetricsServer) Stop(ctx context.Context) {
+	if ms == nil {
+		return // Nothing to stop
+	}
+	if !ms.running.CompareAndSwap(true, false) {
+		return // already stopped, or never started
+	}
+	// The channels are deliberately not closed. Their producers run until the context is cancelled
+	// and send inside a select on ctx.Done, and a select gives no protection against sending on a
+	// closed channel - closing one under a live producer panics. The consumers already exit on
+	// ctx.Done, so closing buys nothing, and the channels are collected once unreferenced.
+	log.Ctx(ctx).Info().Msg("Metrics server stopped")
+}

--- a/pkg/wekafs/metricsserver.go
+++ b/pkg/wekafs/metricsserver.go
@@ -28,6 +28,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"go.opentelemetry.io/otel"
@@ -94,9 +95,8 @@ type MetricsServer struct {
 	// persistentVolumesChan carries PersistentVolumes from PersistentVolumeStreamer to
 	// PersistentVolumeStreamProcessor.
 	persistentVolumesChan chan *v1.PersistentVolume
-	// volumeMetricsChan carries freshly fetched statistics to the (not yet ported) Prometheus
-	// reporter. It is declared here because Stop needs something to close, but nothing in this file
-	// writes to it - that arrives with the metrics-fetch half of the metrics server.
+	// volumeMetricsChan carries freshly fetched statistics from the fetchers (fetchSingleMetric,
+	// GetMetricsFromQuotaMap) to MetricsReportStreamer, which is the only reader.
 	volumeMetricsChan chan *VolumeMetric
 
 	quotaMaps           *QuotaMapsPerFilesystem
@@ -106,9 +106,10 @@ type MetricsServer struct {
 	// that Runnable's context remains live (i.e. until leadership is lost or the manager shuts down).
 	wg sync.WaitGroup
 
-	// capacityFetchRunning will guard the periodic single-metrics fetch loop (part 2) against
-	// overlapping invocations. Declared now, alongside `running`, as an atomic.Bool rather than a
-	// plain bool: both fields are read and written from more than one goroutine.
+	// capacityFetchRunning guards PeriodicSingleMetricsFetcher's fetch cycles against overlapping
+	// invocations: if one cycle is still running when the next tick fires, the next tick is skipped
+	// rather than piling another full fetch on top of it. It is an atomic.Bool, like `running`,
+	// because both fields are read and written from more than one goroutine.
 	capacityFetchRunning atomic.Bool
 }
 
@@ -167,6 +168,7 @@ func NewMetricsServer(driver *WekaFsDriver) (*MetricsServer, error) {
 		volumeMetrics:         NewVolumeMetrics(),
 		prometheusMetrics:     NewPrometheusMetrics(),
 		persistentVolumesChan: make(chan *v1.PersistentVolume, driver.config.metricsFetchConcurrentRequests),
+		volumeMetricsChan:     make(chan *VolumeMetric, VolumeMetricsBufferSize),
 		quotaMaps:             NewQuotaMapsPerFilesystem(),
 	}
 	ret.observedFilesystems = NewObservedFilesystems()
@@ -342,9 +344,10 @@ func (ms *MetricsServer) pruneOldVolumes(ctx context.Context, pvList []*v1.Persi
 	}
 }
 
-// pruneVolumeMetric stops tracking one PersistentVolume: it drops it from volumeMetrics and, if
-// that was the last volume on its filesystem, releases the filesystem from observedFilesystems and
-// forgets its cached quota map.
+// pruneVolumeMetric stops tracking one PersistentVolume: it drops it from volumeMetrics, deletes its
+// Prometheus label values so a removed volume's series stop being exported rather than going stale,
+// and, if that was the last volume on its filesystem, releases the filesystem from
+// observedFilesystems and forgets its cached quota map.
 //
 // Unlike the version this was ported from, this does not re-resolve the volume's filesystem through
 // the Weka API to find what to release - the filesystem and inode a volume was tracked under are
@@ -366,9 +369,9 @@ func (ms *MetricsServer) pruneVolumeMetric(ctx context.Context, pvUID types.UID)
 	if ms.observedFilesystems.DecRef(vm.key.filesystemUid) {
 		ms.quotaMaps.Forget(vm.key.filesystemUid)
 	}
-	// Reporting - e.g. deleting the Prometheus label values for this volume - belongs to the metrics
-	// fetch/report half of the metrics server, not to PersistentVolume discovery, so it is not done
-	// here.
+	if vm.persistentVolume != nil {
+		ms.removePrometheusMetricsForLabels(ctx, vm)
+	}
 	logger.Info().Str("pv_uid", string(pvUID)).Msg("Removed persistent volume from metric collection")
 }
 
@@ -590,12 +593,714 @@ func (ms *MetricsServer) InvalidateSecret(ctx context.Context, secretName, secre
 	delete(ms.secrets.secrets, key)
 }
 
+// quotaToUsageStats turns one filesystem quota into the capacity view a PersistentVolume reports.
+// Free is derived rather than reported by the API, since a quota describes a hard limit rather than
+// a used/free split.
+func quotaToUsageStats(q *apiclient.Quota, ts time.Time) *UsageStats {
+	return &UsageStats{
+		Capacity:  int64(q.HardLimitBytes),
+		Used:      int64(q.TotalBytes),
+		Free:      int64(q.HardLimitBytes - q.TotalBytes),
+		Timestamp: ts,
+	}
+}
+
+// fetchPvUsageStatsFromWeka fetches one volume's usage directly: resolve its inode, then ask the
+// Weka API for the quota at that inode. This is one API round trip per volume, which is fine at
+// small scale but is exactly what the quota-map path (fetchSinglePvUsageStatsFromQuotaMap) exists to
+// avoid at larger scale.
+func (ms *MetricsServer) fetchPvUsageStatsFromWeka(ctx context.Context, vm *VolumeMetric) (*UsageStats, error) {
+	v := vm.volume
+	inodeId, err := v.getInodeId(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get inode ID for PersistentVolume %s: %w", vm.pvName(), err)
+	}
+	fsObj, err := v.getFilesystemObj(ctx, true)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get filesystem object for PersistentVolume %s: %w", vm.pvName(), err)
+	}
+	if fsObj == nil {
+		return nil, fmt.Errorf("failed to get filesystem object for PersistentVolume %s", vm.pvName())
+	}
+	quotaEntry, err := v.apiClient.GetQuotaByFileSystemAndInode(ctx, fsObj, inodeId)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch quota for inode ID %d: %w", inodeId, err)
+	}
+	if quotaEntry == nil {
+		return nil, fmt.Errorf("no quota entry found for inode ID %d", inodeId)
+	}
+	// apiclient.Quota carries no per-quota fetch timestamp on this branch (dev's quotaEntry had
+	// LastUpdateTime; here that field only exists at the QuotaMap level), so the reading is stamped
+	// with the time it was actually fetched.
+	return quotaToUsageStats(quotaEntry, time.Now()), nil
+}
+
+// fetchPvUsageStatsFromWekaWithCache is fetchPvUsageStatsFromWeka with a per-volume cache in front of
+// it, so a volume whose last reading is still within quotaCacheValidityDuration is served from
+// memory instead of costing another API round trip.
+func (ms *MetricsServer) fetchPvUsageStatsFromWekaWithCache(ctx context.Context, vm *VolumeMetric) (*UsageStats, error) {
+	v := vm.volume
+	if v.lastUsageStats == nil || time.Since(v.lastUsageStats.Timestamp) > ms.getConfig().quotaCacheValidityDuration {
+		usageStats, err := ms.fetchPvUsageStatsFromWeka(ctx, vm)
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch usage stats from Weka for PersistentVolume %s: %w", vm.pvName(), err)
+		}
+		v.lastUsageStats = usageStats
+	}
+	return v.lastUsageStats, nil
+}
+
+// fetchSinglePvUsageStatsFromQuotaMap resolves one volume's usage from its filesystem's cached quota
+// map instead of a per-volume API call. The map itself has to already be cached - refreshing it here
+// on a miss would turn every volume's read into the very per-volume API traffic this path exists to
+// avoid; refreshing it is batchRefreshQuotaMaps' job.
+func (ms *MetricsServer) fetchSinglePvUsageStatsFromQuotaMap(ctx context.Context, vm *VolumeMetric) (*UsageStats, error) {
+	v := vm.volume
+	inodeId, err := v.getInodeId(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get inode ID for PersistentVolume %s: %w", vm.pvName(), err)
+	}
+	fsObj, err := v.getFilesystemObj(ctx, true)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get filesystem object for PersistentVolume %s: %w", vm.pvName(), err)
+	}
+	if fsObj == nil {
+		return nil, fmt.Errorf("failed to get filesystem object for PersistentVolume %s", vm.pvName())
+	}
+	quotaMap, err := ms.GetQuotaMapForFilesystem(ctx, fsObj)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get quota map for filesystem %s: %w", fsObj.Name, err)
+	}
+	quotaEntry := quotaMap.GetQuotaForInodeId(inodeId)
+	if quotaEntry == nil {
+		return nil, fmt.Errorf("no quota entry found for inode ID %d in cached quota map for filesystem %s", inodeId, fsObj.Name)
+	}
+	return quotaToUsageStats(quotaEntry, quotaMap.LastUpdate), nil
+}
+
+// FetchPvStatsFromQuotaMap is FetchPvStats' implementation for useQuotaMapsForMetrics=true.
+func (ms *MetricsServer) FetchPvStatsFromQuotaMap(ctx context.Context, vm *VolumeMetric) (*PvStats, error) {
+	usageStats, err := ms.fetchSinglePvUsageStatsFromQuotaMap(ctx, vm)
+	if err != nil {
+		return nil, err
+	}
+	return &PvStats{Usage: usageStats}, nil
+}
+
+// FetchPvStatsFromWeka is FetchPvStats' implementation for useQuotaMapsForMetrics=false.
+func (ms *MetricsServer) FetchPvStatsFromWeka(ctx context.Context, vm *VolumeMetric) (*PvStats, error) {
+	usageStats, err := ms.fetchPvUsageStatsFromWekaWithCache(ctx, vm)
+	if err != nil {
+		return nil, err
+	}
+	return &PvStats{Usage: usageStats}, nil
+}
+
+// FetchPvStats fetches one volume's usage statistics, routing to the filesystem-wide quota map or to
+// a direct per-volume API call depending on how the driver is configured.
+func (ms *MetricsServer) FetchPvStats(ctx context.Context, vm *VolumeMetric) (*PvStats, error) {
+	if ms.getConfig().useQuotaMapsForMetrics {
+		return ms.FetchPvStatsFromQuotaMap(ctx, vm)
+	}
+	return ms.FetchPvStatsFromWeka(ctx, vm)
+}
+
+// fetchSingleMetric fetches statistics for one tracked volume and, on success, hands it to
+// MetricsReportStreamer over volumeMetricsChan.
+func (ms *MetricsServer) fetchSingleMetric(ctx context.Context, vm *VolumeMetric) error {
+	component := "fetchSingleMetric"
+	ctx, span := otel.Tracer(TracerName).Start(ctx, component)
+	defer span.End()
+	ctx = log.With().Str("trace_id", span.SpanContext().TraceID().String()).Str("span_id", span.SpanContext().SpanID().String()).Str("component", component).Str("pv_name", vm.pvName()).Logger().WithContext(ctx)
+
+	startTime := time.Now()
+	ms.prometheusMetrics.server.FetchSinglePvMetricsOperationsInvokeCount.Inc()
+	defer func() {
+		dur := time.Since(startTime).Seconds()
+		ms.prometheusMetrics.server.FetchSinglePvMetricsOperationsDurationSeconds.Add(dur)
+		ms.prometheusMetrics.server.FetchSinglePvMetricsOperationsDurationHistogram.Observe(dur)
+	}()
+
+	pvStats, err := ms.FetchPvStats(ctx, vm)
+	if err != nil {
+		ms.prometheusMetrics.server.FetchSinglePvMetricsOperationsFailureCount.Inc()
+		return fmt.Errorf("failed to fetch metric for persistent volume %s: %w", vm.pvName(), err)
+	}
+
+	vm.metrics = pvStats
+	select {
+	case ms.volumeMetricsChan <- vm:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+	ms.prometheusMetrics.server.FetchSinglePvMetricsOperationsSuccessCount.Inc()
+	return nil
+}
+
+// FetchMetricsOneByOne fetches statistics for every currently tracked volume, one Weka API call at a
+// time per volume, bounded to quotaFetchConcurrentRequests concurrent fetches. It is the
+// useQuotaMapsForMetrics=false counterpart to batchRefreshQuotaMaps.
+//
+// Unlike the version this was ported from, this actually waits for every fetch to finish before
+// returning: that version created a WaitGroup but never called Add on it, so Wait returned
+// immediately and the duration/success metrics recorded in the caller measured how long it took to
+// launch the fetches, not how long they took to complete.
+func (ms *MetricsServer) FetchMetricsOneByOne(ctx context.Context) error {
+	component := "FetchMetricsOneByOne"
+	ctx, span := otel.Tracer(TracerName).Start(ctx, component)
+	defer span.End()
+	ctx = log.With().Str("trace_id", span.SpanContext().TraceID().String()).Str("span_id", span.SpanContext().SpanID().String()).Str("component", component).Logger().WithContext(ctx)
+	logger := log.Ctx(ctx)
+
+	startTime := time.Now()
+	vms := ms.volumeMetrics.All()
+	ms.prometheusMetrics.server.FetchMetricsBatchSize.Set(float64(len(vms)))
+	ms.prometheusMetrics.server.FetchMetricsBatchOperationsInvokeCount.Inc()
+
+	var succeeded atomic.Bool
+	succeeded.Store(true)
+	defer func() {
+		dur := time.Since(startTime).Seconds()
+		if succeeded.Load() {
+			ms.prometheusMetrics.server.FetchMetricsBatchOperationsSuccessCount.Inc()
+		} else {
+			ms.prometheusMetrics.server.FetchMetricsBatchOperationsFailureCount.Inc()
+		}
+		ms.prometheusMetrics.server.FetchMetricsBatchOperationsDurationSeconds.Add(dur)
+		ms.prometheusMetrics.server.FetchMetricsBatchOperationsDurationHistogram.Observe(dur)
+		if dur > ms.getConfig().metricsFetchInterval.Seconds() {
+			logger.Warn().Int("pv_count", len(vms)).Dur("fetch_duration", time.Duration(dur*float64(time.Second))).Msg("Fetching metrics took longer than the configured interval, consider increasing metricsFetchInterval or metricsFetchConcurrentRequests")
+		} else {
+			logger.Info().Int("pv_count", len(vms)).Dur("fetch_duration", time.Duration(dur*float64(time.Second))).Msg("Fetched metrics for PersistentVolumes")
+		}
+	}()
+
+	logger.Info().Int("pv_count", len(vms)).Msg("Starting to fetch metrics for PersistentVolumes")
+	sem := make(chan struct{}, ms.getConfig().quotaFetchConcurrentRequests)
+	var wg sync.WaitGroup
+	for _, vm := range vms {
+		if vm == nil || vm.persistentVolume == nil {
+			// could happen if it was already pruned while this loop was building its snapshot
+			continue
+		}
+		sem <- struct{}{} // acquire a slot in the semaphore
+		wg.Add(1)
+		go func(vm *VolumeMetric) {
+			defer wg.Done()
+			defer func() { <-sem }() // release the slot in the semaphore
+			if err := ms.fetchSingleMetric(ctx, vm); err != nil {
+				succeeded.Store(false)
+				logger.Warn().Err(err).Str("pv_name", vm.pvName()).Msg("Failed to fetch metric for persistent volume")
+			}
+		}(vm)
+	}
+	wg.Wait()
+	return nil
+}
+
+// GetMetricsFromQuotaMap updates every tracked volume on qm's filesystem from a freshly fetched
+// quota map, and hands each of them to MetricsReportStreamer over volumeMetricsChan.
+//
+// It walks the map's own distinct inodes rather than the filesystem's tracked volumes, and for each
+// one calls VolumeMetrics.ForInode to reach every PersistentVolume sharing it: the version this was
+// ported from assumed one PersistentVolume per inode and updated only the first match, so a
+// filesystem where two PVs point at the same static path (ordinary under static provisioning) would
+// silently stop reporting for one of them.
+func (ms *MetricsServer) GetMetricsFromQuotaMap(ctx context.Context, qm *apiclient.QuotaMap) {
+	component := "GetMetricsFromQuotaMap"
+	ctx, span := otel.Tracer(TracerName).Start(ctx, component)
+	defer span.End()
+	ctx = log.With().Str("trace_id", span.SpanContext().TraceID().String()).Str("span_id", span.SpanContext().SpanID().String()).Str("component", component).Logger().WithContext(ctx)
+	logger := log.Ctx(ctx)
+
+	if qm == nil {
+		logger.Error().Msg("QuotaMap is nil, cannot update volume metrics from it")
+		return
+	}
+
+	// ForFilesystem is only used to enumerate the distinct inodes this filesystem's tracked volumes
+	// sit at; ForInode below is what actually looks up who to update at each one, since several
+	// PersistentVolumes can share an inode.
+	seenInodes := make(map[uint64]struct{})
+	for _, vm := range ms.volumeMetrics.ForFilesystem(qm.FileSystemUid) {
+		inodeId := vm.key.inodeId
+		if inodeId == 0 {
+			logger.Trace().Str("pv_name", vm.pvName()).Msg("Volume has no known inode ID, skipping")
+			continue
+		}
+		if _, ok := seenInodes[inodeId]; ok {
+			continue
+		}
+		seenInodes[inodeId] = struct{}{}
+
+		q := qm.GetQuotaForInodeId(inodeId)
+		if q == nil {
+			logger.Warn().Uint64("inode_id", inodeId).Msg("No quota entry found for inode ID in quota map, skipping")
+			continue
+		}
+		stats := &PvStats{Usage: quotaToUsageStats(q, qm.LastUpdate)}
+
+		for _, target := range ms.volumeMetrics.ForInode(qm.FileSystemUid, inodeId) {
+			target.metrics = stats
+			select {
+			case ms.volumeMetricsChan <- target:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}
+}
+
+// MetricsReportStreamer reads freshly fetched statistics off volumeMetricsChan and reports them to
+// Prometheus.
+func (ms *MetricsServer) MetricsReportStreamer(ctx context.Context) {
+	component := "MetricsReportStreamer"
+	ctx, span := otel.Tracer(TracerName).Start(ctx, component)
+	defer span.End()
+	ctx = log.With().Str("trace_id", span.SpanContext().TraceID().String()).Str("span_id", span.SpanContext().SpanID().String()).Str("component", component).Logger().WithContext(ctx)
+	logger := log.Ctx(ctx)
+
+	logger.Info().Msg("Starting to report metrics for PersistentVolumes")
+	for {
+		select {
+		case <-ctx.Done():
+			logger.Info().Msg("Context cancelled, stopping reporting of metrics")
+			return
+		case metric, ok := <-ms.volumeMetricsChan:
+			if !ok {
+				logger.Info().Msg("volumeMetricsChan closed, stopping reporting of metrics")
+				return
+			}
+			// metric.persistentVolume is guarded here too (not just where it is added to
+			// volumeMetricsChan): createPrometheusLabelsForMetric dereferences it, and a nil check at
+			// the one call site that fills the channel today is easy to lose track of as more
+			// producers are added.
+			if metric == nil || metric.metrics == nil || metric.persistentVolume == nil {
+				continue
+			}
+			u := metric.metrics.Usage
+			p := metric.metrics.Performance
+			labelValues := ms.createPrometheusLabelsForMetric(metric)
+
+			if u != nil {
+				logger.Trace().Str("pv_name", metric.pvName()).Msg("Reporting metrics for PersistentVolume")
+				ms.prometheusMetrics.volumes.CapacityBytes.WithLabelValues(labelValues...).SetWithTimestamp(float64(u.Capacity), u.Timestamp)
+				ms.prometheusMetrics.volumes.UsedBytes.WithLabelValues(labelValues...).SetWithTimestamp(float64(u.Used), u.Timestamp)
+				ms.prometheusMetrics.volumes.FreeBytes.WithLabelValues(labelValues...).SetWithTimestamp(float64(u.Free), u.Timestamp)
+			}
+			if p != nil {
+				ms.prometheusMetrics.volumes.ReadsTotal.WithLabelValues(labelValues...).SetWithTimestamp(float64(p.Reads), p.Timestamp)
+				ms.prometheusMetrics.volumes.WritesTotal.WithLabelValues(labelValues...).SetWithTimestamp(float64(p.Writes), p.Timestamp)
+				ms.prometheusMetrics.volumes.ReadBytesTotal.WithLabelValues(labelValues...).SetWithTimestamp(float64(p.ReadBytes), p.Timestamp)
+				ms.prometheusMetrics.volumes.WriteBytes.WithLabelValues(labelValues...).SetWithTimestamp(float64(p.WriteBytes), p.Timestamp)
+				ms.prometheusMetrics.volumes.ReadDurationUs.WithLabelValues(labelValues...).SetWithTimestamp(float64(p.ReadLatencyUs), p.Timestamp)
+				ms.prometheusMetrics.volumes.WriteDurationUs.WithLabelValues(labelValues...).SetWithTimestamp(float64(p.WriteLatencyUs), p.Timestamp)
+			}
+			if u != nil || p != nil {
+				ms.prometheusMetrics.server.ReportedMetricsSuccessCount.Inc()
+			} else {
+				ms.prometheusMetrics.server.ReportedMetricsFailureCount.Inc()
+			}
+		}
+	}
+}
+
+// createPrometheusLabelsForMetric builds the LabelsForCsiVolumes label values for one volume.
+func (ms *MetricsServer) createPrometheusLabelsForMetric(metric *VolumeMetric) []string {
+	labelValues := []string{
+		ms.driver.name,
+		metric.persistentVolume.Name,
+		metric.apiClient.ClusterGuid.String(),
+		metric.persistentVolume.Spec.StorageClassName,
+		metric.volume.FilesystemName,
+		string(metric.volume.GetBackingType()),
+	}
+	if metric.persistentVolume.Spec.ClaimRef != nil {
+		labelValues = append(labelValues,
+			metric.persistentVolume.Spec.ClaimRef.Name,
+			metric.persistentVolume.Spec.ClaimRef.Namespace,
+			string(metric.persistentVolume.Spec.ClaimRef.UID))
+	} else {
+		labelValues = append(labelValues, "", "", "")
+	}
+	return labelValues
+}
+
+// removePrometheusMetricsForLabels deletes every Prometheus series for one volume, e.g. once it is
+// pruned. Without this, a removed volume's last-reported values (and, for the plain, non-timed
+// PvReportedCapacityBytes gauge, its stale value) would keep being exported forever.
+func (ms *MetricsServer) removePrometheusMetricsForLabels(ctx context.Context, metric *VolumeMetric) {
+	log.Ctx(ctx).Trace().Str("pv_name", metric.pvName()).Msg("Removing Prometheus metric labels for volume")
+	labelValues := ms.createPrometheusLabelsForMetric(metric)
+	ms.prometheusMetrics.volumes.CapacityBytes.DeleteLabelValues(labelValues...)
+	ms.prometheusMetrics.volumes.UsedBytes.DeleteLabelValues(labelValues...)
+	ms.prometheusMetrics.volumes.FreeBytes.DeleteLabelValues(labelValues...)
+	ms.prometheusMetrics.volumes.PvReportedCapacityBytes.DeleteLabelValues(labelValues...)
+	ms.prometheusMetrics.volumes.ReadsTotal.DeleteLabelValues(labelValues...)
+	ms.prometheusMetrics.volumes.WritesTotal.DeleteLabelValues(labelValues...)
+	ms.prometheusMetrics.volumes.ReadBytesTotal.DeleteLabelValues(labelValues...)
+	ms.prometheusMetrics.volumes.WriteBytes.DeleteLabelValues(labelValues...)
+	ms.prometheusMetrics.volumes.ReadDurationUs.DeleteLabelValues(labelValues...)
+	ms.prometheusMetrics.volumes.WriteDurationUs.DeleteLabelValues(labelValues...)
+}
+
+// PeriodicPersistentVolumeCapacityReporter periodically re-reports every tracked volume's
+// Kubernetes-known capacity. It is a fallback, independent of whether Weka statistics are being
+// fetched successfully: if the cluster is unreachable, or the useQuotaMapsForMetrics quota map
+// hasn't refreshed yet, PvReportedCapacityBytes still reflects what the PersistentVolume claims.
+func (ms *MetricsServer) PeriodicPersistentVolumeCapacityReporter(ctx context.Context) {
+	component := "PeriodicPersistentVolumeCapacityReporter"
+	ctx, span := otel.Tracer(TracerName).Start(ctx, component)
+	defer span.End()
+	ctx = log.With().Str("trace_id", span.SpanContext().TraceID().String()).Str("span_id", span.SpanContext().SpanID().String()).Str("component", component).Logger().WithContext(ctx)
+	logger := log.Ctx(ctx)
+
+	logger.Info().Msg("Starting periodic reporting of PersistentVolume capacities once a minute. This is a fallback mechanism to ensure capacities are reported even if metrics are not fetched from the Weka API for some reason.")
+	ticker := time.NewTicker(time.Minute)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			logger.Info().Msg("Context cancelled, stopping periodic reporting of PersistentVolume capacities")
+			return
+		case <-ticker.C:
+			ms.reportOnlyPvCapacities(ctx)
+		}
+	}
+}
+
+// reportOnlyPvCapacities reports every tracked volume's Kubernetes-known capacity to
+// PvReportedCapacityBytes. Unlike the version this was ported from, which re-looked-up each volume
+// by UID one at a time, this takes one snapshot of the tracked set up front via VolumeMetrics.All -
+// there is no exported key list to iterate on this branch, and a snapshot is what that call was
+// approximating anyway.
+func (ms *MetricsServer) reportOnlyPvCapacities(ctx context.Context) {
+	component := "reportOnlyPvCapacities"
+	ctx, span := otel.Tracer(TracerName).Start(ctx, component)
+	defer span.End()
+	ctx = log.With().Str("trace_id", span.SpanContext().TraceID().String()).Str("span_id", span.SpanContext().SpanID().String()).Str("component", component).Logger().WithContext(ctx)
+	logger := log.Ctx(ctx)
+
+	vms := ms.volumeMetrics.All()
+	logger.Info().Int("pv_count", len(vms)).Msg("Starting to report only PersistentVolume capacities")
+	if len(vms) == 0 {
+		logger.Info().Msg("No PersistentVolumes found, nothing to report")
+		return
+	}
+
+	for _, vm := range vms {
+		if vm == nil || vm.persistentVolume == nil {
+			// could happen if it was already pruned while this loop was building its snapshot
+			continue
+		}
+		r := vm.persistentVolume.Spec.Capacity.Storage()
+		if r == nil {
+			logger.Warn().Str("pv_name", vm.pvName()).Msg("PersistentVolume capacity is nil, skipping")
+			continue
+		}
+		labels := ms.createPrometheusLabelsForMetric(vm)
+		ms.prometheusMetrics.volumes.PvReportedCapacityBytes.WithLabelValues(labels...).Set(float64(r.Value()))
+	}
+	logger.Info().Int("pv_count", len(vms)).Msg("Finished reporting PersistentVolume capacities")
+}
+
+// GetQuotaMapForFilesystem returns the cached quota map for a filesystem, or an error if none has
+// been fetched yet. It never fetches: populating the cache is refreshQuotaMapPerFilesystem's job,
+// invoked from batchRefreshQuotaMaps on its own schedule.
+func (ms *MetricsServer) GetQuotaMapForFilesystem(ctx context.Context, fs *apiclient.FileSystem) (*apiclient.QuotaMap, error) {
+	if fs == nil {
+		return nil, errors.New("filesystem is nil")
+	}
+	if fs.Uid == uuid.Nil {
+		return nil, errors.New("filesystem UID is empty")
+	}
+	quotaMap := ms.quotaMaps.GetQuotaMap(fs.Uid)
+	if quotaMap == nil {
+		return nil, errors.New("quota map not found for filesystem")
+	}
+	return quotaMap, nil
+}
+
+// refreshQuotaMapPerFilesystem fetches a fresh quota map for one filesystem and installs it, unless
+// the cached one is still within quotaCacheValidityDuration and force is false.
+//
+// The per-filesystem lock (from QuotaMapsPerFilesystem.GetLock) is held across the API call rather
+// than just around installing the result. That is a deliberate departure from "don't hold a lock
+// across I/O": without it, two overlapping refreshes of the same filesystem - which
+// batchRefreshQuotaMaps does not otherwise prevent if one cycle is still running when the next
+// PeriodicQuotaMapUpdater tick fires - would both see the cached map as stale, both call the API, and
+// the loser's response would overwrite the winner's regardless of which was actually newer. Holding
+// the lock makes the second refresh observe the first one's fresh result and skip the API call
+// entirely via the check below, rather than merely narrowing the window in which the double fetch can
+// happen.
+//
+// Unlike the version this was ported from, the lock is released via defer immediately after it is
+// acquired. That version locked, then called the API, and returned on the error path before the
+// deferred unlock was ever registered - so a single failed fetch left the filesystem's lock held
+// forever, and every later refresh of it (forever after) blocked with no chance of recovering.
+func (ms *MetricsServer) refreshQuotaMapPerFilesystem(ctx context.Context, fs *apiclient.FileSystem, force bool) (*apiclient.QuotaMap, error) {
+	component := "refreshQuotaMapPerFilesystem"
+	ctx, span := otel.Tracer(TracerName).Start(ctx, component)
+	defer span.End()
+	ctx = log.With().Str("trace_id", span.SpanContext().TraceID().String()).Str("span_id", span.SpanContext().SpanID().String()).Str("component", component).Logger().WithContext(ctx)
+	logger := log.Ctx(ctx)
+
+	if fs == nil {
+		return nil, errors.New("filesystem is nil")
+	}
+
+	logger.Debug().Str("filesystem", fs.Name).Msg("Updating QuotaMap for filesystem")
+
+	maplock := ms.quotaMaps.GetLock(fs.Uid)
+	maplock.Lock()
+	defer maplock.Unlock()
+
+	startTime := time.Now()
+	defer func() {
+		dur := time.Since(startTime)
+		logger.Debug().Str("filesystem", fs.Name).Dur("duration", dur).Msg("Finished updating QuotaMap for filesystem")
+		if dur > ms.getConfig().metricsFetchInterval {
+			logger.Warn().Str("filesystem", fs.Name).Dur("duration", dur).Msg("Updating QuotaMap took longer than expected, consider increasing metricsFetchInterval")
+		}
+	}()
+
+	// optimization: if the quota map is still valid, skip the update unless force is set
+	if existing := ms.quotaMaps.GetQuotaMap(fs.Uid); existing != nil && !force && existing.LastUpdate.Add(ms.getConfig().quotaCacheValidityDuration).After(time.Now()) {
+		logger.Debug().Str("filesystem", fs.Name).Msg("QuotaMap is up-to-date, skipping update")
+		return existing, nil
+	}
+
+	apiClient := ms.observedFilesystems.GetApiClient(fs.Uid)
+	if apiClient == nil {
+		return nil, fmt.Errorf("no API client found for filesystem UID %s", fs.Uid)
+	}
+
+	labelValues := []string{ms.driver.name, apiClient.ClusterGuid.String(), fs.Name}
+	ms.prometheusMetrics.server.QuotaMapRefreshInvokeCount.WithLabelValues(labelValues...).Inc()
+	defer func() {
+		dur := time.Since(startTime).Seconds()
+		ms.prometheusMetrics.server.QuotaMapRefreshDurationSeconds.WithLabelValues(labelValues...).Add(dur)
+		ms.prometheusMetrics.server.QuotaMapRefreshDurationHistogram.WithLabelValues(labelValues...).Observe(dur)
+	}()
+
+	quotaMap, err := apiClient.GetQuotaMap(ctx, fs)
+	if err != nil {
+		ms.prometheusMetrics.server.QuotaMapRefreshFailureCount.WithLabelValues(labelValues...).Inc()
+		return nil, fmt.Errorf("failed to fetch QuotaMap for filesystem %s: %w", fs.Name, err)
+	}
+	ms.prometheusMetrics.server.QuotaMapRefreshSuccessCount.WithLabelValues(labelValues...).Inc()
+
+	ms.quotaMaps.SetQuotaMap(fs.Uid, quotaMap)
+	return quotaMap, nil
+}
+
+// batchRefreshQuotaMaps refreshes the quota map for every observed filesystem, bounded to
+// quotaFetchConcurrentRequests concurrent refreshes, then asynchronously pushes the results into
+// volumeMetrics via GetMetricsFromQuotaMap. Filesystems are visited least-recently-refreshed first,
+// so a batch that cannot get through all of them (more filesystems than the concurrency limit and
+// interval allow) makes progress on the ones most overdue rather than starving them indefinitely in
+// favor of ones already fresh.
+//
+// Unlike the version this was ported from, this waits (via a WaitGroup) for every refresh to finish
+// before logging the cycle's summary. That version launched every refresh in its own goroutine and
+// then immediately computed and logged "cycle duration" and per-filesystem averages from counters
+// that had barely had a chance to be incremented - the numbers it reported described how long it took
+// to launch the batch, not how long the batch took to run.
+func (ms *MetricsServer) batchRefreshQuotaMaps(ctx context.Context, force bool) {
+	component := "batchRefreshQuotaMaps"
+	ctx, span := otel.Tracer(TracerName).Start(ctx, component)
+	defer span.End()
+	ctx = log.With().Str("trace_id", span.SpanContext().TraceID().String()).Str("span_id", span.SpanContext().SpanID().String()).Str("component", component).Logger().WithContext(ctx)
+	logger := log.Ctx(ctx)
+
+	startTime := time.Now()
+	concurrency := ms.getConfig().quotaFetchConcurrentRequests
+	sortedObservedFilesystems := ms.observedFilesystems.ByQuotaUpdateTime()
+
+	validity := ms.getConfig().quotaCacheValidityDuration
+	var countNeverUpdated, countUpToDate, countExpired int
+	for _, ofs := range sortedObservedFilesystems {
+		switch ts := ofs.LastQuotaUpdate(); {
+		case ts.IsZero():
+			countNeverUpdated++
+		case ts.Before(time.Now().Add(-validity)):
+			countExpired++
+		default:
+			countUpToDate++
+		}
+	}
+	batchSize := len(sortedObservedFilesystems)
+	logger.Info().Int("never_updated", countNeverUpdated).Int("up_to_date", countUpToDate).Int("expired", countExpired).Int("total", batchSize).Msg("Starting to update quota maps")
+	if batchSize == 0 {
+		logger.Info().Msg("No observed filesystems to update, skipping batch refresh")
+		return
+	}
+
+	ms.prometheusMetrics.server.QuotaUpdateBatchInvokeCount.Inc()
+	defer func() {
+		dur := time.Since(startTime).Seconds()
+		ms.prometheusMetrics.server.QuotaUpdateBatchSuccessCount.Inc()
+		ms.prometheusMetrics.server.QuotaUpdateBatchDurationSeconds.Add(dur)
+		ms.prometheusMetrics.server.QuotaUpdateBatchDurationHistogram.Observe(dur)
+		ms.prometheusMetrics.server.QuotaUpdateBatchSize.Set(float64(batchSize))
+	}()
+
+	var totalDurationNanos, countStarted, countSuccessful, countFailed atomic.Int64
+	cycleStart := time.Now()
+	sampledLogger := logger.Sample(&zerolog.BasicSampler{N: 50})
+	concurrencySem := make(chan struct{}, concurrency)
+	var wg sync.WaitGroup
+
+	for _, ofs := range sortedObservedFilesystems {
+		fsObj, err := ofs.GetFileSystem(ctx, time.Minute)
+		if err != nil || fsObj == nil {
+			logger.Error().Err(err).Str("fs_uid", ofs.Uid().String()).Msg("Failed to get filesystem object, skipping")
+			continue
+		}
+		select {
+		case <-ctx.Done():
+			wg.Wait()
+			return
+		case concurrencySem <- struct{}{}:
+		}
+		countStarted.Add(1)
+		wg.Add(1)
+		go func(fsObj *apiclient.FileSystem) {
+			defer wg.Done()
+			defer func() { <-concurrencySem }()
+			start := time.Now()
+			qm, err := ms.refreshQuotaMapPerFilesystem(ctx, fsObj, force)
+			dur := time.Since(start)
+			totalDurationNanos.Add(dur.Nanoseconds())
+
+			if err != nil {
+				countFailed.Add(1)
+				logger.Error().Err(err).Str("filesystem_name", fsObj.Name).Msg("Failed to update quota map for filesystem")
+			} else {
+				countSuccessful.Add(1)
+				ofs.MarkQuotaUpdated(qm.LastUpdate)
+				go ms.GetMetricsFromQuotaMap(ctx, qm)
+			}
+			sampledLogger.Info().Int64("complete_count", countSuccessful.Load()+countFailed.Load()).Dur("duration", dur).Msg("Quota maps batch refresh progress")
+		}(fsObj)
+	}
+	wg.Wait()
+
+	cycleDuration := time.Since(cycleStart)
+	countComplete := countSuccessful.Load() + countFailed.Load()
+	var avgDurationEffective, avgDurationSuccessful, parallelism float64
+	if countComplete > 0 {
+		avgDurationEffective = time.Duration(totalDurationNanos.Load()).Seconds() / float64(countComplete)
+		parallelism = float64(countComplete) / cycleDuration.Seconds()
+	}
+	if s := countSuccessful.Load(); s > 0 {
+		avgDurationSuccessful = time.Duration(totalDurationNanos.Load()).Seconds() / float64(s)
+	}
+
+	logger.Info().Dur("cycle_duration", cycleDuration).
+		Float64("parallelism", parallelism).
+		Float64("avg_duration_effective", avgDurationEffective).
+		Float64("avg_duration_successful", avgDurationSuccessful).
+		Int64("count_total", countStarted.Load()).
+		Int64("count_successful", countSuccessful.Load()).
+		Int64("count_failed", countFailed.Load()).
+		Int64("count_completed", countComplete).
+		Msg("Quota maps batch refresh completed")
+}
+
+// PeriodicQuotaMapUpdater periodically refreshes the quota maps for all observed filesystems. It is
+// the useQuotaMapsForMetrics=true counterpart to PeriodicSingleMetricsFetcher.
+func (ms *MetricsServer) PeriodicQuotaMapUpdater(ctx context.Context) {
+	component := "PeriodicQuotaMapUpdater"
+	ctx, span := otel.Tracer(TracerName).Start(ctx, component)
+	defer span.End()
+	ctx = log.With().Str("trace_id", span.SpanContext().TraceID().String()).Str("span_id", span.SpanContext().SpanID().String()).Str("component", component).Logger().WithContext(ctx)
+	logger := log.Ctx(ctx)
+
+	logger.Info().Msg("Starting PeriodicQuotaMapUpdater")
+	for {
+		select {
+		case <-ctx.Done():
+			logger.Info().Msg("PeriodicQuotaMapUpdater context cancelled, stopping...")
+			return
+		case <-time.After(time.Minute):
+			logger.Info().Msg("PeriodicQuotaMapUpdater cycle triggered")
+			ms.batchRefreshQuotaMaps(ctx, false)
+		}
+	}
+}
+
+// runSingleMetricsFetchCycle is one tick of PeriodicSingleMetricsFetcher: it guards against
+// overlapping with a still-running previous cycle via capacityFetchRunning, then runs
+// FetchMetricsOneByOne.
+//
+// Unlike the version this was ported from, the success/failure counters below are the right way
+// around. That version incremented PeriodicFetchMetricsSuccessCount when FetchMetricsOneByOne
+// returned an error, and PeriodicFetchMetricsFailureCount when it did not.
+func (ms *MetricsServer) runSingleMetricsFetchCycle(ctx context.Context) {
+	component := "PeriodicSingleMetricsFetchCycle"
+	ctx, span := otel.Tracer(TracerName).Start(ctx, component)
+	defer span.End()
+	ctx = log.With().Str("trace_id", span.SpanContext().TraceID().String()).Str("span_id", span.SpanContext().SpanID().String()).Str("component", component).Logger().WithContext(ctx)
+	logger := log.Ctx(ctx)
+
+	startTime := time.Now()
+	logger.Info().Msg("Periodic fetch metrics cycle triggered")
+	ms.prometheusMetrics.server.PeriodicFetchMetricsInvokeCount.Inc()
+
+	if !ms.capacityFetchRunning.CompareAndSwap(false, true) {
+		logger.Warn().Msg("Capacity fetch is already running, skipping this cycle. This can happen if the fetch takes longer than the configured interval.")
+		ms.prometheusMetrics.server.PeriodicFetchMetricsSkipCount.Inc()
+		return
+	}
+	defer ms.capacityFetchRunning.Store(false)
+
+	logger.Info().Int("pv_count", ms.volumeMetrics.Len()).Msg("Fetching metrics for PersistentVolumes")
+	if err := ms.FetchMetricsOneByOne(ctx); err != nil {
+		logger.Error().Err(err).Msg("Error fetching metrics")
+		ms.prometheusMetrics.server.PeriodicFetchMetricsFailureCount.Inc()
+	} else {
+		ms.prometheusMetrics.server.PeriodicFetchMetricsSuccessCount.Inc()
+	}
+	logger.Info().Dur("duration", time.Since(startTime)).Msg("Periodic fetch metrics cycle completed")
+}
+
+// PeriodicSingleMetricsFetcher periodically fetches metrics for all tracked PersistentVolumes and
+// reports them to Prometheus, one Weka API call per volume. It is only relevant when
+// useQuotaMapsForMetrics is false.
+//
+// It ticks every 30 seconds rather than once per metricsFetchInterval so that outdated volumes are
+// swept up gradually through the interval instead of all being fetched in one spike at its end -
+// fetching outstanding volumes across several ticks spreads the load on the Weka API more evenly
+// than one fetch of everything per interval would.
+func (ms *MetricsServer) PeriodicSingleMetricsFetcher(ctx context.Context) {
+	component := "PeriodicSingleMetricsFetcher"
+	ctx, span := otel.Tracer(TracerName).Start(ctx, component)
+	defer span.End()
+	ctx = log.With().Str("trace_id", span.SpanContext().TraceID().String()).Str("span_id", span.SpanContext().SpanID().String()).Str("component", component).Logger().WithContext(ctx)
+	logger := log.Ctx(ctx)
+
+	logger.Info().Str("interval", ms.getConfig().metricsFetchInterval.String()).Msg("Starting collection of WEKA metrics for PVs")
+
+	const tickInterval = 30 * time.Second
+	for {
+		select {
+		case <-ctx.Done():
+			logger.Info().Msg("Periodic fetch metrics context cancelled, stopping...")
+			return
+		case <-time.After(tickInterval):
+			// Run each cycle in its own goroutine rather than inline, so a fetch that runs long does
+			// not delay the next tick from being noticed - runSingleMetricsFetchCycle's own
+			// capacityFetchRunning check is what actually prevents them piling up.
+			go ms.runSingleMetricsFetchCycle(ctx)
+		}
+	}
+}
+
 // Start brings the metrics server up: it wires health/readiness checks into the controller-runtime
 // manager, then registers a Runnable that only does its work while this pod holds leadership (or
 // unconditionally, if leader election is disabled for the manager itself), and starts the manager.
-//
-// Only the PersistentVolume discovery goroutines are started here. Fetching statistics from Weka,
-// refreshing quota maps, and reporting to Prometheus are a separate piece not yet wired in.
 func (ms *MetricsServer) Start(ctx context.Context) {
 	component := "StartMetricsServer"
 	ctx, span := otel.Tracer(TracerName).Start(ctx, component)
@@ -627,8 +1332,16 @@ func (ms *MetricsServer) Start(ctx context.Context) {
 
 		go ms.PersistentVolumeStreamer(ctx)
 		go ms.PersistentVolumeStreamProcessor(ctx)
-		// The metrics-fetch, quota-map-refresh, and Prometheus-reporting loops are a separate piece
-		// of the metrics server and are deliberately not started here.
+		go ms.MetricsReportStreamer(ctx)
+		go ms.PeriodicPersistentVolumeCapacityReporter(ctx)
+
+		// Depending on configuration, quotas are refreshed either in filesystem-wide batches or one
+		// volume at a time; only the matching loop is started.
+		if ms.getConfig().useQuotaMapsForMetrics {
+			go ms.PeriodicQuotaMapUpdater(ctx)
+		} else {
+			go ms.PeriodicSingleMetricsFetcher(ctx)
+		}
 
 		<-ctx.Done()
 		logger.Info().Msg("Leadership lost or shutdown, stopping...")

--- a/pkg/wekafs/metricsserver.go
+++ b/pkg/wekafs/metricsserver.go
@@ -87,11 +87,6 @@ type MetricsServer struct {
 	volumeMetrics     *VolumeMetrics
 	prometheusMetrics *PrometheusMetrics
 
-	// running guards Start/Stop against being invoked more than once concurrently, and against Stop
-	// running before Start (or twice). It is an atomic.Bool rather than a field read and written
-	// under an ad hoc lock, so the two can race safely.
-	running atomic.Bool
-
 	// persistentVolumesChan carries PersistentVolumes from PersistentVolumeStreamer to
 	// PersistentVolumeStreamProcessor.
 	persistentVolumesChan chan *v1.PersistentVolume
@@ -102,20 +97,11 @@ type MetricsServer struct {
 	quotaMaps           *QuotaMapsPerFilesystem
 	observedFilesystems *ObservedFilesystems // tracks observed filesystem UIDs, their reference counts, and API clients
 
-	// wg tracks the leader-elected Runnable started in Start, so Wait blocks for exactly as long as
-	// that Runnable's context remains live (i.e. until leadership is lost or the manager shuts down).
-	wg sync.WaitGroup
-
 	// capacityFetchRunning guards PeriodicSingleMetricsFetcher's fetch cycles against overlapping
 	// invocations: if one cycle is still running when the next tick fires, the next tick is skipped
-	// rather than piling another full fetch on top of it. It is an atomic.Bool, like `running`,
-	// because both fields are read and written from more than one goroutine.
+	// rather than piling another full fetch on top of it. It is an atomic.Bool because it is read and
+	// written from more than one goroutine.
 	capacityFetchRunning atomic.Bool
-}
-
-// getBackgroundTasksWg returns the WaitGroup tracking the metrics server's background work.
-func (ms *MetricsServer) getBackgroundTasksWg() *sync.WaitGroup {
-	return &ms.wg
 }
 
 // getMounter satisfies AnyServer. The metrics server never mounts a filesystem directly - it only
@@ -177,35 +163,6 @@ func NewMetricsServer(driver *WekaFsDriver) (*MetricsServer, error) {
 	ret.prometheusMetrics.server.QuotaCacheValiditySeconds.Set(ret.getConfig().quotaCacheValidityDuration.Seconds())
 
 	return ret, nil
-}
-
-// initManager wires the metrics server's health and readiness checks into the controller-runtime
-// manager. It returns an error instead of killing the process, so Start can decide how to react.
-func (ms *MetricsServer) initManager(ctx context.Context) error {
-	if ms.driver.manager == nil {
-		return errors.New("metrics server has no controller-runtime manager, cannot start")
-	}
-
-	logger := log.Ctx(ctx).With().Str("component", "MetricsServer").Logger()
-	if err := ms.driver.manager.AddReadyzCheck("leader", func(req *http.Request) error {
-		if !ms.getConfig().enableMetricsServerLeaderElection {
-			return nil // if leader election is not enabled, we are always ready
-		}
-		select {
-		case <-ms.driver.manager.Elected():
-			return nil // we are the leader
-		default:
-			return fmt.Errorf("not the leader yet")
-		}
-	}); err != nil {
-		logger.Error().Err(err).Msg("Failed to add readiness check for leader election")
-		return fmt.Errorf("failed to add readiness check for leader election: %w", err)
-	}
-	if err := ms.driver.manager.AddHealthzCheck("alwaysReady", healthz.Ping); err != nil {
-		logger.Error().Err(err).Msg("Failed to add health check")
-		return fmt.Errorf("failed to add health check: %w", err)
-	}
-	return nil
 }
 
 // PersistentVolumeStreamer periodically lists this driver's PersistentVolumes and streams the
@@ -1298,36 +1255,38 @@ func (ms *MetricsServer) PeriodicSingleMetricsFetcher(ctx context.Context) {
 	}
 }
 
-// Start brings the metrics server up: it wires health/readiness checks into the controller-runtime
-// manager, then registers a Runnable that only does its work while this pod holds leadership (or
-// unconditionally, if leader election is disabled for the manager itself), and starts the manager.
-func (ms *MetricsServer) Start(ctx context.Context) {
-	component := "StartMetricsServer"
-	ctx, span := otel.Tracer(TracerName).Start(ctx, component)
-	defer span.End()
-	ctx = log.With().Str("trace_id", span.SpanContext().TraceID().String()).Str("span_id", span.SpanContext().SpanID().String()).Logger().WithContext(ctx)
-	logger := log.Ctx(ctx)
-
-	if !ms.running.CompareAndSwap(false, true) {
-		logger.Info().Msg("MetricsServer is already running")
-		return
+// AddToManager wires the metrics server's health/readiness checks into the controller-runtime
+// manager and registers a Runnable that only does its work while this pod holds leadership (or
+// unconditionally, if leader election is disabled for the manager itself). It must be called before
+// the manager is started - controller-runtime rejects Add calls afterward - so it never starts the
+// manager itself; that is the driver's job, once every runnable has been registered.
+func (ms *MetricsServer) AddToManager() error {
+	if ms.driver.manager == nil {
+		return errors.New("metrics server has no controller-runtime manager, cannot register")
 	}
 
-	logger.Info().Msg("Starting MetricsServer")
+	logger := log.With().Str("component", "MetricsServer").Logger()
 
-	if err := ms.initManager(ctx); err != nil {
-		logger.Error().Err(err).Msg("Failed to initialize MetricsServer manager, cannot start")
-		ms.running.Store(false)
-		return
+	if err := ms.driver.manager.AddReadyzCheck("leader", func(req *http.Request) error {
+		if !ms.getConfig().enableMetricsServerLeaderElection {
+			return nil // if leader election is not enabled, we are always ready
+		}
+		select {
+		case <-ms.driver.manager.Elected():
+			return nil // we are the leader
+		default:
+			return fmt.Errorf("not the leader yet")
+		}
+	}); err != nil {
+		logger.Error().Err(err).Msg("Failed to add readiness check for leader election")
+		return fmt.Errorf("failed to add readiness check for leader election: %w", err)
+	}
+	if err := ms.driver.manager.AddHealthzCheck("alwaysReady", healthz.Ping); err != nil {
+		logger.Error().Err(err).Msg("Failed to add health check")
+		return fmt.Errorf("failed to add health check: %w", err)
 	}
 
-	// give the manager's cache a moment to sync before the first PersistentVolume fetch
-	time.Sleep(1 * time.Second)
-	logger.Info().Msg("started manager, starting to fetch PersistentVolumes")
-
-	ms.wg.Add(1)
-	err := ms.driver.manager.Add(manager.RunnableFunc(func(ctx context.Context) error {
-		defer ms.wg.Done()
+	if err := ms.driver.manager.Add(manager.RunnableFunc(func(ctx context.Context) error {
 		logger.Info().Msg("Leader elected, starting MetricsServer processors")
 
 		go ms.PersistentVolumeStreamer(ctx)
@@ -1346,39 +1305,10 @@ func (ms *MetricsServer) Start(ctx context.Context) {
 		<-ctx.Done()
 		logger.Info().Msg("Leadership lost or shutdown, stopping...")
 		return nil
-	}))
-	if err != nil {
+	})); err != nil {
 		logger.Error().Err(err).Msg("Failed to add Runnable to manager")
-		ms.wg.Done()
-		ms.running.Store(false)
-		return
+		return fmt.Errorf("failed to add MetricsServer runnable to manager: %w", err)
 	}
 
-	go func() {
-		if err := ms.driver.manager.Start(ctx); err != nil {
-			logger.Error().Err(err).Msg("MetricsServer manager exited with error")
-		}
-	}()
-}
-
-// Wait blocks until the metrics server's leader-elected work has stopped, i.e. until leadership is
-// lost or the manager shuts down.
-func (ms *MetricsServer) Wait() {
-	ms.wg.Wait()
-}
-
-// Stop tears down the metrics server's channels. It is safe to call on a nil receiver, and safe to
-// call more than once or before Start - both are no-ops.
-func (ms *MetricsServer) Stop(ctx context.Context) {
-	if ms == nil {
-		return // Nothing to stop
-	}
-	if !ms.running.CompareAndSwap(true, false) {
-		return // already stopped, or never started
-	}
-	// The channels are deliberately not closed. Their producers run until the context is cancelled
-	// and send inside a select on ctx.Done, and a select gives no protection against sending on a
-	// closed channel - closing one under a live producer panics. The consumers already exit on
-	// ctx.Done, so closing buys nothing, and the channels are collected once unreferenced.
-	log.Ctx(ctx).Info().Msg("Metrics server stopped")
+	return nil
 }

--- a/pkg/wekafs/metricsserver.go
+++ b/pkg/wekafs/metricsserver.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"go.opentelemetry.io/otel"
@@ -163,6 +164,17 @@ func NewMetricsServer(driver *WekaFsDriver) (*MetricsServer, error) {
 	ret.prometheusMetrics.server.QuotaCacheValiditySeconds.Set(ret.getConfig().quotaCacheValidityDuration.Seconds())
 
 	return ret, nil
+}
+
+// MetricsServerCollectors returns the metrics server's own Prometheus collectors for main.go to
+// register, or nil if the metrics server is disabled or failed to construct. Nothing in this
+// package calls prometheus.MustRegister - that only ever happens in main.go, once for the whole
+// process, so importing this package never has the side effect of registering anything.
+func (driver *WekaFsDriver) MetricsServerCollectors() []prometheus.Collector {
+	if driver.metricsServer == nil {
+		return nil
+	}
+	return driver.metricsServer.prometheusMetrics.Collectors()
 }
 
 // PersistentVolumeStreamer periodically lists this driver's PersistentVolumes and streams the

--- a/pkg/wekafs/metricsserver.go
+++ b/pkg/wekafs/metricsserver.go
@@ -171,10 +171,10 @@ func NewMetricsServer(driver *WekaFsDriver) (*MetricsServer, error) {
 // package calls prometheus.MustRegister - that only ever happens in main.go, once for the whole
 // process, so importing this package never has the side effect of registering anything.
 func (driver *WekaFsDriver) MetricsServerCollectors() []prometheus.Collector {
-	if driver.metricsServer == nil {
+	if driver.ms == nil {
 		return nil
 	}
-	return driver.metricsServer.prometheusMetrics.Collectors()
+	return driver.ms.prometheusMetrics.Collectors()
 }
 
 // PersistentVolumeStreamer periodically lists this driver's PersistentVolumes and streams the

--- a/pkg/wekafs/utilities.go
+++ b/pkg/wekafs/utilities.go
@@ -653,7 +653,8 @@ func GetCsiPluginMode(mode *string) CsiPluginMode {
 	switch ret {
 	case CsiModeNode,
 		CsiModeController,
-		CsiModeAll:
+		CsiModeAll,
+		CsiModeMetricsServer:
 		return ret
 	default:
 		log.Fatal().Str("required_plugin_mode", string(ret)).Msg("Unsupported plugin mode")

--- a/pkg/wekafs/utilities.go
+++ b/pkg/wekafs/utilities.go
@@ -675,9 +675,16 @@ func stripUnnecessaryPVFields(obj interface{}) (interface{}, error) {
 			Name:            pv.ObjectMeta.Name,
 			UID:             pv.ObjectMeta.UID,
 			ResourceVersion: pv.ObjectMeta.ResourceVersion,
+			// Needed by the metrics server (processSinglePersistentVolume) to skip a volume that is
+			// already being deleted rather than tracking it right before it disappears.
+			DeletionTimestamp: pv.ObjectMeta.DeletionTimestamp,
 		},
 		Spec: v1.PersistentVolumeSpec{
 			Capacity: pv.Spec.Capacity, // Need for capacity validation
+			// ClaimRef and StorageClassName are only read by the metrics server, to label the
+			// per-volume Prometheus series it reports (createPrometheusLabelsForMetric).
+			ClaimRef:         pv.Spec.ClaimRef,
+			StorageClassName: pv.Spec.StorageClassName,
 		},
 		Status: v1.PersistentVolumeStatus{
 			Phase: pv.Status.Phase, // Need to check if Bound or Released
@@ -694,6 +701,9 @@ func stripUnnecessaryPVFields(obj interface{}) (interface{}, error) {
 			ControllerPublishSecretRef: pv.Spec.CSI.ControllerPublishSecretRef,
 			NodeStageSecretRef:         pv.Spec.CSI.NodeStageSecretRef,
 			NodePublishSecretRef:       pv.Spec.CSI.NodePublishSecretRef,
+			// Needed by the metrics server (ensurePersistentVolumeValid) to check the volume type is
+			// one it knows how to report on.
+			VolumeAttributes: pv.Spec.CSI.VolumeAttributes,
 		}
 	}
 

--- a/pkg/wekafs/volume.go
+++ b/pkg/wekafs/volume.go
@@ -70,6 +70,14 @@ type Volume struct {
 	// inodeId caches the root inode ID of the volume, once resolved, so repeated lookups (e.g. from
 	// the metrics server, which polls quotas by inode) don't re-resolve or re-mount for it every time.
 	inodeId uint64
+
+	// lastUsageStats caches the metrics server's last one-by-one Weka fetch for this volume (only
+	// used on the useQuotaMapsForMetrics=false path), so a fetch cycle that runs before
+	// quotaCacheValidityDuration has elapsed can serve the cached reading instead of hitting the API
+	// again. There is no equivalent for the quota-map path: a filesystem's quota map is already
+	// cached at the filesystem level by QuotaMapsPerFilesystem, so caching it a second time here
+	// would buy nothing.
+	lastUsageStats *UsageStats
 }
 
 func (v *Volume) hasCustomEncryptionSettings() bool {

--- a/pkg/wekafs/volume.go
+++ b/pkg/wekafs/volume.go
@@ -66,6 +66,10 @@ type Volume struct {
 
 	fileSystemObject *apiclient.FileSystem
 	snapshotObject   *apiclient.Snapshot
+
+	// inodeId caches the root inode ID of the volume, once resolved, so repeated lookups (e.g. from
+	// the metrics server, which polls quotas by inode) don't re-resolve or re-mount for it every time.
+	inodeId uint64
 }
 
 func (v *Volume) hasCustomEncryptionSettings() bool {
@@ -844,8 +848,18 @@ func (v *Volume) getInodeId(ctx context.Context) (inode uint64, retErr error) {
 
 	logger := log.Ctx(ctx).With().Str("volume_id", v.GetId()).Logger()
 
+	if v.inodeId != 0 {
+		logger.Trace().Uint64("inode_id", v.inodeId).Msg("Using cached inode ID")
+		return v.inodeId, nil
+	}
+
 	if v.apiClient.SupportsResolvePathToInode() {
-		return v.getInodeIdFromApi(ctx)
+		inodeId, err := v.getInodeIdFromApi(ctx)
+		if err != nil {
+			return inodeId, err
+		}
+		v.inodeId = inodeId
+		return v.inodeId, nil
 	}
 	err, unmount := v.MountUnderlyingFS(ctx)
 	defer deferUmount(unmount, &retErr)
@@ -866,7 +880,8 @@ func (v *Volume) getInodeId(ctx context.Context) (inode uint64, retErr error) {
 		return 0, errors.New(fmt.Sprintf("failed to obtain inodeId from %s", v.mountPath))
 	}
 	logger.Debug().Uint64("inode_id", stat.Ino).Msg("Succesfully fetched root inode ID")
-	return stat.Ino, nil
+	v.inodeId = stat.Ino
+	return v.inodeId, nil
 }
 
 func (v *Volume) getInodeIdFromApi(ctx context.Context) (uint64, error) {

--- a/pkg/wekafs/volumemetrics.go
+++ b/pkg/wekafs/volumemetrics.go
@@ -26,6 +26,15 @@ type VolumeMetric struct {
 	pvUID types.UID
 }
 
+// pvName is how an operator identifies this volume: errors and logs from the metrics server name
+// the PersistentVolume, not the internal volume id.
+func (vm *VolumeMetric) pvName() string {
+	if vm == nil || vm.persistentVolume == nil {
+		return ""
+	}
+	return vm.persistentVolume.Name
+}
+
 // volumeKey locates a volume on the cluster. Quotas are fetched per filesystem and keyed by inode,
 // so this is what a quota map entry has to be matched back to.
 type volumeKey struct {

--- a/tests/csi-sanity/docker-compose-sanity.yaml
+++ b/tests/csi-sanity/docker-compose-sanity.yaml
@@ -3,7 +3,7 @@ version: '3.8'
 services:
   plugin_controller:
     image: sanity:${IMAGE_TAG:-latest}
-    command: timeout 10m wekafsplugin -nodeid 1 -v ${PLUGIN_VERBOSITY} --allowinsecurehttps --endpoint=unix://tmp/weka-csi-test/controller.sock --csimode=controller -allowautofscreation -allowautofsexpansion -allowsnapshotsoflegacyvolumes -alwaysallowsnapshotvolumes -usenfs -interfacegroupname=NFS ${TRACING_SETTING}
+    command: timeout 10m wekafsplugin -nodeid 1 -v ${PLUGIN_VERBOSITY} --allowinsecurehttps --endpoint=unix://tmp/weka-csi-test/controller.sock --csimode=controller -allowautofscreation -allowautofsexpansion -allowsnapshotsofdirectoryvolumes -alwaysallowsnapshotvolumes -usenfs -interfacegroupname=NFS ${TRACING_SETTING}
     volumes:
       - test-volume:/tmp/weka-csi-test
     privileged: true
@@ -19,7 +19,7 @@ services:
     init: true
   plugin_node:
     image: sanity:${IMAGE_TAG:-latest}
-    command: timeout 10m wekafsplugin -nodeid 1 -v ${PLUGIN_VERBOSITY} --allowinsecurehttps --endpoint=unix://tmp/weka-csi-test/node.sock --csimode=node -allowautofscreation -allowautofsexpansion -allowsnapshotsoflegacyvolumes -alwaysallowsnapshotvolumes -usenfs -interfacegroupname=NFS ${TRACING_SETTING}
+    command: timeout 10m wekafsplugin -nodeid 1 -v ${PLUGIN_VERBOSITY} --allowinsecurehttps --endpoint=unix://tmp/weka-csi-test/node.sock --csimode=node -allowautofscreation -allowautofsexpansion -allowsnapshotsofdirectoryvolumes -alwaysallowsnapshotvolumes -usenfs -interfacegroupname=NFS ${TRACING_SETTING}
     volumes:
       - test-volume:/tmp/weka-csi-test
     privileged: true


### PR DESCRIPTION
### TL;DR
Ships the WEKA CSI metrics server end to end: its own binary, container image, Helm charts, and CI.

### What changed?
- New standalone binary/image `quay.io/weka.io/csi-metricsserver`, also runnable via `--csimode=metricsserver`
- New standalone `csi-metricsserver` Helm chart
- The `csi-wekafsplugin` chart can now deploy the same component too (off by default, since running both against one WEKA cluster doubles quota API load for no extra data)
- Health and readiness are served on a single port, `HEALTH_PORT` (default 9196)
- CI builds and publishes both images and charts

### How to test?
1. Deploy the `csi-metricsserver` chart, or set the plugin chart's metrics-server option to enabled
2. Confirm the pod becomes ready and `/metrics` exposes per-volume capacity metrics

### Why make this change?
Operators need per-volume WEKA capacity metrics without growing the CSI controller/node footprint. Shipping this as its own deployable component lets it be enabled and scaled independently of the CSI plugin.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds cluster-wide read RBAC on PersistentVolumes and referenced Secrets for metrics collection, plus new publish/deploy paths; misconfiguration (two collectors on one cluster) increases WEKA API load rather than breaking storage paths.
> 
> **Overview**
> This PR **delivers the WEKA CSI metrics server as its own product**: a dedicated `cmd/metricsserver` entrypoint (same runtime as `--csimode=metricsserver`), **UBI-based images** (`Dockerfile-metricsserver` / GHA variant), and a new **`csi-metricsserver` Helm chart** with Deployment, RBAC, PodMonitor, and OpenShift SCC.
> 
> The **main CSI plugin chart** can optionally deploy the same workload (`metricsServer.enabled`, default **off**), with install notes warning against running **both** charts against one cluster because quota polling would double WEKA API load. Image references move to **`quay.io/weka.io/csi-metricsserver`**, and the plugin image also bundles the binary for compatibility.
> 
> **CI/release** gains parallel jobs to build/push the metrics image, package/upload the metrics chart to S3, and chart-test it in kind; release flow versions **`csi-metricsserver`** alongside the plugin chart. A new **Dagger** module automates Go build, image publish, and Helm push/deploy for internal registries. Minor fixes include using **`AWS_REGION`** (not the secret key) in Helm S3 steps and dropping meaningless `pull_request` checkout refs on **workflow_dispatch** release jobs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71a4ccd23a09a4e2b1fd864fc364a4481d9edaa3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->