### PR TITLE
feat: per-volume capacity dashboard, alerts and monitoring docs

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -38,6 +38,7 @@ csi-wekafs/
 │   ├── values.yaml              # 100+ configurable options
 │   ├── values.schema.json
 │   └── templates/               # Deployment, DaemonSet, RBAC, CSIDriver
+├── dashboards/                  # Grafana dashboards (export format) + PrometheusRule alerts
 ├── examples/                    # Usage examples (dynamic, static, snapshots, encryption)
 ├── tests/csi-sanity/            # CSI sanity test suite (docker-compose based)
 ├── .github/workflows/           # CI/CD (sanity tests, release, dev builds, PR lint)
@@ -85,6 +86,10 @@ Key components deployed:
 - Volume IDs encode filesystem/snapshot/path info - see `utilities.go`
 - Mount operations have separate implementations: native Weka (`wekafsmount.go`) and NFS (`nfsmount.go`)
 - Controller-side Kubernetes access goes through the controller-runtime manager: `manager.GetClient()` for cached PV reads (indexed by `spec.csi.volumeHandle`), `manager.GetAPIReader()` for Secrets, so no Secret informer is started
+- Volume capacity metrics are published with `SetWithTimestamp` carrying the *measurement* time, not
+  the scrape time, and quotas are cached for `quotaCacheValiditySeconds`. Prometheus (with
+  `honorTimestamps`) drops repeats of the same timestamp, so a volume emits ~1 sample per cache
+  period. Any dashboard or alert window over these metrics must exceed that cache validity
 - Tests colocated with source files (`*_test.go`)
 
 ## Workflow Rules

--- a/README.md.gotmpl
+++ b/README.md.gotmpl
@@ -49,6 +49,13 @@ the Weka cluster. Credentials are taken from the API secret referenced by the Pe
   older clusters cannot resolve a path to an inode over the API. On older clusters the volume
   condition is reported as unknown rather than abnormal, and capacity is taken from the PV
 
