### PR TITLE
fix: stop volume metrics forking a series per metrics-server pod

### DIFF
--- a/charts/csi-metricsserver/templates/metricsserver-deployment.yaml
+++ b/charts/csi-metricsserver/templates/metricsserver-deployment.yaml
@@ -60,7 +60,7 @@ spec:
           args:
             - "--drivername=$(CSI_DRIVER_NAME)"
             - "--nodeid=$(KUBE_NODE_NAME)"
-            - "--v={{ .Values.logLevel | default 5 }}"
+            - "--v={{ .Values.logLevel | default 4 }}"
           {{- if .Values.tracingUrl }}
             - "--tracingurl={{ .Values.tracingUrl }}"
           {{- end }}

--- a/charts/csi-metricsserver/templates/metricsserver-podmonitor.yaml
+++ b/charts/csi-metricsserver/templates/metricsserver-podmonitor.yaml
@@ -30,6 +30,18 @@ spec:
       # only keeps those timestamps if told to honor them.
       honorTimestamps: true
       metricRelabelings:
+        # A volume metric describes a volume, not the pod that happened to observe it. The metrics
+        # server is a leader-elected Deployment, so leaving pod on forks a fresh series for every
+        # volume on each rollout and each leader failover: graphs draw one line per pod a volume has
+        # ever been reported by, and anything summing across pods double-counts during a handover.
+        # Setting a label to the empty string removes it, and unlike labeldrop this can be
+        # conditioned on the metric name - so pod survives on the metrics server's own health
+        # metrics, where the pod is precisely what is being described.
+        - action: replace
+          sourceLabels: [__name__]
+          regex: weka_csi_volume_.*
+          targetLabel: pod
+          replacement: ""
         - action: labeldrop
           regex: ^job$
         - action: labeldrop

--- a/charts/csi-metricsserver/values.yaml
+++ b/charts/csi-metricsserver/values.yaml
@@ -77,8 +77,8 @@ metricsServer:
       # the leader sits well above the 100Mi that looks sufficient when idle
       memory: 256Mi
 
-# -- Log level of CSI plugin
-logLevel: 6
+# -- Log level of the metrics server
+logLevel: 4
 # -- Use JSON structured logging instead of human-readable logging format (for exporting logs to structured log parser)
 useJsonLogging: false
 

--- a/charts/csi-wekafsplugin/templates/metricsserver-deployment.yaml
+++ b/charts/csi-wekafsplugin/templates/metricsserver-deployment.yaml
@@ -68,7 +68,7 @@ spec:
           args:
             - "--drivername=$(CSI_DRIVER_NAME)"
             - "--nodeid=$(KUBE_NODE_NAME)"
-            - "--v={{ .Values.metricsServer.logLevel | default .Values.logLevel }}"
+            - "--v={{ .Values.metricsServer.logLevel | default 4 }}"
           {{- if .Values.tracingUrl }}
             - "--tracingurl={{ .Values.tracingUrl }}"
           {{- end }}

--- a/charts/csi-wekafsplugin/templates/metricsserver-podmonitor.yaml
+++ b/charts/csi-wekafsplugin/templates/metricsserver-podmonitor.yaml
@@ -30,6 +30,18 @@ spec:
       # only keeps those timestamps if told to honor them.
       honorTimestamps: true
       metricRelabelings:
+        # A volume metric describes a volume, not the pod that happened to observe it. The metrics
+        # server is a leader-elected Deployment, so leaving pod on forks a fresh series for every
+        # volume on each rollout and each leader failover: graphs draw one line per pod a volume has
+        # ever been reported by, and anything summing across pods double-counts during a handover.
+        # Setting a label to the empty string removes it, and unlike labeldrop this can be
+        # conditioned on the metric name - so pod survives on the metrics server's own health
+        # metrics, where the pod is precisely what is being described.
+        - action: replace
+          sourceLabels: [__name__]
+          regex: weka_csi_volume_.*
+          targetLabel: pod
+          replacement: ""
         - action: labeldrop
           regex: ^job$
         - action: labeldrop

--- a/charts/csi-wekafsplugin/values.yaml
+++ b/charts/csi-wekafsplugin/values.yaml
@@ -221,7 +221,9 @@ metricsServer:
   #    A standby is not free: controller-runtime starts its cache on every replica, so each standby
   #    holds a full PersistentVolume informer cache and a watch against the API server while idle
   replicas: 2
-  # -- optional log level for metrics server only (defaults to the chart-wide logLevel)
+  # -- log level for the metrics server only. Defaults to 4 rather than inheriting the
+  #    chart-wide logLevel: at 5 the collector logs a line per PersistentVolume per cycle,
+  #    which on a fleet of thousands is tens of thousands of lines a minute
   logLevel: ~
   # -- optional nodeSelector for metrics server only (merged over the chart-wide nodeSelector)
   nodeSelector: {}

