### PR TITLE
fix: give the metrics server its own leader election lease

### DIFF
--- a/pkg/wekafs/driver.go
+++ b/pkg/wekafs/driver.go
@@ -228,6 +228,24 @@ func (driver *WekaFsDriver) Run(ctx context.Context) {
 	}
 }
 
+// leaderElectionIDForMode names the lease a mode competes for. The metrics server gets its own,
+// because it elects a leader for an unrelated reason: one replica should collect metrics, which says
+// nothing about which replica should serve the CSI controller service.
+//
+// Sharing one lease made them compete. With the metrics server enabled inside the plugin release,
+// its pods could win the controller's lease, leaving both controller pods waiting for a leadership
+// they would never get: the gRPC server never started, wait-for-leader gated every sidecar forever,
+// and provisioning stopped while every pod still reported healthy.
+//
+// The controller's lease name is deliberately unchanged. Renaming it would have old and new pods
+// electing separate leaders from the same release during a rolling upgrade.
+func leaderElectionIDForMode(driverName string, mode CsiPluginMode) string {
+	if mode == CsiModeMetricsServer {
+		return fmt.Sprintf("%s-metricsserver-leader", driverName)
+	}
+	return fmt.Sprintf("%s-controller-leader", driverName)
+}
+
 // initManager initializes the controller-runtime manager.
 // Pass leaderElection=true for controller mode (acquires a lease before serving).
 // Pass leaderElection=false for node mode (client-only, no lease required).
@@ -299,7 +317,7 @@ func (d *WekaFsDriver) initManager(ctx context.Context, leaderElection bool) err
 		}
 		mgrOpts.LeaderElection = true
 		mgrOpts.LeaderElectionNamespace = namespace
-		mgrOpts.LeaderElectionID = fmt.Sprintf("%s-controller-leader", d.name)
+		mgrOpts.LeaderElectionID = leaderElectionIDForMode(d.name, d.csiMode)
 		mgrOpts.LeaderElectionReleaseOnCancel = true
 	}
 

--- a/pkg/wekafs/leaderelection_id_test.go
+++ b/pkg/wekafs/leaderelection_id_test.go
@@ -1,0 +1,35 @@
+package wekafs
+
+import "testing"
+
+// The metrics server and the CSI controller elect leaders for unrelated reasons, so they must not
+// compete for one lease. When they did, the metrics server could win the controller's lease and both
+// controller pods sat waiting for a leadership they would never get - no gRPC server, every sidecar
+// gated by wait-for-leader, and provisioning stopped while every pod still reported healthy.
+func TestLeaderElectionIDIsSeparatePerRole(t *testing.T) {
+	const driver = "csi.weka.io"
+
+	controller := leaderElectionIDForMode(driver, CsiModeController)
+	all := leaderElectionIDForMode(driver, CsiModeAll)
+	metricsServer := leaderElectionIDForMode(driver, CsiModeMetricsServer)
+
+	if metricsServer == controller {
+		t.Errorf("metrics server and controller share the lease %q - they would compete for it", controller)
+	}
+
+	// A driver serving the controller service must keep the same lease whichever mode it runs in,
+	// or an "all" pod and a "controller" pod in one release would each elect their own leader.
+	if all != controller {
+		t.Errorf("CsiModeAll uses %q but CsiModeController uses %q - both serve the controller service", all, controller)
+	}
+
+	// Unchanged on purpose: renaming it would split leadership across a rolling upgrade.
+	if controller != "csi.weka.io-controller-leader" {
+		t.Errorf("controller lease is %q, want csi.weka.io-controller-leader - renaming splits leadership mid-upgrade", controller)
+	}
+
+	// Two drivers installed side by side must not collide either.
+	if leaderElectionIDForMode("other.weka.io", CsiModeMetricsServer) == metricsServer {
+		t.Error("lease name does not vary by driver name - two installs would compete")
+	}
+}


### PR DESCRIPTION
### TL;DR
Gave the metrics server its own leader-election lease so it can't stall the CSI controller.

### What changed?
- The metrics server now uses a separate leader-election lease name from the CSI controller
- The controller's lease name is unchanged, to avoid split leadership across a rolling upgrade

### How to test?
1. Enable `metricsServer.enabled` on the `csi-wekafsplugin` chart alongside the controller.
2. Run `kubectl get lease` and confirm the controller and metrics server each hold a distinct lease.
3. Confirm the controller acquires leadership, its gRPC server starts, and new PVCs provision normally.

### Why make this change?
Both processes previously competed for one lease. On a live cluster, the metrics server won it: both controller pods sat waiting for leadership, the gRPC server never started, volume health reporting stopped, and new PVCs stayed Pending indefinitely — while every pod still reported Running, so nothing looked wrong from the outside.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches CSI controller startup and leader election—critical for provisioning—but the change is narrow (lease naming only) with explicit tests and an unchanged controller lease ID for upgrades.
> 
> **Overview**
> Fixes a deadlock where the in-chart metrics server and CSI controller both competed for the same Kubernetes leader-election lease (`{driver}-controller-leader`). When metrics pods won that lease, controller replicas never became leader—gRPC never started, sidecars stayed on wait-for-leader, and provisioning stalled while pods looked healthy.
> 
> **`leaderElectionIDForMode`** now assigns **`{driver}-metricsserver-leader`** only for `CsiModeMetricsServer`; controller, `CsiModeAll`, and other modes still use the unchanged **`{driver}-controller-leader`** so rolling upgrades do not split controller leadership. `initManager` sets `LeaderElectionID` via this helper instead of a single hardcoded name.
> 
> Unit tests lock in: metrics vs controller leases differ, `CsiModeAll` matches controller, the controller lease string is unchanged, and lease names vary by driver name.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1597454ada735d8e915a98fc6f16ba6a829eda19. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->