+## Monitoring
+The plugin exposes Prometheus metrics from every component, and optionally deploys a metrics server
+that reports per-volume capacity by querying the Weka cluster. Two Grafana dashboards and a set of
+alert rules ship in `dashboards/`.
+
+- [Monitoring, metrics server and Grafana dashboards](docs/monitoring.md)
+
 ## Additional Documentation
 - [Official Weka CSI Plugin documentation](https://docs.weka.io/appendices/weka-csi-plugin)
 

--- a/dashboards/volume-capacity-alerts.yaml
+++ b/dashboards/volume-capacity-alerts.yaml
@@ -1,0 +1,85 @@
+# Alert rules for the thresholds drawn on the "Weka CSI volume capacity" dashboard
+# (dashboards/volume-capacity.json). Apply to a cluster running the Prometheus Operator:
+#
+#   kubectl apply -n <prometheus-namespace> -f dashboards/volume-capacity-alerts.yaml
+#
+# For a plain Prometheus, lift the `groups:` block into your own rule file.
+#
+# Two things about these expressions are deliberate:
+#
+#   * last_over_time over 15m, not an instant selector. A reading carries the timestamp of its own
+#     measurement, and the metrics server serves a quota from cache for quotaCacheValiditySeconds
+#     (chart default 300s), so a volume emits roughly one sample per cache period rather than one
+#     per scrape. An instant query would evaluate against gaps and the alert would flap. The window
+#     must stay comfortably larger than quotaCacheValiditySeconds - raise it if you raise that.
+#
+#   * clamp_min on the denominator. A volume whose capacity reads zero would otherwise divide by
+#     zero and evaluate to +Inf, firing every alert here at once.
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: weka-csi-volume-capacity
+  labels:
+    app.kubernetes.io/name: csi-wekafsplugin
+    app.kubernetes.io/component: alerts
+spec:
+  groups:
+    - name: weka-csi-volume-capacity
+      rules:
+        # Recording rule so both alerts and any ad-hoc query share one definition of "utilisation",
+        # and so the expensive division is evaluated once per interval rather than per alert.
+        - record: weka_csi_volume:used_ratio
+          expr: |
+            100
+              * last_over_time(weka_csi_volume_used_bytes[15m])
+              / clamp_min(last_over_time(weka_csi_volume_capacity_bytes[15m]), 1)
+
+        - alert: WekaCsiVolumeAlmostFull
+          expr: weka_csi_volume:used_ratio >= 85 < 95
+          # Longer than the quota cache validity, so a single stale or transient reading cannot
+          # fire this on its own.
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: >-
+              PersistentVolume {{ $labels.pvc_namespace }}/{{ $labels.pvc_name }} is
+              {{ $value | printf "%.1f" }}% full
+            description: >-
+              PersistentVolume {{ $labels.pv_name }} (PVC {{ $labels.pvc_namespace }}/{{
+              $labels.pvc_name }}) on Weka filesystem {{ $labels.filesystem_name }}, tenant {{
+              $labels.organization }}, has used {{ $value | printf "%.1f" }}% of its capacity.
+              Expand the PersistentVolumeClaim or reclaim space before it fills.
+
+        - alert: WekaCsiVolumeFull
+          expr: weka_csi_volume:used_ratio >= 95
+          for: 15m
+          labels:
+            severity: critical
+          annotations:
+            summary: >-
+              PersistentVolume {{ $labels.pvc_namespace }}/{{ $labels.pvc_name }} is critically
+              full at {{ $value | printf "%.1f" }}%
+            description: >-
+              PersistentVolume {{ $labels.pv_name }} (PVC {{ $labels.pvc_namespace }}/{{
+              $labels.pvc_name }}) on Weka filesystem {{ $labels.filesystem_name }}, tenant {{
+              $labels.organization }}, has used {{ $value | printf "%.1f" }}% of its capacity.
+              Writes will start failing when it reaches the quota's hard limit.
+
+        # Not a capacity threshold, but the alert that makes the two above trustworthy: if the
+        # metrics server stops collecting, utilisation freezes at its last value instead of going
+        # missing, and a volume can fill without either alert ever firing.
+        - alert: WekaCsiVolumeMetricsStale
+          expr: |
+            count(count_over_time(weka_csi_volume_used_bytes[15m]))
+              < 0.9 * max(weka_csi_metricsserver_monitored_persistent_volumes_gauge)
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: Weka CSI volume capacity metrics are stale
+            description: >-
+              Only {{ $value }} volumes reported capacity in the last 15 minutes, against the
+              number the metrics server believes it is monitoring. Check the metrics server's
+              weka_csi_metricsserver_fetch_* failure counters and its ability to reach the Weka
+              API.

--- a/dashboards/volume-capacity.json
+++ b/dashboards/volume-capacity.json
@@ -1,0 +1,1843 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__elements": {},
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "12.0.2"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "table",
+      "name": "Table",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "type": "row",
+      "title": "Per-volume capacity",
+      "id": 1,
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "panels": []
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "type": "timeseries",
+      "title": "Used capacity per volume",
+      "description": "Capped at 100 series. With thousands of volumes a graph of all of them is neither readable nor cheap to render, so narrow the scope with the variables at the top rather than raising the cap.",
+      "id": 2,
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 0,
+        "y": 1
+      },
+      "pluginVersion": "12.0.2",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "sortBy": "Last *",
+          "sortDesc": true,
+          "width": 430
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc",
+          "maxHeight": 600
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "topk(100, max by (csi_driver_name, pv_name, cluster_guid, storage_class_name, filesystem_name, volume_type, organization, pvc_name, pvc_namespace, pvc_uid) (last_over_time(weka_csi_volume_used_bytes{organization=~\"$organization\", filesystem_name=~\"$filesystem_name\", storage_class_name=~\"$storage_class_name\", pvc_namespace=~\"$pvc_namespace\", pv_name=~\"$pv_name\"}[$value_max_age])))",
+          "legendFormat": "{{pvc_namespace}}/{{pvc_name}}",
+          "range": true,
+          "instant": false,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "type": "timeseries",
+      "title": "Total capacity per volume",
+      "description": "Capped at 100 series. With thousands of volumes a graph of all of them is neither readable nor cheap to render, so narrow the scope with the variables at the top rather than raising the cap.",
+      "id": 3,
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 12,
+        "y": 1
+      },
+      "pluginVersion": "12.0.2",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "sortBy": "Last *",
+          "sortDesc": true,
+          "width": 430
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc",
+          "maxHeight": 600
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "topk(100, max by (csi_driver_name, pv_name, cluster_guid, storage_class_name, filesystem_name, volume_type, organization, pvc_name, pvc_namespace, pvc_uid) (last_over_time(weka_csi_volume_capacity_bytes{organization=~\"$organization\", filesystem_name=~\"$filesystem_name\", storage_class_name=~\"$storage_class_name\", pvc_namespace=~\"$pvc_namespace\", pv_name=~\"$pv_name\"}[$value_max_age])))",
+          "legendFormat": "{{pvc_namespace}}/{{pvc_name}}",
+          "range": true,
+          "instant": false,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "type": "timeseries",
+      "title": "Free capacity per volume",
+      "description": "The volumes with the least free space, which are the ones worth watching. Capped at 100 series. With thousands of volumes a graph of all of them is neither readable nor cheap to render, so narrow the scope with the variables at the top rather than raising the cap.",
+      "id": 4,
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 0,
+        "y": 11
+      },
+      "pluginVersion": "12.0.2",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "sortBy": "Last *",
+          "sortDesc": true,
+          "width": 430
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc",
+          "maxHeight": 600
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "bottomk(100, max by (csi_driver_name, pv_name, cluster_guid, storage_class_name, filesystem_name, volume_type, organization, pvc_name, pvc_namespace, pvc_uid) (last_over_time(weka_csi_volume_free_bytes{organization=~\"$organization\", filesystem_name=~\"$filesystem_name\", storage_class_name=~\"$storage_class_name\", pvc_namespace=~\"$pvc_namespace\", pv_name=~\"$pv_name\"}[$value_max_age])))",
+          "legendFormat": "{{pvc_namespace}}/{{pvc_name}}",
+          "range": true,
+          "instant": false,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "type": "timeseries",
+      "title": "Utilisation per volume",
+      "description": "Used as a percentage of each volume's own capacity. Dashed lines mark the 85% and 95% alert thresholds. Capped at 100 series. With thousands of volumes a graph of all of them is neither readable nor cheap to render, so narrow the scope with the variables at the top rather than raising the cap.",
+      "id": 5,
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 12,
+        "y": 11
+      },
+      "pluginVersion": "12.0.2",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": true,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "dashed"
+            }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "orange",
+                "value": 85
+              },
+              {
+                "color": "red",
+                "value": 95
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true,
+          "sortBy": "Last *",
+          "sortDesc": true,
+          "width": 430
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc",
+          "maxHeight": 600
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "topk(100, 100 * max by (csi_driver_name, pv_name, cluster_guid, storage_class_name, filesystem_name, volume_type, organization, pvc_name, pvc_namespace, pvc_uid) (last_over_time(weka_csi_volume_used_bytes{organization=~\"$organization\", filesystem_name=~\"$filesystem_name\", storage_class_name=~\"$storage_class_name\", pvc_namespace=~\"$pvc_namespace\", pv_name=~\"$pv_name\"}[$value_max_age])) / clamp_min(max by (csi_driver_name, pv_name, cluster_guid, storage_class_name, filesystem_name, volume_type, organization, pvc_name, pvc_namespace, pvc_uid) (last_over_time(weka_csi_volume_capacity_bytes{organization=~\"$organization\", filesystem_name=~\"$filesystem_name\", storage_class_name=~\"$storage_class_name\", pvc_namespace=~\"$pvc_namespace\", pv_name=~\"$pv_name\"}[$value_max_age])), 1))",
+          "legendFormat": "{{pvc_namespace}}/{{pvc_name}}",
+          "range": true,
+          "instant": false,
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "title": "Volume rankings",
+      "id": 6,
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 21
+      },
+      "panels": []
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "type": "table",
+      "title": "Top volume sizes",
+      "description": "The 100 largest volumes by provisioned capacity.",
+      "id": 7,
+      "gridPos": {
+        "h": 12,
+        "w": 12,
+        "x": 0,
+        "y": 22
+      },
+      "pluginVersion": "12.0.2",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false,
+            "filterable": true
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text"
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Namespace"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 250
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "PVC"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 250
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "PersistentVolume"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 250
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Filesystem"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 250
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Tenant"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 250
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Capacity"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 130
+              },
+              {
+                "id": "unit",
+                "value": "bytes"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Used"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 130
+              },
+              {
+                "id": "unit",
+                "value": "bytes"
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "showHeader": true,
+        "cellHeight": "sm",
+        "footer": {
+          "show": false,
+          "reducer": [
+            "sum"
+          ],
+          "countRows": false,
+          "fields": ""
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "topk(100, max by (csi_driver_name, pv_name, cluster_guid, storage_class_name, filesystem_name, volume_type, organization, pvc_name, pvc_namespace, pvc_uid) (last_over_time(weka_csi_volume_capacity_bytes{organization=~\"$organization\", filesystem_name=~\"$filesystem_name\", storage_class_name=~\"$storage_class_name\", pvc_namespace=~\"$pvc_namespace\", pv_name=~\"$pv_name\"}[$value_max_age])))",
+          "legendFormat": "__auto",
+          "range": false,
+          "instant": true,
+          "refId": "A",
+          "format": "table"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "max by (csi_driver_name, pv_name, cluster_guid, storage_class_name, filesystem_name, volume_type, organization, pvc_name, pvc_namespace, pvc_uid) (last_over_time(weka_csi_volume_used_bytes{organization=~\"$organization\", filesystem_name=~\"$filesystem_name\", storage_class_name=~\"$storage_class_name\", pvc_namespace=~\"$pvc_namespace\", pv_name=~\"$pv_name\"}[$value_max_age])) and on (pv_name) topk(100, max by (csi_driver_name, pv_name, cluster_guid, storage_class_name, filesystem_name, volume_type, organization, pvc_name, pvc_namespace, pvc_uid) (last_over_time(weka_csi_volume_capacity_bytes{organization=~\"$organization\", filesystem_name=~\"$filesystem_name\", storage_class_name=~\"$storage_class_name\", pvc_namespace=~\"$pvc_namespace\", pv_name=~\"$pv_name\"}[$value_max_age])))",
+          "legendFormat": "__auto",
+          "range": false,
+          "instant": true,
+          "refId": "B",
+          "format": "table"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "merge",
+          "options": {}
+        },
+        {
+          "id": "filterFieldsByName",
+          "options": {
+            "include": {
+              "names": [
+                "pvc_namespace",
+                "pvc_name",
+                "pv_name",
+                "filesystem_name",
+                "organization",
+                "Value #A",
+                "Value #B"
+              ]
+            }
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "renameByName": {
+              "pvc_namespace": "Namespace",
+              "pvc_name": "PVC",
+              "pv_name": "PersistentVolume",
+              "filesystem_name": "Filesystem",
+              "organization": "Tenant",
+              "Value #A": "Capacity",
+              "Value #B": "Used"
+            },
+            "indexByName": {
+              "pvc_namespace": 0,
+              "pvc_name": 1,
+              "pv_name": 2,
+              "filesystem_name": 3,
+              "organization": 4,
+              "Value #A": 5,
+              "Value #B": 6
+            }
+          }
+        },
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "field": "Capacity",
+                "desc": true
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "type": "table",
+      "title": "Top volume usage",
+      "description": "The 100 fullest volumes. Amber at 85%, red at 95% \u2014 the same thresholds as the WekaCsiVolumeAlmostFull and WekaCsiVolumeFull alert rules in dashboards/volume-capacity-alerts.yaml.",
+      "id": 8,
+      "gridPos": {
+        "h": 12,
+        "w": 12,
+        "x": 12,
+        "y": 22
+      },
+      "pluginVersion": "12.0.2",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false,
+            "filterable": true
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text"
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Namespace"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 250
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "PVC"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 250
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "PersistentVolume"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 250
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Filesystem"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 250
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Tenant"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 250
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Used %"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 130
+              },
+              {
+                "id": "unit",
+                "value": "percent"
+              },
+              {
+                "id": "max",
+                "value": 100
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-background",
+                  "mode": "gradient"
+                }
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green"
+                    },
+                    {
+                      "color": "orange",
+                      "value": 85
+                    },
+                    {
+                      "color": "red",
+                      "value": 95
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Used"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 130
+              },
+              {
+                "id": "unit",
+                "value": "bytes"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Capacity"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 130
+              },
+              {
+                "id": "unit",
+                "value": "bytes"
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "showHeader": true,
+        "cellHeight": "sm",
+        "footer": {
+          "show": false,
+          "reducer": [
+            "sum"
+          ],
+          "countRows": false,
+          "fields": ""
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "topk(100, 100 * max by (csi_driver_name, pv_name, cluster_guid, storage_class_name, filesystem_name, volume_type, organization, pvc_name, pvc_namespace, pvc_uid) (last_over_time(weka_csi_volume_used_bytes{organization=~\"$organization\", filesystem_name=~\"$filesystem_name\", storage_class_name=~\"$storage_class_name\", pvc_namespace=~\"$pvc_namespace\", pv_name=~\"$pv_name\"}[$value_max_age])) / clamp_min(max by (csi_driver_name, pv_name, cluster_guid, storage_class_name, filesystem_name, volume_type, organization, pvc_name, pvc_namespace, pvc_uid) (last_over_time(weka_csi_volume_capacity_bytes{organization=~\"$organization\", filesystem_name=~\"$filesystem_name\", storage_class_name=~\"$storage_class_name\", pvc_namespace=~\"$pvc_namespace\", pv_name=~\"$pv_name\"}[$value_max_age])), 1))",
+          "legendFormat": "__auto",
+          "range": false,
+          "instant": true,
+          "refId": "A",
+          "format": "table"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "max by (csi_driver_name, pv_name, cluster_guid, storage_class_name, filesystem_name, volume_type, organization, pvc_name, pvc_namespace, pvc_uid) (last_over_time(weka_csi_volume_used_bytes{organization=~\"$organization\", filesystem_name=~\"$filesystem_name\", storage_class_name=~\"$storage_class_name\", pvc_namespace=~\"$pvc_namespace\", pv_name=~\"$pv_name\"}[$value_max_age])) and on (pv_name) topk(100, 100 * max by (csi_driver_name, pv_name, cluster_guid, storage_class_name, filesystem_name, volume_type, organization, pvc_name, pvc_namespace, pvc_uid) (last_over_time(weka_csi_volume_used_bytes{organization=~\"$organization\", filesystem_name=~\"$filesystem_name\", storage_class_name=~\"$storage_class_name\", pvc_namespace=~\"$pvc_namespace\", pv_name=~\"$pv_name\"}[$value_max_age])) / clamp_min(max by (csi_driver_name, pv_name, cluster_guid, storage_class_name, filesystem_name, volume_type, organization, pvc_name, pvc_namespace, pvc_uid) (last_over_time(weka_csi_volume_capacity_bytes{organization=~\"$organization\", filesystem_name=~\"$filesystem_name\", storage_class_name=~\"$storage_class_name\", pvc_namespace=~\"$pvc_namespace\", pv_name=~\"$pv_name\"}[$value_max_age])), 1))",
+          "legendFormat": "__auto",
+          "range": false,
+          "instant": true,
+          "refId": "B",
+          "format": "table"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "max by (csi_driver_name, pv_name, cluster_guid, storage_class_name, filesystem_name, volume_type, organization, pvc_name, pvc_namespace, pvc_uid) (last_over_time(weka_csi_volume_capacity_bytes{organization=~\"$organization\", filesystem_name=~\"$filesystem_name\", storage_class_name=~\"$storage_class_name\", pvc_namespace=~\"$pvc_namespace\", pv_name=~\"$pv_name\"}[$value_max_age])) and on (pv_name) topk(100, 100 * max by (csi_driver_name, pv_name, cluster_guid, storage_class_name, filesystem_name, volume_type, organization, pvc_name, pvc_namespace, pvc_uid) (last_over_time(weka_csi_volume_used_bytes{organization=~\"$organization\", filesystem_name=~\"$filesystem_name\", storage_class_name=~\"$storage_class_name\", pvc_namespace=~\"$pvc_namespace\", pv_name=~\"$pv_name\"}[$value_max_age])) / clamp_min(max by (csi_driver_name, pv_name, cluster_guid, storage_class_name, filesystem_name, volume_type, organization, pvc_name, pvc_namespace, pvc_uid) (last_over_time(weka_csi_volume_capacity_bytes{organization=~\"$organization\", filesystem_name=~\"$filesystem_name\", storage_class_name=~\"$storage_class_name\", pvc_namespace=~\"$pvc_namespace\", pv_name=~\"$pv_name\"}[$value_max_age])), 1))",
+          "legendFormat": "__auto",
+          "range": false,
+          "instant": true,
+          "refId": "C",
+          "format": "table"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "merge",
+          "options": {}
+        },
+        {
+          "id": "filterFieldsByName",
+          "options": {
+            "include": {
+              "names": [
+                "pvc_namespace",
+                "pvc_name",
+                "pv_name",
+                "filesystem_name",
+                "organization",
+                "Value #A",
+                "Value #B",
+                "Value #C"
+              ]
+            }
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "renameByName": {
+              "pvc_namespace": "Namespace",
+              "pvc_name": "PVC",
+              "pv_name": "PersistentVolume",
+              "filesystem_name": "Filesystem",
+              "organization": "Tenant",
+              "Value #A": "Used %",
+              "Value #B": "Used",
+              "Value #C": "Capacity"
+            },
+            "indexByName": {
+              "pvc_namespace": 0,
+              "pvc_name": 1,
+              "pv_name": 2,
+              "filesystem_name": 3,
+              "organization": 4,
+              "Value #A": 5,
+              "Value #B": 6,
+              "Value #C": 7
+            }
+          }
+        },
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "field": "Used %",
+                "desc": true
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "type": "row",
+      "title": "Filesystem and tenant rankings",
+      "id": 9,
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 34
+      },
+      "panels": []
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "type": "table",
+      "title": "Top filesystems",
+      "description": "Volumes aggregated per filesystem. Directory-backed volumes share one filesystem, so this is where a fleet's real concentration shows.",
+      "id": 10,
+      "gridPos": {
+        "h": 12,
+        "w": 12,
+        "x": 0,
+        "y": 35
+      },
+      "pluginVersion": "12.0.2",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false,
+            "filterable": true
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text"
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Cluster"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 250
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Filesystem"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 250
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Tenant"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 250
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Used"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 130
+              },
+              {
+                "id": "unit",
+                "value": "bytes"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Capacity"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 130
+              },
+              {
+                "id": "unit",
+                "value": "bytes"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Volumes"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 130
+              },
+              {
+                "id": "unit",
+                "value": "short"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Used %"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 130
+              },
+              {
+                "id": "unit",
+                "value": "percent"
+              },
+              {
+                "id": "max",
+                "value": 100
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-background",
+                  "mode": "gradient"
+                }
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green"
+                    },
+                    {
+                      "color": "orange",
+                      "value": 85
+                    },
+                    {
+                      "color": "red",
+                      "value": 95
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "showHeader": true,
+        "cellHeight": "sm",
+        "footer": {
+          "show": false,
+          "reducer": [
+            "sum"
+          ],
+          "countRows": false,
+          "fields": ""
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "topk(100, sum by (cluster_guid, filesystem_name, organization) (max by (csi_driver_name, pv_name, cluster_guid, storage_class_name, filesystem_name, volume_type, organization, pvc_name, pvc_namespace, pvc_uid) (last_over_time(weka_csi_volume_used_bytes{organization=~\"$organization\", filesystem_name=~\"$filesystem_name\", storage_class_name=~\"$storage_class_name\", pvc_namespace=~\"$pvc_namespace\", pv_name=~\"$pv_name\"}[$value_max_age]))))",
+          "legendFormat": "__auto",
+          "range": false,
+          "instant": true,
+          "refId": "A",
+          "format": "table"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (cluster_guid, filesystem_name, organization) (max by (csi_driver_name, pv_name, cluster_guid, storage_class_name, filesystem_name, volume_type, organization, pvc_name, pvc_namespace, pvc_uid) (last_over_time(weka_csi_volume_capacity_bytes{organization=~\"$organization\", filesystem_name=~\"$filesystem_name\", storage_class_name=~\"$storage_class_name\", pvc_namespace=~\"$pvc_namespace\", pv_name=~\"$pv_name\"}[$value_max_age]))) and on (cluster_guid, filesystem_name, organization) topk(100, sum by (cluster_guid, filesystem_name, organization) (max by (csi_driver_name, pv_name, cluster_guid, storage_class_name, filesystem_name, volume_type, organization, pvc_name, pvc_namespace, pvc_uid) (last_over_time(weka_csi_volume_used_bytes{organization=~\"$organization\", filesystem_name=~\"$filesystem_name\", storage_class_name=~\"$storage_class_name\", pvc_namespace=~\"$pvc_namespace\", pv_name=~\"$pv_name\"}[$value_max_age]))))",
+          "legendFormat": "__auto",
+          "range": false,
+          "instant": true,
+          "refId": "B",
+          "format": "table"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "count by (cluster_guid, filesystem_name, organization) (max by (csi_driver_name, pv_name, cluster_guid, storage_class_name, filesystem_name, volume_type, organization, pvc_name, pvc_namespace, pvc_uid) (last_over_time(weka_csi_volume_capacity_bytes{organization=~\"$organization\", filesystem_name=~\"$filesystem_name\", storage_class_name=~\"$storage_class_name\", pvc_namespace=~\"$pvc_namespace\", pv_name=~\"$pv_name\"}[$value_max_age]))) and on (cluster_guid, filesystem_name, organization) topk(100, sum by (cluster_guid, filesystem_name, organization) (max by (csi_driver_name, pv_name, cluster_guid, storage_class_name, filesystem_name, volume_type, organization, pvc_name, pvc_namespace, pvc_uid) (last_over_time(weka_csi_volume_used_bytes{organization=~\"$organization\", filesystem_name=~\"$filesystem_name\", storage_class_name=~\"$storage_class_name\", pvc_namespace=~\"$pvc_namespace\", pv_name=~\"$pv_name\"}[$value_max_age]))))",
+          "legendFormat": "__auto",
+          "range": false,
+          "instant": true,
+          "refId": "C",
+          "format": "table"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "100 * sum by (cluster_guid, filesystem_name, organization) (max by (csi_driver_name, pv_name, cluster_guid, storage_class_name, filesystem_name, volume_type, organization, pvc_name, pvc_namespace, pvc_uid) (last_over_time(weka_csi_volume_used_bytes{organization=~\"$organization\", filesystem_name=~\"$filesystem_name\", storage_class_name=~\"$storage_class_name\", pvc_namespace=~\"$pvc_namespace\", pv_name=~\"$pv_name\"}[$value_max_age]))) / clamp_min(sum by (cluster_guid, filesystem_name, organization) (max by (csi_driver_name, pv_name, cluster_guid, storage_class_name, filesystem_name, volume_type, organization, pvc_name, pvc_namespace, pvc_uid) (last_over_time(weka_csi_volume_capacity_bytes{organization=~\"$organization\", filesystem_name=~\"$filesystem_name\", storage_class_name=~\"$storage_class_name\", pvc_namespace=~\"$pvc_namespace\", pv_name=~\"$pv_name\"}[$value_max_age]))), 1) and on (cluster_guid, filesystem_name, organization) topk(100, sum by (cluster_guid, filesystem_name, organization) (max by (csi_driver_name, pv_name, cluster_guid, storage_class_name, filesystem_name, volume_type, organization, pvc_name, pvc_namespace, pvc_uid) (last_over_time(weka_csi_volume_used_bytes{organization=~\"$organization\", filesystem_name=~\"$filesystem_name\", storage_class_name=~\"$storage_class_name\", pvc_namespace=~\"$pvc_namespace\", pv_name=~\"$pv_name\"}[$value_max_age]))))",
+          "legendFormat": "__auto",
+          "range": false,
+          "instant": true,
+          "refId": "D",
+          "format": "table"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "merge",
+          "options": {}
+        },
+        {
+          "id": "filterFieldsByName",
+          "options": {
+            "include": {
+              "names": [
+                "cluster_guid",
+                "filesystem_name",
+                "organization",
+                "Value #A",
+                "Value #B",
+                "Value #C",
+                "Value #D"
+              ]
+            }
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "renameByName": {
+              "cluster_guid": "Cluster",
+              "filesystem_name": "Filesystem",
+              "organization": "Tenant",
+              "Value #A": "Used",
+              "Value #B": "Capacity",
+              "Value #C": "Volumes",
+              "Value #D": "Used %"
+            },
+            "indexByName": {
+              "cluster_guid": 0,
+              "filesystem_name": 1,
+              "organization": 2,
+              "Value #A": 3,
+              "Value #B": 4,
+              "Value #C": 5,
+              "Value #D": 6
+            }
+          }
+        },
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "field": "Used",
+                "desc": true
+              }
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "type": "table",
+      "title": "Top tenants",
+      "description": "Volumes aggregated per Weka organization, taken from the credentials each volume's API client authenticated with. Ranked by usage; the Capacity column ranks by size.",
+      "id": 11,
+      "gridPos": {
+        "h": 12,
+        "w": 12,
+        "x": 12,
+        "y": 35
+      },
+      "pluginVersion": "12.0.2",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false,
+            "filterable": true
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text"
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Tenant"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 250
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Used"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 130
+              },
+              {
+                "id": "unit",
+                "value": "bytes"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Capacity"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 130
+              },
+              {
+                "id": "unit",
+                "value": "bytes"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Volumes"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 130
+              },
+              {
+                "id": "unit",
+                "value": "short"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Used %"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 130
+              },
+              {
+                "id": "unit",
+                "value": "percent"
+              },
+              {
+                "id": "max",
+                "value": 100
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-background",
+                  "mode": "gradient"
+                }
+              },
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green"
+                    },
+                    {
+                      "color": "orange",
+                      "value": 85
+                    },
+                    {
+                      "color": "red",
+                      "value": 95
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "options": {
+        "showHeader": true,
+        "cellHeight": "sm",
+        "footer": {
+          "show": false,
+          "reducer": [
+            "sum"
+          ],
+          "countRows": false,
+          "fields": ""
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "topk(100, sum by (organization) (max by (csi_driver_name, pv_name, cluster_guid, storage_class_name, filesystem_name, volume_type, organization, pvc_name, pvc_namespace, pvc_uid) (last_over_time(weka_csi_volume_used_bytes{organization=~\"$organization\", filesystem_name=~\"$filesystem_name\", storage_class_name=~\"$storage_class_name\", pvc_namespace=~\"$pvc_namespace\", pv_name=~\"$pv_name\"}[$value_max_age]))))",
+          "legendFormat": "__auto",
+          "range": false,
+          "instant": true,
+          "refId": "A",
+          "format": "table"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (organization) (max by (csi_driver_name, pv_name, cluster_guid, storage_class_name, filesystem_name, volume_type, organization, pvc_name, pvc_namespace, pvc_uid) (last_over_time(weka_csi_volume_capacity_bytes{organization=~\"$organization\", filesystem_name=~\"$filesystem_name\", storage_class_name=~\"$storage_class_name\", pvc_namespace=~\"$pvc_namespace\", pv_name=~\"$pv_name\"}[$value_max_age]))) and on (organization) topk(100, sum by (organization) (max by (csi_driver_name, pv_name, cluster_guid, storage_class_name, filesystem_name, volume_type, organization, pvc_name, pvc_namespace, pvc_uid) (last_over_time(weka_csi_volume_used_bytes{organization=~\"$organization\", filesystem_name=~\"$filesystem_name\", storage_class_name=~\"$storage_class_name\", pvc_namespace=~\"$pvc_namespace\", pv_name=~\"$pv_name\"}[$value_max_age]))))",
+          "legendFormat": "__auto",
+          "range": false,
+          "instant": true,
+          "refId": "B",
+          "format": "table"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "count by (organization) (max by (csi_driver_name, pv_name, cluster_guid, storage_class_name, filesystem_name, volume_type, organization, pvc_name, pvc_namespace, pvc_uid) (last_over_time(weka_csi_volume_capacity_bytes{organization=~\"$organization\", filesystem_name=~\"$filesystem_name\", storage_class_name=~\"$storage_class_name\", pvc_namespace=~\"$pvc_namespace\", pv_name=~\"$pv_name\"}[$value_max_age]))) and on (organization) topk(100, sum by (organization) (max by (csi_driver_name, pv_name, cluster_guid, storage_class_name, filesystem_name, volume_type, organization, pvc_name, pvc_namespace, pvc_uid) (last_over_time(weka_csi_volume_used_bytes{organization=~\"$organization\", filesystem_name=~\"$filesystem_name\", storage_class_name=~\"$storage_class_name\", pvc_namespace=~\"$pvc_namespace\", pv_name=~\"$pv_name\"}[$value_max_age]))))",
+          "legendFormat": "__auto",
+          "range": false,
+          "instant": true,
+          "refId": "C",
+          "format": "table"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "editorMode": "code",
+          "expr": "100 * sum by (organization) (max by (csi_driver_name, pv_name, cluster_guid, storage_class_name, filesystem_name, volume_type, organization, pvc_name, pvc_namespace, pvc_uid) (last_over_time(weka_csi_volume_used_bytes{organization=~\"$organization\", filesystem_name=~\"$filesystem_name\", storage_class_name=~\"$storage_class_name\", pvc_namespace=~\"$pvc_namespace\", pv_name=~\"$pv_name\"}[$value_max_age]))) / clamp_min(sum by (organization) (max by (csi_driver_name, pv_name, cluster_guid, storage_class_name, filesystem_name, volume_type, organization, pvc_name, pvc_namespace, pvc_uid) (last_over_time(weka_csi_volume_capacity_bytes{organization=~\"$organization\", filesystem_name=~\"$filesystem_name\", storage_class_name=~\"$storage_class_name\", pvc_namespace=~\"$pvc_namespace\", pv_name=~\"$pv_name\"}[$value_max_age]))), 1) and on (organization) topk(100, sum by (organization) (max by (csi_driver_name, pv_name, cluster_guid, storage_class_name, filesystem_name, volume_type, organization, pvc_name, pvc_namespace, pvc_uid) (last_over_time(weka_csi_volume_used_bytes{organization=~\"$organization\", filesystem_name=~\"$filesystem_name\", storage_class_name=~\"$storage_class_name\", pvc_namespace=~\"$pvc_namespace\", pv_name=~\"$pv_name\"}[$value_max_age]))))",
+          "legendFormat": "__auto",
+          "range": false,
+          "instant": true,
+          "refId": "D",
+          "format": "table"
+        }
+      ],
+      "transformations": [
+        {
+          "id": "merge",
+          "options": {}
+        },
+        {
+          "id": "filterFieldsByName",
+          "options": {
+            "include": {
+              "names": [
+                "organization",
+                "Value #A",
+                "Value #B",
+                "Value #C",
+                "Value #D"
+              ]
+            }
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "renameByName": {
+              "organization": "Tenant",
+              "Value #A": "Used",
+              "Value #B": "Capacity",
+              "Value #C": "Volumes",
+              "Value #D": "Used %"
+            },
+            "indexByName": {
+              "organization": 0,
+              "Value #A": 1,
+              "Value #B": 2,
+              "Value #C": 3,
+              "Value #D": 4
+            }
+          }
+        },
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "field": "Used",
+                "desc": true
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ],
+  "refresh": "1m",
+  "schemaVersion": 41,
+  "tags": [
+    "weka",
+    "csi",
+    "capacity"
+  ],
+  "templating": {
+    "list": [
+      {
+        "name": "value_max_age",
+        "label": "Value max age",
+        "type": "interval",
+        "description": "How stale a reading may be and still count. Must be larger than the metrics server's quotaCacheValiditySeconds (chart default 300s): each reading carries the timestamp of its own measurement, so a window at or below the cache validity drops the volumes that have not been re-fetched yet, and the panel appears to lose volumes periodically.",
+        "query": "5m,10m,15m,20m,25m,30m,1h",
+        "current": {
+          "text": "10m",
+          "value": "10m"
+        },
+        "options": [
+          {
+            "selected": false,
+            "text": "5m",
+            "value": "5m"
+          },
+          {
+            "selected": true,
+            "text": "10m",
+            "value": "10m"
+          },
+          {
+            "selected": false,
+            "text": "15m",
+            "value": "15m"
+          },
+          {
+            "selected": false,
+            "text": "20m",
+            "value": "20m"
+          },
+          {
+            "selected": false,
+            "text": "25m",
+            "value": "25m"
+          },
+          {
+            "selected": false,
+            "text": "30m",
+            "value": "30m"
+          },
+          {
+            "selected": false,
+            "text": "1h",
+            "value": "1h"
+          }
+        ],
+        "auto": false,
+        "auto_count": 30,
+        "auto_min": "10s",
+        "refresh": 2,
+        "hide": 0
+      },
+      {
+        "name": "organization",
+        "label": "Tenant",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "definition": "label_values(weka_csi_volume_capacity_bytes, organization)",
+        "query": {
+          "qryType": 1,
+          "query": "label_values(weka_csi_volume_capacity_bytes, organization)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery-organization"
+        },
+        "description": "Weka organization the volume belongs to.",
+        "includeAll": true,
+        "allValue": ".+",
+        "multi": true,
+        "current": {
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "options": [],
+        "refresh": 2,
+        "regex": "",
+        "sort": 1,
+        "hide": 0
+      },
+      {
+        "name": "filesystem_name",
+        "label": "Filesystem",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "definition": "label_values(weka_csi_volume_capacity_bytes, filesystem_name)",
+        "query": {
+          "qryType": 1,
+          "query": "label_values(weka_csi_volume_capacity_bytes, filesystem_name)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery-filesystem_name"
+        },
+        "description": "Weka filesystem backing the volume.",
+        "includeAll": true,
+        "allValue": ".*",
+        "multi": true,
+        "current": {
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "options": [],
+        "refresh": 2,
+        "regex": "",
+        "sort": 1,
+        "hide": 0
+      },
+      {
+        "name": "storage_class_name",
+        "label": "Storage class",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "definition": "label_values(weka_csi_volume_capacity_bytes, storage_class_name)",
+        "query": {
+          "qryType": 1,
+          "query": "label_values(weka_csi_volume_capacity_bytes, storage_class_name)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery-storage_class_name"
+        },
+        "description": "StorageClass the volume was provisioned from.",
+        "includeAll": true,
+        "allValue": ".*",
+        "multi": true,
+        "current": {
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "options": [],
+        "refresh": 2,
+        "regex": "",
+        "sort": 1,
+        "hide": 0
+      },
+      {
+        "name": "pvc_namespace",
+        "label": "Namespace",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "definition": "label_values(weka_csi_volume_capacity_bytes, pvc_namespace)",
+        "query": {
+          "qryType": 1,
+          "query": "label_values(weka_csi_volume_capacity_bytes, pvc_namespace)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery-pvc_namespace"
+        },
+        "description": "Namespace of the bound PersistentVolumeClaim.",
+        "includeAll": true,
+        "allValue": ".*",
+        "multi": true,
+        "current": {
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "options": [],
+        "refresh": 2,
+        "regex": "",
+        "sort": 1,
+        "hide": 0
+      },
+      {
+        "name": "pv_name",
+        "label": "PersistentVolume",
+        "type": "query",
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "definition": "label_values(weka_csi_volume_capacity_bytes, pv_name)",
+        "query": {
+          "qryType": 1,
+          "query": "label_values(weka_csi_volume_capacity_bytes, pv_name)",
+          "refId": "PrometheusVariableQueryEditor-VariableQuery-pv_name"
+        },
+        "description": "Optional filter down to individual volumes. Leave on All and rely on the 100-series cap, or pick specific volumes to see every one of them.",
+        "includeAll": true,
+        "allValue": ".*",
+        "multi": true,
+        "current": {
+          "text": [
+            "All"
+          ],
+          "value": [
+            "$__all"
+          ]
+        },
+        "options": [],
+        "refresh": 2,
+        "regex": "",
+        "sort": 1,
+        "hide": 0
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Weka CSI volume capacity",
+  "uid": "weka-csi-volume-capacity",
+  "version": 1,
+  "weekStart": ""
+}

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -1,0 +1,230 @@
+# Monitoring the Weka CSI Plugin
+
+## Overview
+The Weka CSI Plugin exposes Prometheus metrics from every component, and ships a **metrics server**
+that reports the capacity of each provisioned volume by asking the Weka cluster directly. Two Grafana
+dashboards and a set of alert rules are included for both.
+
+| Component | Exposes | Deployed by |
+|---|---|---|
+| Controller server | CSI gRPC operations, concurrency, Weka API calls | always |
+| Node server | CSI gRPC operations, concurrency, Weka API calls | always |
+| Metrics server | Per-volume used / free / total capacity, and its own collection health | `metricsServer.enabled=true`, or the separate `csi-metricsserver` chart |
+
+The controller and node servers report only on work they perform. Volume capacity is not among that
+work - the CSI specification has no "tell me how full every volume is" call - which is why capacity
+reporting is a component of its own.
+
+---
+
+## The Metrics Server
+
+### What it does
+The metrics server watches every `PersistentVolume` provisioned by this driver, resolves each one to
+its Weka filesystem and directory, and reads its quota over the Weka REST API. From the quota it
+derives the volume's capacity (the quota's hard limit), its used bytes, and its free bytes, and
+publishes all three to Prometheus labelled with enough Kubernetes identity to be findable:
+PersistentVolume name, PersistentVolumeClaim name and namespace, StorageClass, Weka filesystem, Weka
+organization, and cluster GUID.
+
+Credentials come from the API secret each PersistentVolume references, so a fleet spread across
+several Weka clusters or several organizations is handled without extra configuration.
+
+### Deployment
+Two options, and you should pick exactly one:
+
+```console
+# alongside the CSI plugin (recommended)
+helm upgrade --install csi-wekafs charts/csi-wekafsplugin --set metricsServer.enabled=true
+
+# or standalone, for example to run it in a different namespace or on a different schedule
+helm upgrade --install csi-metricsserver charts/csi-metricsserver
+```
+
+  > **NOTE**: do not run both against the same Weka cluster. Each collector polls every volume's
+  > quota independently, so a second one doubles the Weka API load without reporting any additional
+  > data.
+
+### Permissions
+Enabling the metrics server creates its **own ServiceAccount**, separate from the controller's, and
+grants it cluster-wide read of two resources:
+
+| Resource | Verbs | Why |
+|---|---|---|
+| `persistentvolumes` | `get`, `list`, `watch` | to discover which volumes to report on |
+| `secrets` | `get`, `list` | to read the Weka API credentials each volume references |
+
+No write verb is granted on either. Namespaced, it additionally needs `leases` (for leader election)
+and `events`. Read of Secrets cluster-wide is a real widening of what the release can see - it is the
+reason the metrics server is off by default.
+
+### High availability
+The metrics server runs with `metricsServer.replicas: 2` and leader election on. Exactly one replica
+collects; the others hold a warm PersistentVolume cache and stand by. This matters for how it is
+monitored:
+
+- **Only the leader publishes volume metrics.** A standby publishes none, so scraping both replicas
+  yields exactly one copy of every volume - there is nothing to de-duplicate and no need to put a
+  proxy in front of the pods to select the leader.
+- **Standbys are not free.** Each runs its own PersistentVolume informer cache and holds a watch
+  against the Kubernetes API server while idle. On a fleet of thousands of volumes that is real
+  memory.
+- **A standby reports `Ready`.** There is deliberately no readiness probe: gating readiness on
+  leadership would hold every standby `NotReady` for its whole life, which restarts nothing but
+  raises `KubePodNotReady` and `KubeDeploymentReplicasMismatch` permanently on any cluster running
+  the kube-prometheus stack. Which replica holds leadership is visible in the `Lease` object, and on
+  the `/readyz` endpoint, not in pod status.
+
+### How quotas are fetched
+Two modes, controlled by `metricsServer.enableBatchModeForQuotaUpdates`:
+
+| Mode | Requests per cycle | When it wins |
+|---|---|---|
+| **Batch** (default, `true`) | one quota map per *filesystem* | Directory-backed volumes, which share a filesystem. A fleet of 5800 directory volumes over 5 filesystems costs 5 requests instead of 5800 |
+| Per-volume (`false`) | one per *volume* | Nothing at scale. Retained as an escape hatch |
+
+Filesystem-backed volumes hold one volume per filesystem, so batching is no worse for them.
+
+Measured on a 10,000-volume fleet, switching to batch mode took the Weka API load from **~32
+requests/second to effectively zero**.
+
+### Freshness, and the one thing that trips people up
+Quotas are cached for `metricsServer.quotaCacheValiditySeconds` (default `300`). Rather than
+pretending a cached reading is fresh, **each metric is published with the timestamp of its own
+measurement**, and the PodMonitor sets `honorTimestamps: true` so Prometheus records it at that time.
+
+The consequence is not obvious: Prometheus discards a repeated scrape of an unchanged timestamp as a
+duplicate, so **a volume produces roughly one sample per cache period, not one per scrape**. Any
+query window over these metrics must therefore be larger than `quotaCacheValiditySeconds`:
+
+```promql
+# with quotaCacheValiditySeconds=300, this reports a fraction of the fleet, varying over time
+count(count_over_time(weka_csi_volume_used_bytes[5m]))
+
+# this reports all of it
+count(count_over_time(weka_csi_volume_used_bytes[10m]))
+```
+
+Symptoms of getting this wrong are a graph that periodically loses volumes, or - in batch mode, where
+a whole filesystem's volumes share one timestamp and move together - one that drops the entire fleet
+at once and recovers. Neither is a collection failure. Raise the window, or lower
+`quotaCacheValiditySeconds` and accept the extra API load.
+
+`weka_csi_volume_pv_reported_capacity_bytes` is the exception: it comes from the Kubernetes
+PersistentVolume object rather than from Weka, needs no API call, and carries no measurement
+timestamp, so it behaves like an ordinary gauge.
+
+### Tuning
+| Value | Default | Effect |
+|---|---|---|
+| `metricsServer.metricsFetchIntervalSeconds` | `60` | How often a collection cycle runs. Only expired readings are refetched |
+| `metricsServer.quotaCacheValiditySeconds` | `300` | How long a reading stays fresh. Raise on large fleets to cut API load; every query window must stay larger than this |
+| `metricsServer.enableBatchModeForQuotaUpdates` | `true` | Whole-filesystem quota fetch instead of per-volume |
+| `metricsServer.maxConcurrentRequests` | `50` | Concurrent Weka API requests, excluding quota |
+| `metricsServer.quotaUpdateConcurrentRequests` | `25` | Concurrent quota requests |
+| `metricsServer.apiTimeoutSeconds` | `180` | Per-request timeout. Higher than the plugin-wide default because a quota map pulls every quota on a filesystem in one request |
+| `metricsServer.scrapeInterval` | `60s` | PodMonitor interval. Defaults to the fetch interval, since the gauges do not move faster than that |
+| `metricsServer.logLevel` | `4` | Deliberately below the chart-wide default: at `5` the collector logs a line per volume per cycle |
+
+### Labels
+Volume metrics carry `csi_driver_name`, `pv_name`, `cluster_guid`, `storage_class_name`,
+`filesystem_name`, `volume_type`, `organization`, `pvc_name`, `pvc_namespace`, `pvc_uid`.
+
+The PodMonitor deliberately strips `pod` (and `instance`, `job`, `namespace`, `endpoint`,
+`container`) from `weka_csi_volume_*`. A volume metric describes a volume, not the replica that
+happened to observe it, and because the collector is leader-elected, leaving `pod` on would fork a
+new series for every volume on each rollout and each failover - graphs would draw one line per pod a
+volume had ever been reported by, and any query summing across pods would double-count during a
+handover. `pod` is preserved on `weka_csi_metricsserver_*`, where the pod is precisely what is being
+described.
+
+If you scrape these metrics some other way, apply the same rule, or aggregate `pod` away in your
+queries.
+
+---
+
+## Grafana Dashboards
+The `dashboards/` directory holds ready-to-import dashboards in Grafana export format, so they are
+portable across installations.
+
+| File | Shows |
+|---|---|
+| `metricsserver-stats.json` | Metrics server health: Weka API request rate and latency, fetch cycles, quota cache behaviour, PersistentVolumes entering and leaving monitoring |
+| `volume-capacity.json` | Per-volume used, free and total capacity, plus rankings of the largest volumes, the fullest volumes, and usage by filesystem and by tenant |
+
+Import through **Dashboards -> New -> Import**, which prompts for the Prometheus datasource.
+
+  > **NOTE**: importing over the HTTP API requires `/api/dashboards/import` with an `inputs` entry
+  > for `DS_PROMETHEUS`. `/api/dashboards/db` reports success but leaves the datasource unresolved,
+  > and every panel then renders empty.
+
+### volume-capacity.json
+Four per-volume graphs - used, total, free and utilisation - each capped at the **top 100 series**,
+because a fleet of thousands is neither readable nor cheap to render. Narrow the scope with the
+Tenant, Filesystem, Storage class, Namespace and PersistentVolume variables rather than raising the
+cap. Below them are four rankings: largest volumes, fullest volumes, usage by filesystem, and usage
+by tenant.
+
+The **Value max age** variable is the one to understand. It sets the freshness window described
+above, and **must stay larger than `metricsServer.quotaCacheValiditySeconds`**. It defaults to `10m`
+against the default 300s cache; keep roughly that ratio if you change either.
+
+Utilisation panels mark 85% and 95%, matching the alert rules below.
+
+### metricsserver-stats.json
+Scoped to a single metrics-server pod through its `$pod` variable, which resolves only to
+metrics-server pods. The CSI controller and node servers are not visible in it, and on an idle
+cluster most provisioning counters are silent - a `CounterVec` with no observed labels exports
+nothing at all, so a panel reads as broken rather than as zero.
+
+---
+
+## Alerts
+`dashboards/volume-capacity-alerts.yaml` is a `PrometheusRule` for clusters running the Prometheus
+Operator:
+
+```console
+kubectl apply -n <prometheus-namespace> -f dashboards/volume-capacity-alerts.yaml
+```
+
+For a plain Prometheus, lift its `groups:` block into your own rule file.
+
+| Rule | Severity | Fires when |
+|---|---|---|
+| `WekaCsiVolumeAlmostFull` | warning | A volume is between 85% and 95% full for 15m |
+| `WekaCsiVolumeFull` | critical | A volume is at or above 95% full for 15m |
+| `WekaCsiVolumeMetricsStale` | warning | Fewer than 90% of monitored volumes have reported in 15m |
+
+`WekaCsiVolumeMetricsStale` is what makes the other two trustworthy. If collection stops, utilisation
+freezes at its last value instead of going missing, and a volume can fill without either capacity
+alert ever firing.
+
+All three use a 15m window and a 15m `for:`, both comfortably larger than the default 300s quota
+cache. **Raise them if you raise `quotaCacheValiditySeconds`**, or the alerts will flap.
+
+---
+
+## Troubleshooting
+
+**No `weka_csi_volume_*` metrics at all.** Check that the metrics server is deployed and that its
+PodMonitor was created - the chart only renders one if the `monitoring.coreos.com/v1` CRD is present
+at install time, so installing the Prometheus Operator afterwards requires a `helm upgrade`. Then
+confirm the pod is an `up` scrape target.
+
+**Volumes appear and disappear from a panel.** The query window is at or below
+`quotaCacheValiditySeconds`. See *Freshness* above.
+
+**Two or three lines per volume on a graph.** The `pod` label is still present, either because the
+PodMonitor relabeling is missing or because the metrics are scraped some other way. Aggregate `pod`
+away, or add the relabeling.
+
+**A volume is monitored but never reports.** Compare
+`weka_csi_metricsserver_monitored_persistent_volumes_gauge` against
+`count(weka_csi_volume_capacity_bytes)`. A gap means the volume was discovered but its quota could
+not be read - check `weka_csi_metricsserver_fetch_single_pv_metrics_failure_count_total` and the
+collector's logs for that PersistentVolume name.
+
+**High Weka API load.** Confirm `enableBatchModeForQuotaUpdates` is on by checking the pod's args for
+`--fetchquotasinbatchmode=true`, and watch the split between the `filesystems/{guid}/quota` and
+`fileSystems/{guid}/quota/{id}` URLs in `weka_csi_api_request_count`. Traffic on the latter means
+per-volume fetching.


### PR DESCRIPTION
### TL;DR
Adds a per-volume capacity Grafana dashboard, Prometheus alert rules, and monitoring documentation.

### What changed?
- New `volume-capacity.json` dashboard: used/free/total capacity and utilization per volume, plus rankings for largest and fullest volumes and usage by filesystem and tenant. Filterable by tenant, filesystem, storage class, namespace and PersistentVolume.
- New `volume-capacity-alerts.yaml` PrometheusRule: warns at 85% utilization, critical at 95%, plus `WekaCsiVolumeMetricsStale` and `WekaCsiVolumeCapacityNotCollected` so a stalled collector doesn't leave a frozen reading looking healthy. The warning keeps firing above 95% rather than resolving into the critical alert's wait, so add an Alertmanager `inhibit_rule` on severity if you want only one of the pair. Both capacity alerts wait 20m, longer than the window a single reading stays valid for, so one measurement cannot fire them; the two collection alerts page after about 30 minutes.
- A volume whose capacity reads zero is left out of the utilization figures rather than reported as thousands of percent full.
- New `docs/monitoring.md`, linked from the README, covering what the metrics server collects and how to troubleshoot it.

### How to test?
1. Import `dashboards/volume-capacity.json` into Grafana against a Prometheus scraping the metrics server.
2. Apply `dashboards/volume-capacity-alerts.yaml` and confirm the rules load.
3. Push a test volume above 85% and 95% usage and confirm the alerts fire.
4. Stop the metrics server and confirm `WekaCsiVolumeCapacityNotCollected` fires and stays firing while it is down — including with a standby replica still running, which keeps the metrics endpoint scrapeable.

### Why make this change?
The metrics server already collected per-volume capacity but nothing charted or alerted on it. Both the dashboard and alert time windows exceed `quotaCacheValiditySeconds`, since each volume emits roughly one sample per cache period and a narrower window would show volumes as missing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and optional Grafana/Prometheus artifacts only; no driver or metrics-server code changes.
> 
> **Overview**
> Ships **observability for per-volume capacity** that the metrics server already exposes: a Grafana dashboard, matching Prometheus alerts, and operator-facing documentation.
> 
> **New `dashboards/volume-capacity.json`** charts used, total, free, and utilization (85%/95% thresholds), with top-100 caps and filters (tenant, filesystem, storage class, namespace, PV). Rankings cover largest volumes, fullest volumes, and rollups by filesystem and tenant. Queries use **`last_over_time` with a `value_max_age` window** (default 10m) so panels stay correct when samples arrive ~once per **`quotaCacheValiditySeconds`** cache period; utilization excludes zero-capacity volumes via **`capacity > 0`**.
> 
> **New `dashboards/volume-capacity-alerts.yaml`** adds a **`weka_csi_volume:used_ratio`** recording rule plus **`WekaCsiVolumeAlmostFull`** (≥85%, 20m) and **`WekaCsiVolumeFull`** (≥95%, 20m), and **`WekaCsiVolumeMetricsStale`** / **`WekaCsiVolumeCapacityNotCollected`** so frozen last readings do not look healthy when collection stops.
> 
> **New `docs/monitoring.md`** (linked from the README template) documents the metrics server, import/alert apply steps, cache/timestamp behavior, and troubleshooting. **`.claude/CLAUDE.md`** documents the **`dashboards/`** tree and the quota-cache / **`SetWithTimestamp`** convention for dashboards and alerts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f12b6be62f7644284f324422a914352d5c842909. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->