### PR TITLE
fix(CSI-353): take the actual SELinux state rather than the desired one

### DIFF
--- a/pkg/wekafs/selinux_test.go
+++ b/pkg/wekafs/selinux_test.go
@@ -1,0 +1,57 @@
+package wekafs
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// SELinux state must come from the kernel, not from configuration.
+//
+// The case that made this necessary is "config file says enforcing": the plugin image installs
+// container-selinux and therefore ships its own /etc/selinux/config saying SELINUX=enforcing, so
+// reading that file from inside the container reported enforcing on every cluster - including hosts
+// with no SELinux at all - and put an fscontext on every mount.
+func TestSelinuxStatusComesFromTheKernel(t *testing.T) {
+	ctx := context.Background()
+
+	for name, tc := range map[string]struct {
+		enforceContents string // "" means the path does not exist, as on a host without selinuxfs
+		want            bool
+	}{
+		"enforcing":                     {"1", true},
+		"enforcing with trailing space": {"1\n", true},
+		// Permissive still labels, so a mount made without a context would be labelled wrong and
+		// start failing the moment the host is switched to enforcing.
+		"permissive":                 {"0", true},
+		"no selinuxfs on this host":  {"", false},
+		"unreadable/unexpected byte": {"banana", false},
+		"empty file":                 {" ", false},
+	} {
+		t.Run(name, func(t *testing.T) {
+			enforcePath := filepath.Join(t.TempDir(), "enforce")
+			if tc.enforceContents != "" {
+				if err := os.WriteFile(enforcePath, []byte(tc.enforceContents), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if got := selinuxEnabledAt(ctx, enforcePath); got != tc.want {
+				t.Errorf("selinuxEnabledAt(%q) = %v, want %v", tc.enforceContents, got, tc.want)
+			}
+		})
+	}
+}
+
+// The old implementation read this file, and the image ships one saying enforcing. Its presence must
+// no longer influence the answer.
+func TestSelinuxConfigFileIsNotConsulted(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "config"), []byte("SELINUX=enforcing\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// No enforce file alongside it: the kernel has no SELinux, whatever the config claims.
+	if selinuxEnabledAt(context.Background(), filepath.Join(dir, "enforce")) {
+		t.Error("reported SELinux enabled with no selinuxfs present - configuration is being trusted over the kernel")
+	}
+}

--- a/pkg/wekafs/utilities.go
+++ b/pkg/wekafs/utilities.go
@@ -597,30 +597,44 @@ func isWekaRunning(ctx context.Context) bool {
 	return true
 }
 
+// getSelinuxStatus reports whether the host kernel has SELinux active, enforcing or permissive.
+//
+// It reads the kernel's own state through selinuxfs rather than /etc/selinux/config, which describes
+// what the system was configured to do, not what it is doing - and which, read from inside a
+// container, describes the image rather than the host. The plugin image installs container-selinux
+// and so ships its own /etc/selinux/config saying SELINUX=enforcing, which meant every node on a
+// cluster without SELinux was told SELinux was enforcing and had a context added to every mount.
+//
+// Permissive counts as active on purpose: the labels are still applied by the kernel, so a mount
+// made without a context there would be labelled wrong and start failing the moment the host is
+// switched to enforcing.
+//
+// The chart only mounts /sys/fs/selinux into the container for OpenShift or selinuxSupport=enforced,
+// which is also when -selinux-support is passed - so an absent path means SELinux was not asked for,
+// and reporting false is right.
 func getSelinuxStatus(ctx context.Context) bool {
-	logger := log.Ctx(ctx)
-	// check if we have /etc/selinux/config
-	// if it exists, we can check if selinux is enforced or not
-	selinuxConf := "/etc/selinux/config"
-	file, err := os.Open(selinuxConf)
+	return selinuxEnabledAt(ctx, "/sys/fs/selinux/enforce")
+}
+
+// selinuxEnabledAt is getSelinuxStatus with the selinuxfs path injected, so the states can be tested
+// without a host that has SELinux.
+func selinuxEnabledAt(ctx context.Context, enforcePath string) bool {
+	data, err := os.ReadFile(enforcePath)
 	if err != nil {
+		if !os.IsNotExist(err) {
+			log.Ctx(ctx).Error().Err(err).Str("filename", enforcePath).Msg("Failed to read SELinux state")
+		}
 		return false
 	}
-	defer func() { _ = file.Close() }()
 
-	scanner := bufio.NewScanner(file)
-	for scanner.Scan() {
-		line := scanner.Text()
-		if strings.Contains(line, "SELINUX=enforcing") {
-			// no need to repeat each time, just set the selinuxSupport to true
-			return true
-		}
+	switch strings.TrimSpace(string(data)) {
+	case "1": // enforcing
+		return true
+	case "0": // permissive
+		return true
+	default:
+		return false
 	}
-
-	if err := scanner.Err(); err != nil {
-		logger.Error().Err(err).Str("filename", selinuxConf).Msg("Failed to read SELinux config file")
-	}
-	return false
 }
 
 // Die used to intentionally panic and exit, while updating termination log

--- a/pkg/wekafs/utilities.go
+++ b/pkg/wekafs/utilities.go
@@ -596,30 +596,48 @@ func isWekaRunning(ctx context.Context) bool {
 	return true
 }
 
+// getSelinuxStatus reports whether the host kernel has SELinux active, enforcing or permissive.
+//
+// It reads the kernel's own state through selinuxfs rather than /etc/selinux/config, which describes
+// what the system was configured to do, not what it is doing - and which, read from inside a
+// container, describes the image rather than the host. The plugin image installs container-selinux
+// and so ships its own /etc/selinux/config saying SELINUX=enforcing, which meant every node on a
+// cluster without SELinux was told SELinux was enforcing and had a context added to every mount.
+//
+// Permissive counts as active on purpose: the labels are still applied by the kernel, so a mount
+// made without a context there would be labelled wrong and start failing the moment the host is
+// switched to enforcing.
+//
+// The chart mounts /sys/fs/selinux into the node container for OpenShift or selinuxSupport=enforced,
+// but passes -selinux-support only for the latter. Under selinuxSupport=enforced the mounter has
+// already answered true before reaching here, so OpenShift is the case this read actually decides.
+//
+// An absent path means SELinux support was never asked for, and reporting false is right. The
+// controller never gets the mount and so always reports false: its mounts are consumed by the
+// privileged plugin itself rather than propagated to a workload container, so they need no context.
 func getSelinuxStatus(ctx context.Context) bool {
-	logger := log.Ctx(ctx)
-	// check if we have /etc/selinux/config
-	// if it exists, we can check if selinux is enforced or not
-	selinuxConf := "/etc/selinux/config"
-	file, err := os.Open(selinuxConf)
+	return selinuxEnabledAt(ctx, "/sys/fs/selinux/enforce")
+}
+
+// selinuxEnabledAt is getSelinuxStatus with the selinuxfs path injected, so the states can be tested
+// without a host that has SELinux.
+func selinuxEnabledAt(ctx context.Context, enforcePath string) bool {
+	data, err := os.ReadFile(enforcePath)
 	if err != nil {
+		if !os.IsNotExist(err) {
+			log.Ctx(ctx).Error().Err(err).Str("filename", enforcePath).Msg("Failed to read SELinux state")
+		}
 		return false
 	}
-	defer func() { _ = file.Close() }()
 
-	scanner := bufio.NewScanner(file)
-	for scanner.Scan() {
-		line := scanner.Text()
-		if strings.Contains(line, "SELINUX=enforcing") {
-			// no need to repeat each time, just set the selinuxSupport to true
-			return true
-		}
+	switch strings.TrimSpace(string(data)) {
+	case "1": // enforcing
+		return true
+	case "0": // permissive
+		return true
+	default:
+		return false
 	}
-
-	if err := scanner.Err(); err != nil {
-		logger.Error().Err(err).Str("filename", selinuxConf).Msg("Failed to read SELinux config file")
-	}
-	return false
 }
 
 // Die used to intentionally panic and exit, while updating termination log


### PR DESCRIPTION
### TL;DR
On nodes that do not run SELinux, Weka mounts are no longer given an SELinux context (CSI-353).

### What changed?
- SELinux is detected from the node kernel's live state, not from a configuration file the plugin image carries its own copy of
- Permissive nodes now count as SELinux-enabled
- OpenShift and `selinuxSupport: enforced` are unchanged

### How to test?
1. Deploy with the default `selinuxSupport: off` on nodes without SELinux
2. Create a PVC and attach it to a pod
3. On that node, run `mount | grep wekafs` — the options no longer contain `fscontext=` (`context=` for NFS)
4. Repeat with `selinuxSupport: enforced` on an SELinux node — the context is still applied

### Why make this change?
The plugin image ships its own SELinux configuration saying enforcing, so wherever the host's copy was not mounted over it the driver labelled every mount as if SELinux were on. Nothing failed, since a kernel without SELinux discards a context it cannot apply — but the mounts were labelled wrong from the start.