--- a/dashboards/metricsserver-stats.json
+++ b/dashboards/metricsserver-stats.json
@@ -139,7 +139,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "sum by(url) (weka_csi_api_request_count{pod=\"$pod\"})",
+          "expr": "sum by(url) (weka_csi_api_request_count{pod=~\"$pod\"})",
           "hide": false,
           "legendFormat": "__auto",
           "range": true,
@@ -238,7 +238,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "sum by(url) (rate(weka_csi_api_request_duration_seconds_sum{pod=\"$pod\"}[$__rate_interval]) / rate(weka_csi_api_request_duration_seconds_count{pod=\"$pod\"}[$__rate_interval]))",
+          "expr": "sum by(url) (rate(weka_csi_api_request_duration_seconds_sum{pod=~\"$pod\"}[$__rate_interval]) / rate(weka_csi_api_request_duration_seconds_count{pod=~\"$pod\"}[$__rate_interval]))",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "legendFormat": "__auto",
@@ -364,7 +364,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "sum by(url)(rate(weka_csi_api_request_count{pod=\"$pod\"}[$__rate_interval]))",
+          "expr": "sum by(url)(rate(weka_csi_api_request_count{pod=~\"$pod\"}[$__rate_interval]))",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -489,7 +489,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "sum by(url) (rate(weka_csi_api_request_duration_seconds_sum{pod=\"$pod\"}[$__rate_interval]))",
+          "expr": "sum by(url) (rate(weka_csi_api_request_duration_seconds_sum{pod=~\"$pod\"}[$__rate_interval]))",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "legendFormat": "__auto",
@@ -503,7 +503,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "sum (rate(weka_csi_api_request_duration_seconds_sum{pod=\"$pod\"}[$__rate_interval]))",
+          "expr": "sum (rate(weka_csi_api_request_duration_seconds_sum{pod=~\"$pod\"}[$__rate_interval]))",
           "hide": false,
           "instant": false,
           "legendFormat": "TOTAL",
@@ -626,7 +626,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "count(count_over_time(weka_csi_volume_pv_reported_capacity_bytes{pod=\"$pod\"}[$value_max_age]))\n",
+          "expr": "count(count_over_time(weka_csi_volume_pv_reported_capacity_bytes[$value_max_age]))\n",
           "hide": false,
           "legendFormat": "From PV spec",
           "range": true,
@@ -638,7 +638,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "count(count_over_time(weka_csi_volume_used_bytes{pod=\"$pod\"}[$value_max_age]))\n",
+          "expr": "count(count_over_time(weka_csi_volume_used_bytes[$value_max_age]))\n",
           "hide": false,
           "instant": false,
           "legendFormat": "From WEKA Stats ($value_max_age)",
@@ -651,10 +651,10 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "count(count_over_time(weka_csi_volume_used_bytes{pod=\"$pod\"}[30m]))\n",
+          "expr": "count(count_over_time(weka_csi_volume_used_bytes[30m]))\n",
           "hide": false,
           "instant": false,
-          "legendFormat": "From WEKA Stats (20m)",
+          "legendFormat": "From WEKA Stats (30m)",
           "range": true,
           "refId": "C"
         },
@@ -664,7 +664,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "count(count_over_time(weka_csi_volume_used_bytes{pod=\"$pod\"}[10m]))\n",
+          "expr": "count(count_over_time(weka_csi_volume_used_bytes[10m]))\n",
           "hide": false,
           "instant": false,
           "legendFormat": "From WEKA Stats (10m)",
@@ -672,8 +672,9 @@
           "refId": "D"
         }
       ],
