### PR TITLE
refactor: remove the "all" CSI plugin mode

### DIFF
--- a/cmd/wekafsplugin/main.go
+++ b/cmd/wekafsplugin/main.go
@@ -33,7 +33,7 @@ import (
 
 var (
 	mutuallyExclusiveMountOptionsStrings wekafs.MutuallyExclusiveMountOptsStrings
-	csiMode                              = wekafs.CsiPluginMode("all")
+	csiMode                              = wekafs.CsiPluginMode("")
 	endpoint                             = flag.String("endpoint", "unix://tmp/csi.sock", "CSI endpoint")
 	driverName                           = flag.String("drivername", "csi.weka.io", "name of the driver")
 	debugPath                            = flag.String("debugpath", "",
@@ -44,7 +44,7 @@ var (
 	showVersion       = flag.Bool("version", false, "Show version.")
 	dynamicSubPath    = flag.String("dynamic-path", "csi-volumes",
 		"Store dynamically provisioned volumes in subdirectory rather than in root directory of th filesystem")
-	csimodetext                          = flag.String("csimode", "all", "Mode of CSI plugin, either \"controller\", \"node\", \"all\" (default), or \"metricsserver\"")
+	csimodetext                          = flag.String("csimode", "", "Mode of CSI plugin, either \"controller\", \"node\", or \"metricsserver\" (required, no default)")
 	selinuxSupport                       = flag.Bool("selinux-support", false, "Enable support for SELinux")
 	newVolumePrefix                      = flag.String("newvolumeprefix", "csivol-", "Prefix for Weka volumes and snapshots that represent a CSI volume")
 	newSnapshotPrefix                    = flag.String("newsnapshotprefix", "csisnp-", "Prefix for Weka snapshots that represent a CSI snapshot")
@@ -88,8 +88,8 @@ var (
 	keepThinProvisioningRatioOnExpand    = flag.Bool("keepthinprovisioningratioonexpand", true, "On filesystem expansion, scale thin-provisioning min-SSD and max-SSD to preserve their ratios to total capacity")
 	advertiseVolumeHealthSupport         = flag.Bool("advertisevolumehealthsupport", true, "Expose GET_VOLUME and VOLUME_CONDITION, allowing the CSI health monitor to report volume condition and capacity")
 
-	// Metrics server settings. These only take effect when csimode is "metricsserver" or "all" -
-	// the metrics server itself is only ever constructed for those modes (see NewWekaFsDriver).
+	// Metrics server settings. These only take effect when csimode is "metricsserver" -
+	// the metrics server itself is only ever constructed for that mode (see NewWekaFsDriver).
 	wekaMetricsFetchIntervalSeconds          = flag.Int("wekametricsfetchintervalseconds", 60, "Interval in seconds to fetch metrics from Weka cluster")
 	wekaMetricsFetchConcurrentRequests       = flag.Int("wekametricsfetchconcurrentrequests", 1, "Maximum concurrent requests to fetch metrics from Weka cluster")
 	enableMetricsServerLeaderElection        = flag.Bool("enablemetricsserverleaderelection", false, "Enable leader election for metrics server")
@@ -113,8 +113,9 @@ func main() {
 		fmt.Println(baseName, version)
 		return
 	}
-	if csiMode != wekafs.CsiModeAll && csiMode != wekafs.CsiModeController && csiMode != wekafs.CsiModeNode && csiMode != wekafs.CsiModeMetricsServer {
-		log.Panic().Str("requestedCsiMode", string(csiMode)).Msg("Invalid mode specified for CSI driver")
+	if csiMode != wekafs.CsiModeController && csiMode != wekafs.CsiModeNode && csiMode != wekafs.CsiModeMetricsServer {
+		log.Panic().Str("requestedCsiMode", string(csiMode)).
+			Msg(`Invalid mode specified for CSI driver: must be one of "controller", "node", or "metricsserver" - the "all" mode has been removed, run controller and node as separate deployments`)
 	}
 	log.Info().Str("csi_mode", string(csiMode)).Bool("selinux_mode", *selinuxSupport).Msg("Started CSI driver")
 
@@ -124,10 +125,10 @@ func main() {
 		// role this process serves - a node pod exporting a permanently-zero set of controller
 		// series would be misleading.
 		prometheus.MustRegister(apiclient.Collectors()...)
-		if csiMode == wekafs.CsiModeController || csiMode == wekafs.CsiModeAll {
+		if csiMode == wekafs.CsiModeController {
 			prometheus.MustRegister(wekafs.ControllerCollectors()...)
 		}
-		if csiMode == wekafs.CsiModeNode || csiMode == wekafs.CsiModeAll {
+		if csiMode == wekafs.CsiModeNode {
 			prometheus.MustRegister(wekafs.NodeCollectors()...)
 		}
 		bootstrap.ServeMetrics(*metricsPort)
@@ -207,7 +208,7 @@ func handle(ctx context.Context) {
 	config.SetDriver(driver)
 
 	// Register the metrics server's own collectors, but only if metrics export is on in the first
-	// place and a metrics server was actually constructed (csimode "metricsserver" or "all" - see
+	// place and a metrics server was actually constructed (csimode "metricsserver" - see
 	// NewWekaFsDriver) - a driver running in another mode must export nothing. This has to happen
 	// here rather than alongside the other collectors above: those are
 	// registered before the driver exists, and the metrics server (if any) is only built once

--- a/pkg/wekafs/constants.go
+++ b/pkg/wekafs/constants.go
@@ -40,7 +40,6 @@ const (
 
 	CsiModeNode          CsiPluginMode = "node"
 	CsiModeController    CsiPluginMode = "controller"
-	CsiModeAll           CsiPluginMode = "all"
 	CsiModeMetricsServer CsiPluginMode = "metricsserver"
 )
 

--- a/pkg/wekafs/driver.go
+++ b/pkg/wekafs/driver.go
@@ -113,7 +113,7 @@ func NewWekaFsDriver(
 
 	// The metrics server lists PersistentVolumes cluster-wide through the controller-runtime manager,
 	// so it is only ever constructed for the modes that run one - CsiModeMetricsServer (its own
-	// Deployment) or CsiModeAll. It must never be constructed merely because the controller or node
+	// Deployment). It must never be constructed merely because the controller or node
 	// service is running, and never for a node-only pod, which would otherwise list the same
 	// cluster-wide PVs from every node. Constructing it here rather than lazily in Run() lets main.go
 	// register its Prometheus collectors right after the driver is built, before Run() blocks for the
@@ -121,9 +121,9 @@ func NewWekaFsDriver(
 	//
 	// How a failure is handled depends on the mode. A CsiModeMetricsServer pod exists only to export
 	// metrics, so one that came up without a metrics server would sit there looking healthy while
-	// collecting nothing - fail instead, and let the Deployment surface it. Under CsiModeAll the CSI
+	// collecting nothing - fail instead, and let the Deployment surface it. Under the CSI
 	// services are the job and metrics are a bonus, so carry on without them.
-	if csiMode == CsiModeMetricsServer || csiMode == CsiModeAll {
+	if csiMode == CsiModeMetricsServer {
 		ms, err := NewMetricsServer(driver)
 		if err != nil {
 			if csiMode == CsiModeMetricsServer {
@@ -140,7 +140,7 @@ func NewWekaFsDriver(
 
 func (driver *WekaFsDriver) Run(ctx context.Context) {
 	// cleanup of stale leader file on container crash/restart
-	if driver.csiMode == CsiModeController || driver.csiMode == CsiModeAll {
+	if driver.csiMode == CsiModeController {
 		if err := removeLeaderReadyFile(); err != nil {
 			log.Warn().Err(err).Msg("Failed to remove stale leader ready file on startup")
 		}
@@ -159,7 +159,7 @@ func (driver *WekaFsDriver) Run(ctx context.Context) {
 		driver.ids = NewIdentityServer(driver.name, driver.version, driver.config)
 	}
 
-	if driver.csiMode == CsiModeController || driver.csiMode == CsiModeAll {
+	if driver.csiMode == CsiModeController {
 		log.Info().Msg("Loading ControllerServer")
 
 		// Initialize manager with leader election
@@ -172,7 +172,7 @@ func (driver *WekaFsDriver) Run(ctx context.Context) {
 		driver.cs = &ControllerServer{}
 	}
 
-	if driver.csiMode == CsiModeNode || driver.csiMode == CsiModeAll {
+	if driver.csiMode == CsiModeNode {
 		// only if we manage node labels, first clean up before starting node server
 		if driver.config.manageNodeTopologyLabels {
 			log.Info().Msg("Cleaning up node stale labels")
@@ -221,7 +221,7 @@ func (driver *WekaFsDriver) Run(ctx context.Context) {
 	// Controller/metrics-server mode with manager: use leader election
 	// Controller mode without manager (not in K8s): run without leader election
 	// Node-only mode: run without leader election
-	if (driver.csiMode == CsiModeController || driver.csiMode == CsiModeAll || driver.csiMode == CsiModeMetricsServer) && driver.manager != nil {
+	if (driver.csiMode == CsiModeController || driver.csiMode == CsiModeMetricsServer) && driver.manager != nil {
 		driver.runWithLeaderElection(ctx, termContext, s)
 	} else {
 		driver.runWithoutLeaderElection(ctx, termContext, s)
@@ -331,7 +331,7 @@ func (d *WekaFsDriver) initManager(ctx context.Context, leaderElection bool) err
 	// Registering the index starts a PV informer, so only do it where it is actually used - keyed
 	// on the csiMode that serves the controller service, which is also what gates advertising the
 	// capability, rather than on leaderElection which merely happens to correlate today.
-	servesControllerService := d.csiMode == CsiModeController || d.csiMode == CsiModeAll
+	servesControllerService := d.csiMode == CsiModeController
 	if servesControllerService && d.config.advertiseVolumeHealthSupport {
 		if err := mgr.GetFieldIndexer().IndexField(ctx, &v1.PersistentVolume{}, pvIndexVolumeHandle,
 			func(obj runtimeclient.Object) []string {
@@ -426,7 +426,7 @@ func (d *WekaFsDriver) SetNodeLabels(ctx context.Context) {
 		return
 	}
 
-	if d.csiMode != CsiModeNode && d.csiMode != CsiModeAll {
+	if d.csiMode != CsiModeNode {
 		return
 	}
 	config, err := rest.InClusterConfig()

--- a/pkg/wekafs/driverconfig.go
+++ b/pkg/wekafs/driverconfig.go
@@ -56,8 +56,8 @@ type DriverConfig struct {
 	keepThinProvisioningRatioOnExpand bool
 
 	// Metrics server settings. Whether a MetricsServer is constructed at all in NewWekaFsDriver is
-	// gated on csiMode (CsiModeMetricsServer or CsiModeAll), not on any of these; the settings below
-	// only matter to the metrics server lifecycle (see metricsserver.go) once it is running.
+	// gated on csiMode (CsiModeMetricsServer), not on any of these; the settings below only matter to
+	// the metrics server lifecycle (see metricsserver.go) once it is running.
 	metricsFetchInterval              time.Duration // how often the PV streamer refreshes its list and re-polls Weka for stats
 	metricsFetchConcurrentRequests    int           // concurrency cap for both PV processing and single-metric fetches
 	enableMetricsServerLeaderElection bool          // gate the metrics server's readiness on holding leadership

--- a/pkg/wekafs/identityserver.go
+++ b/pkg/wekafs/identityserver.go
@@ -109,7 +109,7 @@ func (ids *identityServer) Probe(ctx context.Context, req *csi.ProbeRequest) (*c
 	if ids.config.manageNodeTopologyLabels {
 		if !isReady {
 			logger.Error().Msg("CSI Probe FAILED: Weka driver not running on host and NFS transport is not configured, not ready to perform operations")
-			if ids.config.driverRef.csiMode == CsiModeNode || ids.config.driverRef.csiMode == CsiModeAll {
+			if ids.config.driverRef.csiMode == CsiModeNode {
 				ids.getConfig().GetDriver().CleanupNodeLabels(ctx)
 			}
 		} else if !ids.getConfig().isInDevMode() {

--- a/pkg/wekafs/leaderelection.go
+++ b/pkg/wekafs/leaderelection.go
@@ -44,17 +44,13 @@ func (driver *WekaFsDriver) runWithLeaderElection(ctx context.Context, termConte
 	}
 
 	// Register the metrics server's health checks and leadership-gated Runnable, same as the health
-	// reconciler above. Nil-guarded since it is only constructed for the modes that run one - under
-	// CsiModeAll it may legitimately be absent (see NewWekaFsDriver). Must happen before
-	// driver.manager.Start below - controller-runtime rejects Add calls once the manager is started.
-	// A failure is fatal in a dedicated metrics-server pod, whose only job this is, and tolerated under
-	// CsiModeAll, where the CSI services carry on without metrics (same split as in NewWekaFsDriver).
+	// reconciler above. Nil-guarded since it is only constructed for the mode that runs it -
+	// CsiModeMetricsServer (see NewWekaFsDriver). Must happen before driver.manager.Start below -
+	// controller-runtime rejects Add calls once the manager is started. A failure is fatal in a
+	// dedicated metrics-server pod, whose only job this is.
 	if driver.ms != nil {
 		if err := driver.ms.AddToManager(); err != nil {
-			if driver.csiMode == CsiModeMetricsServer {
-				log.Fatal().Err(err).Msg("Failed to register metrics server, nothing left for this pod to run")
-			}
-			log.Error().Err(err).Msg("Failed to register metrics server, metrics will not be available")
+			log.Fatal().Err(err).Msg("Failed to register metrics server, nothing left for this pod to run")
 		}
 	}
 
@@ -104,11 +100,9 @@ func (driver *WekaFsDriver) runWithLeaderElection(ctx context.Context, termConte
 		<-termContext.Done()
 		log.Info().Msg("Received termination signal")
 
+		// This path only ever runs for CsiModeController or CsiModeMetricsServer (see Run in
+		// driver.go), neither of which owns node labels, so there is no node cleanup to do here.
 		shutdownOnce.Do(func() {
-			if (driver.csiMode == CsiModeNode || driver.csiMode == CsiModeAll) &&
-				driver.config.manageNodeTopologyLabels {
-				driver.CleanupNodeLabels(ctx)
-			}
 			cancelRun()
 		})
 	}()
@@ -141,7 +135,7 @@ func (driver *WekaFsDriver) runWithoutLeaderElection(ctx context.Context, termCo
 
 	go func() {
 		<-termContext.Done()
-		if (driver.csiMode == CsiModeNode || driver.csiMode == CsiModeAll) &&
+		if driver.csiMode == CsiModeNode &&
 			driver.config.manageNodeTopologyLabels {
 			log.Info().Msg("Cleanup of node labels...")
 			driver.CleanupNodeLabels(ctx)

--- a/pkg/wekafs/leaderelection_id_test.go
+++ b/pkg/wekafs/leaderelection_id_test.go
@@ -10,20 +10,14 @@ func TestLeaderElectionIDIsSeparatePerRole(t *testing.T) {
 	const driver = "csi.weka.io"
 
 	controller := leaderElectionIDForMode(driver, CsiModeController)
-	all := leaderElectionIDForMode(driver, CsiModeAll)
 	metricsServer := leaderElectionIDForMode(driver, CsiModeMetricsServer)
 
 	if metricsServer == controller {
 		t.Errorf("metrics server and controller share the lease %q - they would compete for it", controller)
 	}
 
-	// A driver serving the controller service must keep the same lease whichever mode it runs in,
-	// or an "all" pod and a "controller" pod in one release would each elect their own leader.
-	if all != controller {
-		t.Errorf("CsiModeAll uses %q but CsiModeController uses %q - both serve the controller service", all, controller)
-	}
-
-	// Unchanged on purpose: renaming it would split leadership across a rolling upgrade.
+	// Unchanged on purpose: renaming it would split leadership across a rolling upgrade - old and new
+	// pods from the same release would each elect their own leader instead of one.
 	if controller != "csi.weka.io-controller-leader" {
 		t.Errorf("controller lease is %q, want csi.weka.io-controller-leader - renaming splits leadership mid-upgrade", controller)
 	}

--- a/pkg/wekafs/mountergroup_test.go
+++ b/pkg/wekafs/mountergroup_test.go
@@ -26,8 +26,8 @@ func TestGetDataTransportFromMountPath(t *testing.T) {
 		"nfs mount under the controller base": {
 			mountBaseDirForRole(CsiModeController, dataTransportNfs) + "/default-abc123", dataTransportNfs,
 		},
-		"wekafs mount under the default base": {
-			mountBaseDirForRole(CsiModeAll, dataTransportWekafs) + "/default-abc123", dataTransportWekafs,
+		"wekafs mount under the metrics-server (default) base": {
+			mountBaseDirForRole(CsiModeMetricsServer, dataTransportWekafs) + "/default-abc123", dataTransportWekafs,
 		},
 		// A filesystem may legitimately be called "nfs"; only the path segment decides.
 		"filesystem named nfs on a wekafs mount": {
@@ -50,7 +50,7 @@ func TestGetDataTransportFromMountPath(t *testing.T) {
 // both mounters name a mount {fsName}-{sha1(fsName:options)}, so identical option strings would
 // otherwise produce identical paths and unmounting one would tear down the other.
 func TestMountBaseDirsAreDisjointPerTransport(t *testing.T) {
-	for _, mode := range []CsiPluginMode{CsiModeNode, CsiModeController, CsiModeAll} {
+	for _, mode := range []CsiPluginMode{CsiModeNode, CsiModeController} {
 		nfs := mountBaseDirForRole(mode, dataTransportNfs)
 		wekafs := mountBaseDirForRole(mode, dataTransportWekafs)
 		if nfs == wekafs {

--- a/pkg/wekafs/server.go
+++ b/pkg/wekafs/server.go
@@ -102,13 +102,13 @@ func (s *nonBlockingGRPCServer) serve(endpoint string, ids csi.IdentityServer, c
 		log.Info().Msg("Registering GRPC IdentityServer")
 		csi.RegisterIdentityServer(server, ids)
 	}
-	if s.csiMmode == CsiModeController || s.csiMmode == CsiModeAll {
+	if s.csiMmode == CsiModeController {
 		if cs != nil {
 			log.Info().Msg("Registering GRPC ControllerServer")
 			csi.RegisterControllerServer(server, cs)
 		}
 	}
-	if s.csiMmode == CsiModeNode || s.csiMmode == CsiModeAll {
+	if s.csiMmode == CsiModeNode {
 		if ns != nil {
 			log.Info().Msg("Registering GRPC NodeServer")
 			csi.RegisterNodeServer(server, ns)

--- a/pkg/wekafs/utilities.go
+++ b/pkg/wekafs/utilities.go
@@ -663,18 +663,11 @@ func trimValue(value string) string {
 	return strings.TrimSpace(strings.TrimSuffix(value, "\n"))
 }
 
+// GetCsiPluginMode converts the raw --csimode flag value to a CsiPluginMode. It does not validate:
+// the caller (main) owns that, so it can name the accepted modes and explain a rejected one (e.g. the
+// removed "all" mode) in a single place rather than duplicating the check here.
 func GetCsiPluginMode(mode *string) CsiPluginMode {
-	ret := CsiPluginMode(*mode)
-	switch ret {
-	case CsiModeNode,
-		CsiModeController,
-		CsiModeAll,
-		CsiModeMetricsServer:
-		return ret
-	default:
-		log.Fatal().Str("required_plugin_mode", string(ret)).Msg("Unsupported plugin mode")
-		return ""
-	}
+	return CsiPluginMode(*mode)
 }
 
 // stripUnnecessaryPVFields creates a minimal PV with only fields needed by the plugin features

--- a/pkg/wekafs/volume_test.go
+++ b/pkg/wekafs/volume_test.go
@@ -52,7 +52,7 @@ func GetDriverForTest(t *testing.T) *WekaFsDriver {
 
 		KeepThinProvisioningRatioOnExpand: true,
 	})
-	driver, err := NewWekaFsDriver("csi.weka.io", nodeId, "unix://tmp/csi.sock", 10, "v1.0", "", CsiModeAll, false, driverConfig)
+	driver, err := NewWekaFsDriver("csi.weka.io", nodeId, "unix://tmp/csi.sock", 10, "v1.0", "", CsiModeController, false, driverConfig)
 	if err != nil {
 		t.Fatalf("Failed to create new driver: %v", err)
 	}

--- a/pkg/wekafs/volumehealthreconciler_metrics_test.go
+++ b/pkg/wekafs/volumehealthreconciler_metrics_test.go
@@ -115,7 +115,7 @@ func newHealthReconcilerTestServer(t *testing.T, objs ...runtimeclient.Object) (
 		UseNfs:           false,
 	})
 
-	driver, err := NewWekaFsDriver("csi.weka.io", "localhost", "unix://tmp/csi.sock", 10, "v1.0", "", CsiModeAll, false, driverConfig)
+	driver, err := NewWekaFsDriver("csi.weka.io", "localhost", "unix://tmp/csi.sock", 10, "v1.0", "", CsiModeController, false, driverConfig)
 	if err != nil {
 		t.Fatalf("failed to create driver: %v", err)
 	}

--- a/pkg/wekafs/wekafsmounter.go
+++ b/pkg/wekafs/wekafsmounter.go
@@ -32,7 +32,14 @@ func mountBaseDirForRole(mode CsiPluginMode, transport DataTransport) string {
 		base = "/run/weka-fs-mounts-node"
 	case CsiModeController:
 		base = "/run/weka-fs-mounts-controller"
+	case CsiModeMetricsServer:
+		// Mounters are only ever built when csiMode.servesCsiGrpc() is true (see driver.go), which
+		// excludes CsiModeMetricsServer, so this base is never actually used in production - listed
+		// explicitly so the switch stays exhaustive over every CsiPluginMode rather than relying on a
+		// silent catch-all.
+		base = "/run/weka-fs-mounts"
 	default:
+		log.Warn().Str("mode", string(mode)).Msg("mountBaseDirForRole: unrecognized CSI plugin mode, using generic mount base dir")
 		base = "/run/weka-fs-mounts"
 	}
 	return path.Join(base, string(transport))


### PR DESCRIPTION
### TL;DR
Removes the "all" CSI plugin mode; breaking only for anyone running the binary directly rather than via the Helm charts.

### What changed?
- `CsiModeAll`, which ran controller and node in one process, is removed. The Helm charts always set `--csimode` explicitly (`controller` on the Deployment, `node` on the DaemonSet), so chart users are unaffected.
- `--csimode` is now required: the binary refuses to start with no mode or an unrecognized one, naming the valid modes and noting that "all" was removed.

### How to test?
Run the binary with no `--csimode` and confirm it exits immediately with an error naming the valid modes, instead of starting in a partial, ambiguous state. Also covered by automated tests.

### Why make this change?
Nothing deployed the "all" mode, and supporting it doubled several code paths for no benefit. Anyone invoking the binary directly without `--csimode` — previously silently treated as "all" — must now pass an explicit mode; this trades a silently degraded startup for a clear failure.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking change for anyone invoking the binary without `--csimode` or relying on `"all"`; Helm/chart users with explicit modes are unaffected, but misconfiguration now fails hard at startup instead of running a combined role.
> 
> **Overview**
> Removes **`CsiModeAll`**, which ran controller and node CSI services in one process. The plugin now accepts only **`controller`**, **`node`**, or **`metricsserver`**.
> 
> **Startup:** `--csimode` has **no default** (was `"all"`). Missing or invalid values **panic** with a message that `"all"` was removed and controller/node must be separate deployments. **`GetCsiPluginMode`** only parses the flag; validation lives in **`main`**.
> 
> **Runtime:** Mode checks drop **`|| CsiModeAll`** everywhere—gRPC registration, leader election, Prometheus collectors, node topology labels, metrics-server construction, and PV indexing. The **metrics server** is built **only** in **`metricsserver`** mode; init/register failures are **always fatal** (no more “continue without metrics” under combined mode). Leader-election shutdown no longer tries node-label cleanup on paths that only run for controller/metrics-server.
> 
> **Tests** switch from **`CsiModeAll`** to **`CsiModeController`**; leader-election ID tests no longer assert **`all`** shares the controller lease. **`mountBaseDirForRole`** adds an explicit **`metricsserver`** case for exhaustiveness (unused in production because that mode has no CSI gRPC/mounters).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81bd8818e12d9e8a391ba9f89f452d593c4cf5c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->