### PR TITLE
fix: accept the TenantAdmin API role for CSI operations

### DIFF
--- a/pkg/wekafs/apiclient/constants.go
+++ b/pkg/wekafs/apiclient/constants.go
@@ -12,6 +12,7 @@ const (
 	TracerName                                = "weka-csi"
 	ApiUserRoleClusterAdmin       ApiUserRole = "ClusterAdmin"
 	ApiUserRoleOrgAdmin           ApiUserRole = "OrgAdmin"
+	ApiUserRoleTenantAdmin        ApiUserRole = "TenantAdmin"
 	ApiUserRoleReadOnly           ApiUserRole = "ReadOnly"
 	ApiUserRoleCSI                ApiUserRole = "CSI"
 	ApiUserRoleS3                 ApiUserRole = "S3"

--- a/pkg/wekafs/apiclient/login.go
+++ b/pkg/wekafs/apiclient/login.go
@@ -200,7 +200,11 @@ func (a *ApiClient) userRole() ApiUserRole {
 func (a *ApiClient) HasCSIPermissions() bool {
 	role := a.userRole()
 	if role != "" {
-		return role == ApiUserRoleCSI || role == ApiUserRoleClusterAdmin || role == ApiUserRoleOrgAdmin
+		// TenantAdmin administers a single organization, the same scope OrgAdmin has, so it can do
+		// everything CSI needs within that organization. ReadOnly, S3 and Regular are deliberately
+		// absent: none of them can create or delete filesystems, quotas or snapshots.
+		return role == ApiUserRoleCSI || role == ApiUserRoleClusterAdmin ||
+			role == ApiUserRoleOrgAdmin || role == ApiUserRoleTenantAdmin
 	}
 	return false
 }

--- a/pkg/wekafs/apiclient/permissions_test.go
+++ b/pkg/wekafs/apiclient/permissions_test.go
@@ -1,0 +1,31 @@
+package apiclient
+
+import "testing"
+
+// TestHasCSIPermissions pins which WEKA API user roles the driver will operate as. Getting this
+// wrong is not a subtle failure: ensureSufficientPermissions refuses to bring the client up at all,
+// so every volume operation fails at login with "does not have sufficient permissions".
+func TestHasCSIPermissions(t *testing.T) {
+	for _, tc := range []struct {
+		role    ApiUserRole
+		allowed bool
+		why     string
+	}{
+		{ApiUserRoleCSI, true, "the purpose-built role"},
+		{ApiUserRoleClusterAdmin, true, "administers the whole cluster"},
+		{ApiUserRoleOrgAdmin, true, "administers one organization"},
+		{ApiUserRoleTenantAdmin, true, "same scope as OrgAdmin, one organization"},
+		{ApiUserRoleReadOnly, false, "cannot create filesystems, quotas or snapshots"},
+		{ApiUserRoleS3, false, "scoped to S3, not filesystem management"},
+		{ApiUserRoleRegular, false, "no administrative rights"},
+		{"", false, "role could not be determined"},
+		{"SomethingWekaAddedLater", false, "unknown roles must not be assumed sufficient"},
+	} {
+		t.Run(string(tc.role), func(t *testing.T) {
+			a := &ApiClient{ApiUserRole: tc.role}
+			if got := a.HasCSIPermissions(); got != tc.allowed {
+				t.Errorf("HasCSIPermissions() for role %q = %v, want %v (%s)", tc.role, got, tc.allowed, tc.why)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### TL;DR
Fixed a bug that made the driver unusable for customers whose storage API user has the TenantAdmin role.

### What changed?
- The driver now accepts the `TenantAdmin` role for its storage API user, alongside the already-supported `CSI`, `ClusterAdmin`, and `OrgAdmin` roles

### How to test?
1. Configure the driver's storage API credentials with a user that has the `TenantAdmin` role
2. Create a PVC
3. Confirm the volume provisions successfully instead of failing with a permissions error

### Why make this change?
TenantAdmin grants full administrative control within its organization — the same scope OrgAdmin has — but it was missing from the driver's accepted-role list, blocking those customers entirely.