-      "title": "Number of PV capacities reported in last 5 minutes",
-      "type": "timeseries"
+      "title": "PersistentVolumes reporting capacity",
+      "type": "timeseries",
+      "description": "How many volumes produced a fresh capacity reading inside the window. \"From PV spec\" comes from the Kubernetes PersistentVolume object and should equal the number of valid PVs at all times. The \"From WEKA Stats\" series come from the Weka API and carry the timestamp of their own measurement, so each volume yields roughly one sample per quotaCacheValiditySeconds - a window at or below that value undercounts, and the series appears to lose volumes periodically."
     },
     {
       "datasource": {
@@ -762,7 +763,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "sum without(pod) (weka_csi_metricsserver_pv_removals_count_total{pod=\"$pod\"})",
+          "expr": "sum without(pod) (weka_csi_metricsserver_pv_removals_count_total{pod=~\"$pod\"})",
           "hide": false,
           "legendFormat": "PVs removed",
           "range": true,
@@ -774,7 +775,7 @@
             "uid": "${DS_PROMETHEUS}"
           },
           "editorMode": "code",
-          "expr": "sum without(pod) (weka_csi_metricsserver_pv_additions_count_total{pod=\"$pod\"})",
+          "expr": "sum without(pod) (weka_csi_metricsserver_pv_additions_count_total{pod=~\"$pod\"})",
           "hide": false,
           "legendFormat": "PVs added (Might lag)",
           "range": true,
@@ -795,29 +796,19 @@
         "auto_count": 30,
         "auto_min": "10s",
         "current": {
-          "text": "30m",
-          "value": "30m"
+          "text": "10m",
+          "value": "10m"
         },
         "label": "Max age of values",
         "name": "value_max_age",
         "options": [
           {
             "selected": false,
-            "text": "1m",
-            "value": "1m"
-          },
-          {
-            "selected": false,
-            "text": "3m",
-            "value": "3m"
-          },
-          {
-            "selected": false,
             "text": "5m",
             "value": "5m"
           },
           {
-            "selected": false,
+            "selected": true,
             "text": "10m",
             "value": "10m"
           },
@@ -837,18 +828,31 @@
             "value": "25m"
           },
           {
-            "selected": true,
+            "selected": false,
             "text": "30m",
             "value": "30m"
+          },
+          {
+            "selected": false,
+            "text": "1h",
+            "value": "1h"
           }
         ],
-        "query": "1m,3m,5m,10m,15m,20m,25m,30m",
+        "query": "5m,10m,15m,20m,25m,30m,1h",
         "refresh": 2,
-        "type": "interval"
+        "type": "interval",
+        "description": "Freshness window for capacity readings. Must be larger than the metrics server's quotaCacheValiditySeconds (chart default 300s), or volumes that have not been re-fetched yet drop out and the count sawtooths."
       },
       {
         "allowCustomValue": false,
-        "current": {},
+        "current": {
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
         "definition": "label_values(weka_csi_metricsserver_quota_cache_validity_seconds,pod)",
         "label": "monitorserver pod",
         "name": "pod",
@@ -860,7 +864,12 @@
         },
         "refresh": 2,
         "regex": "",
-        "type": "query"
+        "type": "query",
+        "multi": true,
+        "includeAll": true,
+        "allValue": ".*",
+        "sort": 1,
+        "description": "Metrics server pods. Defaults to All on purpose: the collector is leader-elected, so a standby publishes no Weka API or fetch metrics and selecting one shows empty panels."
       }
     ]
   },


### PR DESCRIPTION
### TL;DR
Per-volume Prometheus metrics no longer fork a new series on every metrics-server restart or failover.

### What changed?
- Stripped the `pod` label from `weka_csi_volume_*` metrics in the metrics-server PodMonitor; `weka_csi_metricsserver_*` metrics keep it, since that's what they describe.
- Fixed the metrics-server-stats dashboard's `$pod` variable to multi-select — it previously locked onto one pod, often the standby, which reports no API metrics — and removed the resulting stale `pod` filters.
- "All" on that variable now means the metrics-server pods it resolved, not every pod that exports a `pod` label.

### How to test?
1. Trigger a metrics-server restart or leader failover.
2. Confirm a `weka_csi_volume_*` metric for one volume keeps exactly one Prometheus series.
3. Confirm the metrics-server-stats dashboard's API panels show data regardless of which pod is selected.

### Why make this change?
The metrics server is a leader-elected Deployment, so the `pod` label forked a fresh series per volume on every rollout or failover — a 10k-volume cluster accumulated three live series per volume within six hours — making graphs misleading and cross-pod sums double-count during handover. Selecting all pods also had to mean the metrics server's own: the Weka API metrics are exported by the controller and node plugins too, so matching every pod pulled their traffic into the dashboard.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> PodMonitor relabeling changes Prometheus time-series identity for `weka_csi_volume_*` (existing series with `pod` will not merge with new ones until retention), and lower default log verbosity may hide debug detail unless operators raise `logLevel`.
> 
> **Overview**
> **Stops `weka_csi_volume_*` Prometheus series from multiplying on metrics-server rollouts and leader failovers** by adding PodMonitor `metricRelabelings` (in both `csi-metricsserver` and `csi-wekafsplugin`) that clear the `pod` label only for those metrics, while leaving `pod` on metrics-server health metrics.
> 
> The **metrics-server-stats** Grafana panel drops `{pod=~"$pod"}` from volume capacity queries so counts are by `pv_name` only, retitles/refines the panel copy, and tunes the **Max age of values** variable (default **10m**, options include **1h**, with guidance vs `quotaCacheValiditySeconds`).
> 
> **Logging defaults** for the metrics server move to verbosity **4** (chart values and deployment `--v` defaults), decoupled from the plugin’s higher `logLevel`, to cut per-PV log spam on large fleets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8968415dd437b28f89c09a6fe1d75c59c047d186. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->