### PR TITLE
fix(ci): write artifacthub changes as a string, and stop committing scratch

### DIFF
--- a/.github/workflows/release-v2.yaml
+++ b/.github/workflows/release-v2.yaml
@@ -279,11 +279,18 @@ jobs:
           yq -i '.sources[0] = "'https://github.com/weka/csi-wekafs/tree/$VERSION'"' Chart.yaml
           yq -i '.annotations."artifacthub.io/prerelease" = "'${{ inputs.preRelease }}'"' Chart.yaml
           yq -i '.annotations."artifacthub.io/containsSecurityUpdates" = "'${{ inputs.containsSecurityUpdates }}'"' Chart.yaml
-          if [[ -f ../../artifacthub_changes.json ]]; then
+          # Helm types chart annotations as map[string]string, so the value has to be a YAML
+          # string that happens to contain a list - `load()` splices the file in as a node and
+          # Chart.yaml stops loading at all ("cannot unmarshal array into ... of type string").
+          # An empty list is the common case, since a change is only recorded for PRs whose
+          # title carries a ticket, so drop the annotation entirely rather than write "[]".
+          if [[ -s ../../artifacthub_changes.json ]] && [[ "$(jq 'length' ../../artifacthub_changes.json)" -gt 0 ]]; then
             echo "Updating artifacthub.io/changes annotation in Chart.yaml"
-            yq -i 'with(.; .annotations."artifacthub.io/changes" = load("../../artifacthub_changes.json") )' Chart.yaml
+            CHANGES="$(yq -o=yaml -P '.' ../../artifacthub_changes.json)" \
+              yq -i '.annotations."artifacthub.io/changes" = strenv(CHANGES)' Chart.yaml
           else
-            echo "artifacthub_changes.json not found, skipping update of artifacthub.io/changes annotation"
+            echo "no artifacthub changes to record, removing the artifacthub.io/changes annotation"
+            yq -i 'del(.annotations."artifacthub.io/changes")' Chart.yaml
           fi
 
           echo ------------------ values ------------------
@@ -340,6 +347,10 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@v7
         with:
           commit_message: Release ${{ steps.set_version.outputs.version }}
+          # Commit only what the release actually rewrites. The default stages the whole
+          # workspace, which swept the downloaded artifacthub_changes.json and a scratch file
+          # left behind by the helm-docs container into the release commit.
+          file_pattern: README.md RELEASE.md charts/
 
       # https://colinwilson.uk/2022/01/27/how-to-sign-helm-charts-using-chart-releaser-action/
       - name: Prepare GPG key

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ main
 .cr-index
 changelog
 changelog1
+semicolon_delimited_script
+artifacthub_changes.json

--- a/semicolon_delimited_script
+++ b/semicolon_delimited_script
@@ -1,4 +1,0 @@
-cd /data
-helm-docs -s file -c charts -o ../../README.md -t ../README.md.gotmpl 
-helm-docs -s file -c charts
-


### PR DESCRIPTION
### TL;DR
Fixes the release job, which produced an unloadable Helm chart and so never published v2.9.0.

### What changed?
- The `artifacthub.io/changes` chart annotation is written as text, and left out entirely when there is nothing to record
- The release commit now includes only the files the release rewrites, instead of everything left lying in the build workspace
- Removed a stray build scratch file that had been committed to the repository

### How to test?
1. Run the release workflow.
2. Confirm it completes, and that a version tag, a GitHub release and a published Helm chart all appear.
3. Run `helm show chart charts/csi-wekafsplugin` and confirm it loads.

### Why make this change?
The release job wrote a list where Helm requires text, which made `Chart.yaml` impossible to load. Chart publishing failed on it, and that single failure also cost the version tag and the GitHub release, so v2.9.0 never went out even though the release commit had already landed. Nothing changes for anyone running the driver.
