### PR TITLE
fix(CSI-344): stop reporting failed NFS permission deletions as successful

### DIFF
--- a/pkg/wekafs/apiclient/filesystem.go
+++ b/pkg/wekafs/apiclient/filesystem.go
@@ -338,7 +338,14 @@ func (a *ApiClient) EnsureNoNfsPermissionsForFilesystem(ctx context.Context, fsN
 		logger.Debug().Int("permissions", len(*permissions)).Str("filesystem", fsName).Msg("Found stale NFS permissions, deleting")
 	}
 	for _, p := range *permissions {
+		// The request layer already retries transient failures five times with backoff, so anything
+		// still failing here is not worth another loop around it.
 		err = a.DeleteNfsPermission(ctx, &NfsPermissionDeleteRequest{Uid: p.Uid})
+		if errors.Is(err, ObjectNotFoundError) {
+			// Someone else removed it first, which is the state this function exists to reach.
+			logger.Trace().Str("permission", p.Uid.String()).Str("filesystem", p.Filesystem).Msg("NFS permission already gone")
+			continue
+		}
 		if err != nil {
 			logger.Error().Err(err).Str("permission", p.Uid.String()).Str("filesystem", p.Filesystem).Str("client_group", p.Group).Msg("Failed to delete NFS permission")
 			return err

--- a/pkg/wekafs/apiclient/nfs.go
+++ b/pkg/wekafs/apiclient/nfs.go
@@ -323,19 +323,31 @@ func (a *ApiClient) DeleteNfsPermission(ctx context.Context, r *NfsPermissionDel
 	}
 	apiResponse := &ApiResponse{}
 	err := a.Delete(ctx, r.getApiUrl(a), nil, nil, apiResponse)
-	if err != nil {
-		switch t := err.(type) {
-		case *ApiNotFoundError:
-			return ObjectNotFoundError
-		case *ApiBadRequestError:
-			for _, c := range t.ApiResponse.ErrorCodes {
-				if c == "PermissionDoesNotExistException" {
-					return ObjectNotFoundError
-				}
+	return classifyNfsPermissionDeleteError(err)
+}
+
+// classifyNfsPermissionDeleteError maps a delete failure onto ObjectNotFoundError when the cluster is
+// telling us the permission is already gone - the state the caller wanted - and returns everything
+// else unchanged.
+//
+// Unhandled errors used to fall out of the switch and be reported as a successful deletion, so a 500,
+// an authorization failure, or retries exhausted against an unreachable cluster left the permission
+// in place while telling the caller it had been removed.
+func classifyNfsPermissionDeleteError(err error) error {
+	if err == nil {
+		return nil
+	}
+	switch t := err.(type) {
+	case *ApiNotFoundError:
+		return ObjectNotFoundError
+	case *ApiBadRequestError:
+		for _, c := range t.ApiResponse.ErrorCodes {
+			if c == "PermissionDoesNotExistException" {
+				return ObjectNotFoundError
 			}
 		}
 	}
-	return nil
+	return err
 }
 
 type NfsClientGroup struct {

--- a/pkg/wekafs/apiclient/nfs_delete_test.go
+++ b/pkg/wekafs/apiclient/nfs_delete_test.go
@@ -1,0 +1,58 @@
+package apiclient
+
+import (
+	"errors"
+	"net/http"
+	"testing"
+)
+
+// DeleteNfsPermission used to fall out of its type switch and return nil for anything it did not
+// recognise, so a 500, an authorization failure, or retries exhausted against an unreachable cluster
+// all reported the permission as deleted while it was still there.
+//
+// The two recognised cases still mean "already gone", which is the outcome the caller wants.
+func TestDeleteNfsPermissionErrorClassification(t *testing.T) {
+	for name, tc := range map[string]struct {
+		err          error
+		wantNotFound bool // maps to ObjectNotFoundError
+		wantNil      bool
+	}{
+		"deleted successfully":  {nil, false, true},
+		"already gone (404)":    {&ApiNotFoundError{}, true, false},
+		"server error (500)":    {&ApiInternalError{}, false, false},
+		"authorization failure": {&ApiAuthorizationError{}, false, false},
+		"retries exhausted":     {&ApiRetriesExceeded{Retries: 5}, false, false},
+	} {
+		t.Run(name, func(t *testing.T) {
+			got := classifyNfsPermissionDeleteError(tc.err)
+			switch {
+			case tc.wantNil && got != nil:
+				t.Errorf("got %v, want nil", got)
+			case tc.wantNotFound && !errors.Is(got, ObjectNotFoundError):
+				t.Errorf("got %v, want ObjectNotFoundError", got)
+			case !tc.wantNil && !tc.wantNotFound && got == nil:
+				t.Error("returned nil - a real failure was reported as a successful deletion")
+			}
+		})
+	}
+}
+
+// A BadRequest naming the permission as absent is the cluster's other way of saying "already gone";
+// any other BadRequest is a genuine failure and must not be swallowed.
+func TestDeleteNfsPermissionBadRequestCodes(t *testing.T) {
+	absent := &ApiBadRequestError{
+		ApiResponse: &ApiResponse{ErrorCodes: []string{"PermissionDoesNotExistException"}},
+		StatusCode:  http.StatusBadRequest,
+	}
+	if got := classifyNfsPermissionDeleteError(absent); !errors.Is(got, ObjectNotFoundError) {
+		t.Errorf("PermissionDoesNotExistException gave %v, want ObjectNotFoundError", got)
+	}
+
+	other := &ApiBadRequestError{
+		ApiResponse: &ApiResponse{ErrorCodes: []string{"SomethingElseEntirely"}},
+		StatusCode:  http.StatusBadRequest,
+	}
+	if got := classifyNfsPermissionDeleteError(other); got == nil || errors.Is(got, ObjectNotFoundError) {
+		t.Errorf("unrelated BadRequest gave %v, want the original error", got)
+	}
+}


### PR DESCRIPTION
### TL;DR
Fixed NFS permission deletions being reported as successful when they actually failed.

### What changed?
- `DeleteNfsPermission` no longer swallows unrecognized errors (server errors, auth failures, exhausted retries) as a silent success
- Only the two "already deleted" cases are still treated as success
- Error classification extracted into `classifyNfsPermissionDeleteError` for testability

### How to test?
Covered by automated tests only: `classifyNfsPermissionDeleteError` is unit-tested for the success case, both "already gone" variants, and the failures that used to be silently discarded.

### Why make this change?
A failed deletion (500, auth error, unreachable cluster) used to fall through to a bare success return, leaving the NFS permission in place while the caller's check for leftover permissions could never fire. Failures now propagate so callers see the real outcome.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes error propagation on NFS permission deletes used during filesystem/volume cleanup; behavior is more correct but may surface failures that were previously hidden.
> 
> **Overview**
> **`DeleteNfsPermission` no longer treats every API failure as a successful delete.** Unrecognized errors (500s, auth failures, exhausted retries) used to fall through to `return nil`, so permissions could remain while callers believed they were removed. Error handling is moved into **`classifyNfsPermissionDeleteError`**, which still maps 404 and `PermissionDoesNotExistException` to `ObjectNotFoundError` (idempotent “already gone”) and **returns all other errors unchanged**.
> 
> **`EnsureNoNfsPermissionsForFilesystem`** now **continues** when delete returns `ObjectNotFoundError` (concurrent removal) and **stops and returns** on real failures, so filesystem cleanup paths like volume teardown see accurate outcomes.
> 
> Unit tests cover success, both “already gone” shapes, and the failure cases that were previously swallowed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8e60dfbeedb6d9697c55f19a2be6304cf30d2b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->