### PR TITLE
fix(CSI-384): read node labels through the controller-runtime client

### DIFF
--- a/pkg/wekafs/driver.go
+++ b/pkg/wekafs/driver.go
@@ -30,10 +30,9 @@ import (
 
 	"github.com/rs/zerolog/log"
 	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/client-go/kubernetes"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -106,33 +105,28 @@ func NewWekaFsDriver(
 		maxVolumesPerNode: maxVolumesPerNode,
 		api:               NewApiStore(config, nodeID, driverName),
 		debugPath:         debugPath,
-		csiMode:           csiMode, // either "controller", "node", "all"
+		csiMode:           csiMode, // either "controller", "node", or "metricsserver"
 		selinuxSupport:    selinuxSupport,
 		config:            config,
 	}
 
 	// The metrics server lists PersistentVolumes cluster-wide through the controller-runtime manager,
-	// so it is only ever constructed for the modes that run one - CsiModeMetricsServer (its own
-	// Deployment). It must never be constructed merely because the controller or node
-	// service is running, and never for a node-only pod, which would otherwise list the same
-	// cluster-wide PVs from every node. Constructing it here rather than lazily in Run() lets main.go
-	// register its Prometheus collectors right after the driver is built, before Run() blocks for the
-	// lifetime of the process.
+	// so it is only ever constructed for the mode that runs it - CsiModeMetricsServer (its own
+	// Deployment). It must never be constructed merely because the controller or node service is
+	// running, and never for a node-only pod, which would otherwise list the same cluster-wide PVs
+	// from every node. Constructing it here rather than lazily in Run() lets main.go register its
+	// Prometheus collectors right after the driver is built, before Run() blocks for the lifetime of
+	// the process.
 	//
-	// How a failure is handled depends on the mode. A CsiModeMetricsServer pod exists only to export
-	// metrics, so one that came up without a metrics server would sit there looking healthy while
-	// collecting nothing - fail instead, and let the Deployment surface it. Under the CSI
-	// services are the job and metrics are a bonus, so carry on without them.
+	// A CsiModeMetricsServer pod exists only to export metrics, so one that came up without a metrics
+	// server would sit there looking healthy while collecting nothing - fail instead, and let the
+	// Deployment surface it.
 	if csiMode == CsiModeMetricsServer {
 		ms, err := NewMetricsServer(driver)
 		if err != nil {
-			if csiMode == CsiModeMetricsServer {
-				return nil, fmt.Errorf("failed to initialize metrics server: %w", err)
-			}
-			log.Warn().Err(err).Msg("Failed to initialize metrics server, continuing without it")
-		} else {
-			driver.ms = ms
+			return nil, fmt.Errorf("failed to initialize metrics server: %w", err)
 		}
+		driver.ms = ms
 	}
 
 	return driver, nil
@@ -179,14 +173,11 @@ func (driver *WekaFsDriver) Run(ctx context.Context) {
 			driver.CleanupNodeLabels(ctx)
 		}
 
