### PR TITLE
fix: decline unimplemented CSI RPCs instead of panicking

### DIFF
--- a/pkg/wekafs/controllerserver.go
+++ b/pkg/wekafs/controllerserver.go
@@ -83,22 +83,22 @@ func (cs *ControllerServer) getApiStore() *ApiStore {
 
 //goland:noinspection GoUnusedParameter
 func (cs *ControllerServer) ControllerPublishVolume(c context.Context, request *csi.ControllerPublishVolumeRequest) (*csi.ControllerPublishVolumeResponse, error) {
-	panic("implement me")
+	return nil, status.Error(codes.Unimplemented, "ControllerPublishVolume is not supported: the driver does not advertise PUBLISH_UNPUBLISH_VOLUME")
 }
 
 //goland:noinspection GoUnusedParameter
 func (cs *ControllerServer) ControllerUnpublishVolume(c context.Context, request *csi.ControllerUnpublishVolumeRequest) (*csi.ControllerUnpublishVolumeResponse, error) {
-	panic("implement me")
+	return nil, status.Error(codes.Unimplemented, "ControllerUnpublishVolume is not supported: the driver does not advertise PUBLISH_UNPUBLISH_VOLUME")
 }
 
 //goland:noinspection GoUnusedParameter
 func (cs *ControllerServer) GetCapacity(c context.Context, request *csi.GetCapacityRequest) (*csi.GetCapacityResponse, error) {
-	panic("implement me")
+	return nil, status.Error(codes.Unimplemented, "GetCapacity is not supported: the driver does not advertise GET_CAPACITY")
 }
 
 //goland:noinspection GoUnusedParameter
 func (cs *ControllerServer) ControllerModifyVolume(context.Context, *csi.ControllerModifyVolumeRequest) (*csi.ControllerModifyVolumeResponse, error) {
-	panic("implement me")
+	return nil, status.Error(codes.Unimplemented, "ControllerModifyVolume is not supported: the driver does not advertise MODIFY_VOLUME")
 }
 
 func NewControllerServer(nodeID string, api *ApiStore, mounter AnyMounter, config *DriverConfig, manager ctrl.Manager) *ControllerServer {
@@ -821,7 +821,7 @@ func (cs *ControllerServer) DeleteSnapshot(ctx context.Context, req *csi.DeleteS
 
 //goland:noinspection GoUnusedParameter
 func (cs *ControllerServer) ListSnapshots(ctx context.Context, req *csi.ListSnapshotsRequest) (*csi.ListSnapshotsResponse, error) {
-	panic("Implement me")
+	return nil, status.Error(codes.Unimplemented, "ListSnapshots is not supported: the driver does not advertise LIST_SNAPSHOTS")
 }
 
 //goland:noinspection GoUnusedParameter

--- a/pkg/wekafs/nodeserver.go
+++ b/pkg/wekafs/nodeserver.go
@@ -81,7 +81,7 @@ func (ns *NodeServer) getMounter() AnyMounter {
 
 //goland:noinspection GoUnusedParameter
 func (ns *NodeServer) NodeExpandVolume(ctx context.Context, request *csi.NodeExpandVolumeRequest) (*csi.NodeExpandVolumeResponse, error) {
-	panic("implement me")
+	return nil, status.Error(codes.Unimplemented, "NodeExpandVolume is not supported: the driver does not advertise the node EXPAND_VOLUME capability")
 }
 
 func (ns *NodeServer) NodeGetVolumeStats(ctx context.Context, req *csi.NodeGetVolumeStatsRequest) (*csi.NodeGetVolumeStatsResponse, error) {
@@ -606,12 +606,12 @@ FORCEUMOUNT:
 
 //goland:noinspection GoUnusedParameter
 func (ns *NodeServer) NodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRequest) (*csi.NodeStageVolumeResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "NodeStageVolume is not supported")
+	return nil, status.Error(codes.Unimplemented, "NodeStageVolume is not supported: the driver does not advertise STAGE_UNSTAGE_VOLUME")
 }
 
 //goland:noinspection GoUnusedParameter
 func (ns *NodeServer) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstageVolumeRequest) (*csi.NodeUnstageVolumeResponse, error) {
-	return nil, status.Error(codes.Unimplemented, "NodeUnstageVolume is not supported")
+	return nil, status.Error(codes.Unimplemented, "NodeUnstageVolume is not supported: the driver does not advertise STAGE_UNSTAGE_VOLUME")
 }
 
 //goland:noinspection GoUnusedParameter

--- a/pkg/wekafs/unimplemented_test.go
+++ b/pkg/wekafs/unimplemented_test.go
@@ -1,0 +1,118 @@
+package wekafs
+
+import (
+	"context"
+	"testing"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// The RPCs the driver does not implement must decline, not panic. A panic in a gRPC handler takes
+// down the whole controller or node process, and with it every other volume operation in flight on
+// that pod - so an unsupported call from a container orchestrator or a sidecar probing for a
+// capability would be a fleet-wide outage rather than one failed request.
+//
+// The servers are constructed bare on purpose: these handlers must not touch driver state, which is
+// also what lets them answer safely before the driver is fully wired up.
+func TestUnimplementedRPCsDeclineInsteadOfPanicking(t *testing.T) {
+	ctx := context.Background()
+	cs := &ControllerServer{}
+	ns := &NodeServer{}
+
+	calls := map[string]func() error{
+		"ControllerPublishVolume": func() error {
+			_, err := cs.ControllerPublishVolume(ctx, &csi.ControllerPublishVolumeRequest{})
+			return err
+		},
+		"ControllerUnpublishVolume": func() error {
+			_, err := cs.ControllerUnpublishVolume(ctx, &csi.ControllerUnpublishVolumeRequest{})
+			return err
+		},
+		"GetCapacity": func() error {
+			_, err := cs.GetCapacity(ctx, &csi.GetCapacityRequest{})
+			return err
+		},
+		"ControllerModifyVolume": func() error {
+			_, err := cs.ControllerModifyVolume(ctx, &csi.ControllerModifyVolumeRequest{})
+			return err
+		},
+		"ListSnapshots": func() error {
+			_, err := cs.ListSnapshots(ctx, &csi.ListSnapshotsRequest{})
+			return err
+		},
+		"NodeStageVolume": func() error {
+			_, err := ns.NodeStageVolume(ctx, &csi.NodeStageVolumeRequest{})
+			return err
+		},
+		"NodeUnstageVolume": func() error {
+			_, err := ns.NodeUnstageVolume(ctx, &csi.NodeUnstageVolumeRequest{})
+			return err
+		},
+		"NodeExpandVolume": func() error {
+			_, err := ns.NodeExpandVolume(ctx, &csi.NodeExpandVolumeRequest{})
+			return err
+		},
+	}
+
+	for name, call := range calls {
+		t.Run(name, func(t *testing.T) {
+			// A panic here fails this subtest rather than tearing down the whole run, so one
+			// regression does not hide the state of the others.
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("panicked instead of returning an error: %v", r)
+				}
+			}()
+
+			err := call()
+			if err == nil {
+				t.Fatal("returned no error, but the RPC is not implemented")
+			}
+			if got := status.Code(err); got != codes.Unimplemented {
+				t.Errorf("returned code %v, want %v - a CO only knows to stop asking on Unimplemented",
+					got, codes.Unimplemented)
+			}
+		})
+	}
+}
+
+// Every RPC above must stay absent from the advertised capabilities: advertising one the driver
+// answers with Unimplemented would have the CO call it and fail, which is the contradiction this
+// pairing exists to prevent.
+func TestUnimplementedRPCsAreNotAdvertised(t *testing.T) {
+	forbiddenController := []csi.ControllerServiceCapability_RPC_Type{
+		csi.ControllerServiceCapability_RPC_PUBLISH_UNPUBLISH_VOLUME,
+		csi.ControllerServiceCapability_RPC_GET_CAPACITY,
+		csi.ControllerServiceCapability_RPC_LIST_SNAPSHOTS,
+		csi.ControllerServiceCapability_RPC_MODIFY_VOLUME,
+	}
+	// Snapshot and clone support are config-gated, so a zero config would leave the capability list
+	// at its smallest and make this pass without checking much. Turn on everything that can be
+	// turned on without a live manager, so the assertion runs against the widest set the driver
+	// ever advertises.
+	maximal := &DriverConfig{advertiseSnapshotSupport: true, advertiseVolumeCloneSupport: true}
+	cs := NewControllerServer("test-node", nil, nil, maximal, nil)
+	if len(cs.caps) == 0 {
+		t.Fatal("no controller capabilities advertised - this test would pass without checking anything")
+	}
+	for _, c := range cs.caps {
+		for _, forbidden := range forbiddenController {
+			if c.GetRpc().GetType() == forbidden {
+				t.Errorf("controller advertises %v, but the RPC returns Unimplemented", forbidden)
+			}
+		}
+	}
+
+	ns := NewNodeServer("test-node", 0, nil, nil, maximal)
+	if len(ns.caps) == 0 {
+		t.Fatal("no node capabilities advertised - this test would pass without checking anything")
+	}
+	for _, c := range ns.caps {
+		if c.GetRpc().GetType() == csi.NodeServiceCapability_RPC_STAGE_UNSTAGE_VOLUME ||
+			c.GetRpc().GetType() == csi.NodeServiceCapability_RPC_EXPAND_VOLUME {
+			t.Errorf("node advertises %v, but the RPC returns Unimplemented", c.GetRpc().GetType())
+		}
+	}
+}


### PR DESCRIPTION
### TL;DR
Unsupported CSI calls used to crash the controller/node process; they now return a normal "unimplemented" response.

### What changed?
- `ControllerPublishVolume`, `ControllerUnpublishVolume`, `GetCapacity`, `ControllerModifyVolume`, `ListSnapshots`, and `NodeExpandVolume` now return `codes.Unimplemented` instead of panicking
- None of the six is reachable today — the driver never advertises the capabilities they require — but this changes what happens the day something does call one
- Adds tests asserting none of the six panics, and that the driver never advertises the capabilities that would make them reachable

### How to test?
Covered only by automated tests.

### Why make this change?
A panic in a gRPC handler kills the whole controller or node process, aborting every other volume operation in flight on that pod. Returning "unimplemented" contains the failure to the single unsupported request instead of causing a fleet-wide outage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Defensive gRPC behavior for RPCs the driver does not advertise; normal volume workflows are unchanged and covered by new unit tests.
> 
> **Overview**
> Unsupported CSI controller and node RPCs now return **`codes.Unimplemented`** with messages tied to the missing capability instead of **`panic`**, so a mistaken or probing call fails one request instead of crashing the whole CSI pod.
> 
> **Controller:** `ControllerPublishVolume`, `ControllerUnpublishVolume`, `GetCapacity`, `ControllerModifyVolume`, and `ListSnapshots` are updated from panics to explicit unimplemented errors.
> 
> **Node:** `NodeExpandVolume` is updated the same way; **`NodeStageVolume`** / **`NodeUnstageVolume`** keep declining but their error text now states that **`STAGE_UNSTAGE_VOLUME`** is not advertised.
> 
> **Tests:** New `unimplemented_test.go` checks those handlers never panic, return **`Unimplemented`**, and that maximal capability advertisement still excludes the RPCs that answer that way.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b0ff43ff04849153391bdc359147ae9e96df969. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->