-		// In node-only mode the controller block above didn't run, so the manager (and
-		// its embedded K8s client) is not yet initialized.  Initialize it now without
-		// leader election – the node server only needs the client to read PVC/Pod
-		// annotations for per-pod mount option overrides.
-		if driver.csiMode == CsiModeNode {
-			if err := driver.initManager(ctx, false); err != nil {
-				log.Warn().Err(err).Msg("Failed to initialize Kubernetes client for node mode, per-pod mount option overrides will be unavailable")
-			}
+		// The controller block above didn't run in node mode, so the manager (and its embedded K8s
+		// client) is not yet initialized. Initialize it now without leader election – the node server
+		// only needs the client to read PVC/Pod annotations for per-pod mount option overrides.
+		if err := driver.initManager(ctx, false); err != nil {
+			log.Warn().Err(err).Msg("Failed to initialize Kubernetes client for node mode, per-pod mount option overrides will be unavailable")
 		}
 
 		log.Info().Msg("Loading NodeServer")
@@ -278,17 +269,29 @@ func (d *WekaFsDriver) initManager(ctx context.Context, leaderElection bool) err
 	zapLogger := zap.New(zap.UseDevMode(false))
 	clog.SetLogger(zapLogger)
 
+	byObject := map[runtimeclient.Object]cache.ByObject{}
+
 	// When PVs are cached at all, keep only the fields the driver reads, so a large cluster's PV
 	// list stays cheap in memory.
-	cacheOpts := cache.Options{}
 	if d.config.requiresPvCaching() {
-		cacheOpts = cache.Options{
-			ByObject: map[runtimeclient.Object]cache.ByObject{
-				&v1.PersistentVolume{}: {
-					Transform: stripUnnecessaryPVFields,
-				},
-			},
+		byObject[&v1.PersistentVolume{}] = cache.ByObject{
+			Transform: stripUnnecessaryPVFields,
 		}
+	}
+
+	// The node server reads its own Node object to reconcile topology labels. controller-runtime
+	// starts an informer lazily on the first Get of a type, so without this the node pod would
+	// LIST and WATCH every Node in the cluster - on a large fleet that is one full Node cache per
+	// node pod. Scope it to this node alone; no other role touches Node objects.
+	if d.csiMode == CsiModeNode {
+		byObject[&v1.Node{}] = cache.ByObject{
+			Field: fields.OneTermEqualSelector("metadata.name", d.nodeID),
+		}
+	}
+
+	cacheOpts := cache.Options{}
+	if len(byObject) > 0 {
+		cacheOpts.ByObject = byObject
 	}
 
 	mgrOpts := ctrl.Options{
@@ -394,143 +397,4 @@ func (d *WekaFsDriver) initManager(ctx context.Context, leaderElection bool) err
 		Str("namespace", mgrOpts.LeaderElectionNamespace).
 		Msg("Kubernetes manager initialized")
 	return nil
-}
-
-// readNodeTopologyLabels reads the standard topology.kubernetes.io/zone and region
-// labels from the Kubernetes node object and stores them on the NodeServer.
-// Called once at startup before gRPC registration.
-func (d *WekaFsDriver) readNodeTopologyLabels(ctx context.Context) {
-	if d.ns == nil || d.manager == nil {
-		return
-	}
-	// Use the API reader (direct client) instead of the cached client because
-	// this runs before the manager is started and its informer cache is synced.
-	readCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
-	defer cancel()
-	node := &v1.Node{}
-	if err := d.manager.GetAPIReader().Get(readCtx, runtimeclient.ObjectKey{Name: d.nodeID}, node); err != nil {
-		log.Warn().Err(err).Msg("Failed to get node object for reading topology labels")
-		return
-	}
-	if zone, ok := node.Labels[TopologyKeyZone]; ok {
-		d.ns.zone = zone
-	}
-	if region, ok := node.Labels[TopologyKeyRegion]; ok {
-		d.ns.region = region
-	}
-	log.Info().Str("zone", d.ns.zone).Str("region", d.ns.region).Msg("Read standard topology labels from node")
-}
-
-func (d *WekaFsDriver) SetNodeLabels(ctx context.Context) {
-	if d.config.isInDevMode() {
-		return
-	}
-
-	if d.csiMode != CsiModeNode {
-		return
-	}
-	config, err := rest.InClusterConfig()
-	if err != nil {
-		log.Error().Err(err).Msg("Failed to create in-cluster config")
-		return
-	}
-
-	clientset, err := kubernetes.NewForConfig(config)
-	if err != nil {
-		log.Error().Err(err).Msg("Failed to create Kubernetes client")
-		return
-	}
-
-	node, err := clientset.CoreV1().Nodes().Get(ctx, d.nodeID, metav1.GetOptions{})
-	if err != nil {
-		log.Error().Err(err).Msg("Failed to get node object from Kubernetes")
-		return
-	}
-
-	transport := func() string {
-		if d.config.useNfs {
-			return "nfs"
-		}
-		wekaRunning := isWekaRunning(ctx)
-		if d.config.allowNfsFailback && !wekaRunning {
-			return "nfs"
-		}
-		return "wekafs"
-	}()
-
-	labelsToSet := make(map[string]string)
-	labelsToSet[TopologyKeyNode] = d.nodeID
-	labelsToSet[fmt.Sprintf(TopologyLabelNodePattern, d.name)] = d.nodeID
-	labelsToSet[fmt.Sprintf(TopologyLabelWekaLocalPattern, d.name)] = "true"
-	labelsToSet[fmt.Sprintf(TopologyLabelTransportPattern, d.name)] = transport
-	updateNeeded := false
-
-	for label, value := range labelsToSet {
-		existing, ok := node.Labels[label]
-		if !ok || existing != value {
-			log.Info().Str("label", fmt.Sprintf("%s=%s", label, value)).Str("node", node.Name).Msg("Setting label on node")
-			node.Labels[label] = value
-			updateNeeded = true
-		}
-	}
-
-	if !updateNeeded {
-		return
-	}
-
-	_, err = clientset.CoreV1().Nodes().Update(ctx, node, metav1.UpdateOptions{})
-	if err != nil {
-		log.Error().Err(err).Msg("Failed to update node labels")
-		return
-	}
-
-	log.Info().Msg("Successfully updated labels on node")
-}
-func (d *WekaFsDriver) CleanupNodeLabels(ctx context.Context) {
-	if d.config.isInDevMode() {
-		return
-	}
-	nodeLabelPatternsToRemove := []string{TopologyLabelNodePattern, TopologyLabelTransportPattern, TopologyLabelWekaLocalPattern}
-	nodeLabelsToRemove := []string{TopologyLabelTransportGlobal, TopologyLabelNodeGlobal, TopologyKeyNode}
-
-	for i, labelPattern := range nodeLabelPatternsToRemove {
-		nodeLabelPatternsToRemove[i] = fmt.Sprintf(labelPattern, d.name)
-	}
-	labelsToRemove := append(nodeLabelsToRemove, nodeLabelPatternsToRemove...)
-
-	config, err := rest.InClusterConfig()
-	if err != nil {
-		log.Error().Err(err).Msg("Failed to create in-cluster config")
-		return
-	}
-
-	clientset, err := kubernetes.NewForConfig(config)
-	if err != nil {
-		log.Error().Err(err).Msg("Failed to create Kubernetes client")
-		return
-	}
-
-	node, err := clientset.CoreV1().Nodes().Get(ctx, d.nodeID, metav1.GetOptions{})
-	if err != nil {
-		log.Error().Err(err).Msg("Failed to get node")
-		return
-	}
-
-	for _, label := range labelsToRemove {
-		delete(node.Labels, label)
-		log.Info().Str("label", label).Str("node", node.Name).Msg("Removing label from node")
-	}
-
-	_, err = clientset.CoreV1().Nodes().Update(ctx, node, metav1.UpdateOptions{})
-	if err != nil {
-		log.Error().Err(err).Msg("Failed to update node labels")
-		return
-	}
-
-	log.Info().Msg("Successfully removed labels from node")
-
-	//output, err := exec.Command("/bin/kubectl", "label", "node", d.nodeID, labelsString).Output()
-	//if err != nil {
-	//	log.Error().Err(err).Str("output", string(output)).Msg("Failed to remove labels from node")
-	//}
 }

--- a/pkg/wekafs/nodelabels.go
+++ b/pkg/wekafs/nodelabels.go
@@ -1,0 +1,180 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package wekafs
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/rs/zerolog/log"
+	v1 "k8s.io/api/core/v1"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// applyNodeLabels fetches nodeName through client and ensures all of desired are present on it, issuing
+// an Update only if something is actually missing or different. client is d.manager.GetClient(), whose
+// cache for the Node type is scoped to this node alone (see initManager in driver.go), so this Get costs
+// no API round trip once the informer has synced - safe to call on every 10s Probe. Exactly one Get, and
+// at most one Update.
+func applyNodeLabels(ctx context.Context, client runtimeclient.Client, nodeName string, desired map[string]string) error {
+	node := &v1.Node{}
+	if err := client.Get(ctx, runtimeclient.ObjectKey{Name: nodeName}, node); err != nil {
+		return fmt.Errorf("failed to get node object from Kubernetes: %w", err)
+	}
+
+	if node.Labels == nil {
+		node.Labels = make(map[string]string, len(desired))
+	}
+
+	updateNeeded := false
+	for label, value := range desired {
+		if existing, ok := node.Labels[label]; !ok || existing != value {
+			log.Info().Str("label", fmt.Sprintf("%s=%s", label, value)).Str("node", node.Name).Msg("Setting label on node")
+			node.Labels[label] = value
+			updateNeeded = true
+		}
+	}
+
+	if !updateNeeded {
+		return nil
+	}
+
+	if err := client.Update(ctx, node); err != nil {
+		return fmt.Errorf("failed to update node labels: %w", err)
+	}
+	log.Info().Msg("Successfully updated labels on node")
+	return nil
+}
+
+// removeNodeLabels fetches nodeName through client and deletes labelsToRemove from it, always issuing an
+// Update - this runs on start/stop, not per Probe, so correctness (removing stale labels even if some
+// were already gone) matters more here than shaving off an Update.
+func removeNodeLabels(ctx context.Context, client runtimeclient.Client, nodeName string, labelsToRemove []string) error {
+	node := &v1.Node{}
+	if err := client.Get(ctx, runtimeclient.ObjectKey{Name: nodeName}, node); err != nil {
+		return fmt.Errorf("failed to get node: %w", err)
+	}
+
+	for _, label := range labelsToRemove {
+		delete(node.Labels, label)
+		log.Info().Str("label", label).Str("node", node.Name).Msg("Removing label from node")
+	}
+
+	if err := client.Update(ctx, node); err != nil {
+		return fmt.Errorf("failed to update node labels: %w", err)
+	}
+	return nil
+}
+
+// SetNodeLabels applies this node's topology/transport labels via the controller-runtime manager's
+// cached client. It is a no-op - logged, not panicking - if the manager was never initialized (e.g.
+// initManager failed and only logged a warning; see Run() in driver.go).
+func (d *WekaFsDriver) SetNodeLabels(ctx context.Context) {
+	if d.config.isInDevMode() {
+		return
+	}
+
+	if d.csiMode != CsiModeNode {
+		return
+	}
+
+	if d.manager == nil {
+		log.Ctx(ctx).Warn().Msg("Kubernetes manager not initialized, skipping node label update")
+		return
+	}
+
+	transport := func() string {
+		if d.config.useNfs {
+			return "nfs"
+		}
+		wekaRunning := isWekaRunning(ctx)
+		if d.config.allowNfsFailback && !wekaRunning {
+			return "nfs"
+		}
+		return "wekafs"
+	}()
+
+	desired := map[string]string{
+		TopologyKeyNode: d.nodeID,
+		fmt.Sprintf(TopologyLabelNodePattern, d.name):      d.nodeID,
+		fmt.Sprintf(TopologyLabelWekaLocalPattern, d.name): "true",
+		fmt.Sprintf(TopologyLabelTransportPattern, d.name): transport,
+	}
+
+	if err := applyNodeLabels(ctx, d.manager.GetClient(), d.nodeID, desired); err != nil {
+		log.Ctx(ctx).Error().Err(err).Msg("Failed to set node labels")
+	}
+}
+
+// managedNodeLabelKeys returns the full set of node label keys CleanupNodeLabels removes for driverName:
+// the four per-driver keys SetNodeLabels actively manages (TopologyKeyNode plus the three
+// TopologyLabel*Pattern keys with driverName substituted in), plus two now-legacy global label keys
+// kept here purely for cleanup, so a node labeled by an older driver version does not retain them
+// across an upgrade.
+func managedNodeLabelKeys(driverName string) []string {
+	patterned := []string{TopologyLabelNodePattern, TopologyLabelTransportPattern, TopologyLabelWekaLocalPattern}
+	for i, pattern := range patterned {
+		patterned[i] = fmt.Sprintf(pattern, driverName)
+	}
+	return append(patterned, TopologyKeyNode, TopologyLabelTransportGlobal, TopologyLabelNodeGlobal)
+}
+
+// CleanupNodeLabels removes this driver's managed node-topology labels via the controller-runtime
+// manager's cached client. It is a no-op - logged, not panicking - if the manager was never initialized.
+func (d *WekaFsDriver) CleanupNodeLabels(ctx context.Context) {
+	if d.config.isInDevMode() {
+		return
+	}
+
+	if d.manager == nil {
+		log.Ctx(ctx).Warn().Msg("Kubernetes manager not initialized, skipping node label cleanup")
+		return
+	}
+
+	if err := removeNodeLabels(ctx, d.manager.GetClient(), d.nodeID, managedNodeLabelKeys(d.name)); err != nil {
+		log.Ctx(ctx).Error().Err(err).Msg("Failed to remove node labels")
+		return
+	}
+
+	log.Info().Msg("Successfully removed labels from node")
+}
+
+// readNodeTopologyLabels reads the standard topology.kubernetes.io/zone and region
+// labels from the Kubernetes node object and stores them on the NodeServer.
+// Called once at startup before gRPC registration.
+func (d *WekaFsDriver) readNodeTopologyLabels(ctx context.Context) {
+	if d.ns == nil || d.manager == nil {
+		return
+	}
+	// Use the API reader (direct client) instead of the cached client because
+	// this runs before the manager is started and its informer cache is synced.
+	readCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	node := &v1.Node{}
+	if err := d.manager.GetAPIReader().Get(readCtx, runtimeclient.ObjectKey{Name: d.nodeID}, node); err != nil {
+		log.Warn().Err(err).Msg("Failed to get node object for reading topology labels")
+		return
+	}
+	if zone, ok := node.Labels[TopologyKeyZone]; ok {
+		d.ns.zone = zone
+	}
+	if region, ok := node.Labels[TopologyKeyRegion]; ok {
+		d.ns.region = region
+	}
+	log.Info().Str("zone", d.ns.zone).Str("region", d.ns.region).Msg("Read standard topology labels from node")
+}

--- a/pkg/wekafs/nodelabels_test.go
+++ b/pkg/wekafs/nodelabels_test.go
@@ -1,0 +1,169 @@
+package wekafs
+
+import (
+	"context"
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+	fakeClient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func nodeKey(name string) runtimeclient.ObjectKey {
+	return runtimeclient.ObjectKey{Name: name}
+}
+
+func TestApplyNodeLabels_AppliesToNodeWithNoLabels(t *testing.T) {
+	node := &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-1"}}
+	client := fakeClient.NewClientBuilder().WithObjects(node).Build()
+	desired := map[string]string{"topology.example/node": "node-1", "topology.example/accessible": "true"}
+
+	if err := applyNodeLabels(context.Background(), client, "node-1", desired); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := &v1.Node{}
+	if err := client.Get(context.Background(), nodeKey("node-1"), got); err != nil {
+		t.Fatalf("unexpected error re-reading node: %v", err)
+	}
+	if got.Labels["topology.example/node"] != "node-1" || got.Labels["topology.example/accessible"] != "true" {
+		t.Errorf("expected both labels to be applied, got %v", got.Labels)
+	}
+}
+
+func TestApplyNodeLabels_AlreadyCorrectMakesNoUpdateCall(t *testing.T) {
+	node := &v1.Node{ObjectMeta: metav1.ObjectMeta{
+		Name:   "node-1",
+		Labels: map[string]string{"topology.example/node": "node-1"},
+	}}
+	client := fakeClient.NewClientBuilder().WithObjects(node).Build()
+	desired := map[string]string{"topology.example/node": "node-1"}
+
+	before := &v1.Node{}
+	if err := client.Get(context.Background(), nodeKey("node-1"), before); err != nil {
+		t.Fatalf("unexpected error reading node: %v", err)
+	}
+	rvBefore := before.ResourceVersion
+
+	if err := applyNodeLabels(context.Background(), client, "node-1", desired); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	after := &v1.Node{}
+	if err := client.Get(context.Background(), nodeKey("node-1"), after); err != nil {
+		t.Fatalf("unexpected error re-reading node: %v", err)
+	}
+	if after.ResourceVersion != rvBefore {
+		t.Errorf("expected no Update call when labels already match (resourceVersion unchanged), before=%s after=%s", rvBefore, after.ResourceVersion)
+	}
+}
+
+func TestApplyNodeLabels_ExternallyChangedLabelIsCorrected(t *testing.T) {
+	node := &v1.Node{ObjectMeta: metav1.ObjectMeta{
+		Name:   "node-1",
+		Labels: map[string]string{"topology.example/node": "wrong-value"},
+	}}
+	client := fakeClient.NewClientBuilder().WithObjects(node).Build()
+	desired := map[string]string{"topology.example/node": "node-1"}
+
+	if err := applyNodeLabels(context.Background(), client, "node-1", desired); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := &v1.Node{}
+	if err := client.Get(context.Background(), nodeKey("node-1"), got); err != nil {
+		t.Fatalf("unexpected error re-reading node: %v", err)
+	}
+	if got.Labels["topology.example/node"] != "node-1" {
+		t.Errorf("expected externally-changed label to be corrected, got %v", got.Labels)
+	}
+}
+
+func TestApplyNodeLabels_TransportLabelReflectsChangedDesiredValue(t *testing.T) {
+	node := &v1.Node{ObjectMeta: metav1.ObjectMeta{
+		Name:   "node-1",
+		Labels: map[string]string{"topology.example/transport": "wekafs"},
+	}}
+	client := fakeClient.NewClientBuilder().WithObjects(node).Build()
+
+	// Transport flips - e.g. NFS failback.
+	desired := map[string]string{"topology.example/transport": "nfs"}
+	if err := applyNodeLabels(context.Background(), client, "node-1", desired); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := &v1.Node{}
+	if err := client.Get(context.Background(), nodeKey("node-1"), got); err != nil {
+		t.Fatalf("unexpected error re-reading node: %v", err)
+	}
+	if got.Labels["topology.example/transport"] != "nfs" {
+		t.Errorf("expected updated transport label on node, got %v", got.Labels)
+	}
+}
+
+func TestSetNodeLabels_NilManagerDoesNotPanic(t *testing.T) {
+	d := &WekaFsDriver{
+		name:    "wekafs.csi.k8s.io",
+		nodeID:  "node-1",
+		csiMode: CsiModeNode,
+		config:  &DriverConfig{},
+		// manager is left nil: this is the crash case being tested.
+	}
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("SetNodeLabels panicked with nil manager: %v", r)
+		}
+	}()
+
+	d.SetNodeLabels(context.Background())
+}
+
+func TestCleanupNodeLabels_NilManagerDoesNotPanic(t *testing.T) {
+	d := &WekaFsDriver{
+		name:    "wekafs.csi.k8s.io",
+		nodeID:  "node-1",
+		csiMode: CsiModeNode,
+		config:  &DriverConfig{},
+		// manager is left nil: this is the crash case being tested.
+	}
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("CleanupNodeLabels panicked with nil manager: %v", r)
+		}
+	}()
+
+	d.CleanupNodeLabels(context.Background())
+}
+
+func TestRemoveNodeLabels_ClearsManagedLabelsOnly(t *testing.T) {
+	driverName := "wekafs.csi.k8s.io"
+	managed := managedNodeLabelKeys(driverName)
+
+	labels := map[string]string{"unrelated": "keep-me"}
+	for _, key := range managed {
+		labels[key] = "some-value"
+	}
+
+	node := &v1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-1", Labels: labels}}
+	client := fakeClient.NewClientBuilder().WithObjects(node).Build()
+
+	if err := removeNodeLabels(context.Background(), client, "node-1", managed); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got := &v1.Node{}
+	if err := client.Get(context.Background(), nodeKey("node-1"), got); err != nil {
+		t.Fatalf("unexpected error re-reading node: %v", err)
+	}
+	for _, key := range managed {
+		if _, ok := got.Labels[key]; ok {
+			t.Errorf("expected managed label %q to be removed, got %v", key, got.Labels)
+		}
+	}
+	if got.Labels["unrelated"] != "keep-me" {
+		t.Errorf("expected unrelated label to survive, got %v", got.Labels)
+	}
+}


### PR DESCRIPTION
### TL;DR
CSI-384: node health probes no longer rebuild a Kubernetes client and re-read the node object on every check.

### What changed?
- Node label sync, previously run from the liveness probe roughly every 10 seconds per node, now reads and writes the Node object through the shared controller-runtime manager client instead of building a fresh clientset and TLS transport each time.
- Node reads are served from a watch-backed cache scoped to just that node, so a probe costs no API round trip and out-of-band label changes are picked up without polling.

### How to test?
Covered by automated tests using a fake Kubernetes client, including the case where the client failed to initialize.

### Why make this change?
Each probe previously issued a fresh `rest.InClusterConfig()` call and an API read against every node in the cluster, every 10 seconds, forever. This eliminates that recurring apiserver load with no behavior change for users.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how and when Node objects are read/written for topology scheduling labels, including startup ordering; behavior is intended to be equivalent but affects every node probe path.
> 
> **Overview**
> **Node topology label sync** no longer builds a fresh `kubernetes` clientset and apiserver GET on every CSI health probe (~10s per node). Label read/write now goes through the shared controller-runtime manager, with logic moved into `nodelabels.go`.
> 
> In **node mode**, `initManager` runs **before** stale-label cleanup so `CleanupNodeLabels` does not silently skip on a nil manager. The manager cache adds a **field selector** so each node pod watches only its own `Node`, avoiding a cluster-wide Node informer per pod.
> 
> **Probe-time reads** use a `cacheThenLive` helper (cached client first, `GetAPIReader` fallback before informers sync); updates are skipped when labels already match. Startup cleanup still **reads via the API reader** and writes via the client. Nil-manager paths log and return instead of panicking. Unit tests cover apply/remove, cache fallback, and the reader/writer split.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75c4e81ff539d3ece1ac4ed3a4dbfc67dfd8a8b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->