### PR TITLE
fix: reject malformed API endpoints and secrets instead of failing later

### DIFF
--- a/pkg/wekafs/apiclient/apiclient.go
+++ b/pkg/wekafs/apiclient/apiclient.go
@@ -116,11 +116,13 @@ func NewApiClient(ctx context.Context, credentials Credentials, opts ApiClientOp
 		apiEndpoints:       NewApiEndPoints(),
 		nfsInterfaceGroups: newInterfaceGroups(),
 	}
-	a.resetDefaultEndpoints(ctx)
 	if len(a.Credentials.Endpoints) < 1 {
 		return nil, &ApiNoEndpointsError{
 			Err: errors.New("no endpoints could be found for API client"),
 		}
+	}
+	if err := a.resetDefaultEndpoints(ctx); err != nil {
+		return nil, &ApiNoEndpointsError{Err: err}
 	}
 
 	logger.Trace().Bool("insecure_skip_verify", opts.AllowInsecureHttps).Bool("custom_ca_cert", useCustomCACert).Msg("Creating new API client")

--- a/pkg/wekafs/apiclient/apiendpoint.go
+++ b/pkg/wekafs/apiclient/apiendpoint.go
@@ -147,34 +147,49 @@ func (eps *ApiEndPoints) Current() *ApiEndPoint {
 	return eps.Rotate()
 }
 
-func (a *ApiClient) resetDefaultEndpoints(ctx context.Context) {
+// constructEndpointFromAddress parses a single raw credential endpoint (e.g. "1.2.3.4",
+// "1.2.3.4:1234", "[::1]:1234" or a hostname) into an ApiEndPoint. It returns an error rather than a
+// nil endpoint so callers can log and skip the specific offending value instead of silently ending up
+// with fewer endpoints than the credentials listed.
+func constructEndpointFromAddress(ctx context.Context, e string) (*ApiEndPoint, error) {
+	if strings.Contains(e, "://") {
+		return nil, fmt.Errorf("endpoint must not include a URL scheme: %s", e)
+	}
+
+	split := strings.Split(e, ":")
+	ip := ""
+	port := "14000" // default port
+
+	// if there is a port number in the endpoint, use it
+	if len(split) > 1 {
+		port = split[len(split)-1]
+		ip = strings.Join(split[:len(split)-1], ":")
+	} else {
+		ip = split[0]
+	}
+
+	if !isValidIPv4Address(ip) && !isValidIPv6Address(ip) && !isValidHostname(ip) {
+		log.Ctx(ctx).Error().Str("ip", ip).Str("port", port).Str("raw_endpoint", e).
+			Msg("Cannot determine a valid hostname, IPv4 or IPv6 address, skipping endpoint")
+		return nil, fmt.Errorf("cannot determine a valid hostname, IPv4 or IPv6 address for endpoint: %s", e)
+	}
+
+	portNum, err := strconv.Atoi(port)
+	if err != nil {
+		log.Ctx(ctx).Error().Err(err).Str("port", port).Msg("Failed to parse port number, using default")
+		portNum = 14000
+	}
+	return &ApiEndPoint{IpAddress: ip, MgmtPort: portNum}, nil
+}
+
+func (a *ApiClient) resetDefaultEndpoints(ctx context.Context) error {
 	actualEndPoints := make(map[string]*ApiEndPoint)
 	for _, e := range a.Credentials.Endpoints {
-
-		split := strings.Split(e, ":")
-		ip := ""
-		port := "14000" // default port
-
-		// if there is a port number in the endpoint, use it
-		if len(split) > 1 {
-			port = split[len(split)-1]
-			ip = strings.Join(split[:len(split)-1], ":")
-		} else {
-			ip = split[0]
-		}
-
-		if !isValidIPv4Address(ip) && !isValidIPv6Address(ip) && !isValidHostname(ip) {
-			log.Ctx(ctx).Error().Str("ip", ip).Str("port", port).Str("raw_endpoint", e).
-				Msg("Cannot determine a valid hostname, IPv4 or IPv6 address, skipping endpoint")
+		endPoint, err := constructEndpointFromAddress(ctx, e)
+		if err != nil {
+			log.Ctx(ctx).Warn().Str("raw_endpoint", e).Err(err).Msg("Skipping invalid API endpoint")
 			continue
 		}
-
-		portNum, err := strconv.Atoi(port)
-		if err != nil {
-			log.Ctx(ctx).Error().Err(err).Str("port", port).Msg("Failed to parse port number, using default")
-			portNum = 14000
-		}
-		endPoint := &ApiEndPoint{IpAddress: ip, MgmtPort: portNum}
 		// Key by the same "ip:port" form ApiEndPoint.String() and UpdateApiEndpoints use, not the
 		// raw credential string: the raw string may carry no port (or a hostname alias) and would
 		// then never match eps.currentEndpoint.String() in Replace, nor existingEndpoints[key] in
@@ -182,7 +197,13 @@ func (a *ApiClient) resetDefaultEndpoints(ctx context.Context) {
 		// on every reset.
 		actualEndPoints[endPoint.String()] = endPoint
 	}
+	// Report the failure before replacing, so a caller holding a working endpoint set is not left
+	// with an empty one because the credentials it was re-reading turned out to be malformed.
+	if len(actualEndPoints) == 0 {
+		return errors.New("no valid API endpoints found")
+	}
 	a.apiEndpoints.Replace(actualEndPoints)
+	return nil
 }
 
 // fetchMountEndpoints used to obtain actual data plane IP addresses
@@ -244,6 +265,10 @@ func (a *ApiClient) UpdateApiEndpoints(ctx context.Context) error {
 		}
 	}
 
+	if len(newEndpoints) == 0 {
+		return errors.New("no valid API endpoints found, keeping the existing endpoint set")
+	}
+
 	a.apiEndpoints.Replace(newEndpoints)
 
 	// always rotate endpoint to make sure we distribute load between different Weka Nodes
@@ -255,7 +280,9 @@ func (a *ApiClient) UpdateApiEndpoints(ctx context.Context) error {
 func (a *ApiClient) rotateEndpoint(ctx context.Context) {
 	logger := log.Ctx(ctx)
 	if a.apiEndpoints.Len() == 0 {
-		a.resetDefaultEndpoints(ctx)
+		// Only reachable once the set is already empty, so a failure here leaves nothing worse
+		// behind - Rotate below reports it as no endpoint to switch to.
+		_ = a.resetDefaultEndpoints(ctx)
 	}
 	current := a.apiEndpoints.Rotate()
 	if current == nil {
@@ -272,15 +299,17 @@ func (a *ApiClient) getEndpoint(ctx context.Context) *ApiEndPoint {
 	if current := a.apiEndpoints.Current(); current != nil {
 		return current
 	}
-	a.resetDefaultEndpoints(ctx)
+	// Same as in rotateEndpoint: the set is already empty, so a failure changes nothing and the
+	// nil return below is the signal callers act on.
+	_ = a.resetDefaultEndpoints(ctx)
 	return a.apiEndpoints.Current()
 }
 
 // requireEndpoint returns the endpoint to use, or ApiNoEndpointsError when none is known.
-// NewApiClient only rejects a raw endpoint list with zero entries; a secret whose entries all fail
-// isValidIPv4Address/isValidIPv6Address/isValidHostname still constructs a client, just with an
-// empty endpoint map, and getEndpoint reports that with nil rather than blocking for one to appear.
-// Every caller that would otherwise dereference getEndpoint's result directly must go through this.
+// NewApiClient now rejects credentials whose entries all fail validation, so a live client should
+// always hold at least one endpoint; this stays as the guard for the case where the set is emptied
+// later - every caller that would otherwise dereference getEndpoint's result directly goes
+// through it rather than risking a nil dereference.
 func (a *ApiClient) requireEndpoint(ctx context.Context) (*ApiEndPoint, apiError) {
 	endpoint := a.getEndpoint(ctx)
 	if endpoint == nil {

--- a/pkg/wekafs/apiclient/apiendpoint_test.go
+++ b/pkg/wekafs/apiclient/apiendpoint_test.go
@@ -139,12 +139,13 @@ func TestApiEndPoints_RotateSingleEndpointIsStable(t *testing.T) {
 	}
 }
 
-// TestNewApiClient_AllInvalidEndpoints_ReturnsErrorInsteadOfPanicking covers fix 8. NewApiClient only
-// rejects a raw endpoint list with zero entries; a secret whose entries all fail
-// isValidIPv4Address/isValidIPv6Address/isValidHostname still constructs a client, just with an
-// empty endpoint map. Before the fix, the first request dereferenced that nil endpoint directly in
-// getBaseUrl and in do()'s stats bookkeeping and panicked.
-func TestNewApiClient_AllInvalidEndpoints_ReturnsErrorInsteadOfPanicking(t *testing.T) {
+// TestNewApiClient_AllInvalidEndpoints_ReturnsError documents the current contract: NewApiClient used
+// to succeed even when every credential endpoint failed validation, silently constructing a client
+// with an empty endpoint map that only failed later - obscurely - at request time (a nil endpoint
+// dereferenced in getBaseUrl and in do()'s stats bookkeeping, which used to panic before that was
+// fixed separately). Failing loudly at construction time is more useful: there is no plausible way
+// to recover a working client from a credential list where nothing parsed.
+func TestNewApiClient_AllInvalidEndpoints_ReturnsError(t *testing.T) {
 	quietLogs(t)
 	creds := Credentials{
 		Username:     "admin",
@@ -154,24 +155,89 @@ func TestNewApiClient_AllInvalidEndpoints_ReturnsErrorInsteadOfPanicking(t *test
 		Endpoints:    []string{"not a valid host!!"},
 	}
 	c, err := NewApiClient(context.Background(), creds, ApiClientOptions{Hostname: "no-endpoints-test"})
-	if err != nil {
-		t.Fatalf("NewApiClient should succeed here - validation failure only empties the endpoint map, it doesn't reject the raw list: %v", err)
+	if err == nil {
+		t.Fatal("expected NewApiClient to return an error when every endpoint fails validation")
+	}
+	if c != nil {
+		t.Fatalf("expected a nil client alongside the error, got %v", c)
+	}
+	if _, ok := err.(*ApiNoEndpointsError); !ok {
+		t.Fatalf("expected *ApiNoEndpointsError, got %T: %v", err, err)
+	}
+}
+
+// TestConstructEndpointFromAddress covers the parsing rules constructEndpointFromAddress applies to a
+// single raw credential endpoint: rejecting a URL scheme, defaulting the port, rejoining IPv6
+// addresses split on ":", and rejecting anything that isn't a valid IPv4/IPv6 address or hostname.
+func TestConstructEndpointFromAddress(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		wantIP   string
+		wantPort int
+		wantErr  bool
+	}{
+		{name: "ipv4 without port", input: "192.168.1.1", wantIP: "192.168.1.1", wantPort: 14000},
+		{name: "ipv4 with port", input: "192.168.1.1:1234", wantIP: "192.168.1.1", wantPort: 1234},
+		{name: "ipv6 with port", input: "::1:1234", wantIP: "::1", wantPort: 1234},
+		{name: "hostname", input: "weka.example.com", wantIP: "weka.example.com", wantPort: 14000},
+		{name: "https scheme rejected", input: "https://192.168.1.1:1234", wantErr: true},
+		// Without the explicit scheme check this one slips through: splitting on ":" leaves "https"
+		// as the host - which passes isValidHostname - and "//weka.example.com" as the port, which
+		// fails to parse and falls back to the default. The result is a bogus "https:14000"
+		// endpoint accepted in silence, so this case is what makes the scheme check load-bearing.
+		{name: "scheme without port rejected", input: "https://weka.example.com", wantErr: true},
+		{name: "garbage rejected", input: "not a valid host!!", wantErr: true},
 	}
 
-	var gotErr error
-	func() {
-		defer func() {
-			if r := recover(); r != nil {
-				t.Fatalf("Get panicked instead of returning an error: %v", r)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			quietLogs(t)
+			ep, err := constructEndpointFromAddress(context.Background(), tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected an error for input %q, got endpoint %v", tt.input, ep)
+				}
+				return
 			}
-		}()
-		gotErr = c.Get(context.Background(), "cluster", nil, &ClusterInfoResponse{})
-	}()
-
-	if gotErr == nil {
-		t.Fatal("expected an error when the client has no valid endpoints")
+			if err != nil {
+				t.Fatalf("unexpected error for input %q: %v", tt.input, err)
+			}
+			if ep.IpAddress != tt.wantIP || ep.MgmtPort != tt.wantPort {
+				t.Fatalf("input %q: expected %s:%d, got %s:%d", tt.input, tt.wantIP, tt.wantPort, ep.IpAddress, ep.MgmtPort)
+			}
+		})
 	}
-	if _, ok := gotErr.(*ApiNoEndpointsError); !ok {
-		t.Fatalf("expected *ApiNoEndpointsError, got %T: %v", gotErr, gotErr)
+}
+
+// TestResetDefaultEndpoints_AllInvalid_ReturnsError covers the new contract: a credential list where
+// every endpoint fails to parse must not silently produce an empty-but-successful endpoint set.
+func TestResetDefaultEndpoints_AllInvalid_ReturnsError(t *testing.T) {
+	quietLogs(t)
+	a := &ApiClient{
+		Credentials:  Credentials{Endpoints: []string{"not a valid host!!", "https://also-bad:1234"}},
+		apiEndpoints: NewApiEndPoints(),
+	}
+	if err := a.resetDefaultEndpoints(context.Background()); err == nil {
+		t.Fatal("expected an error when every endpoint fails to parse")
+	}
+	if got := a.apiEndpoints.Len(); got != 0 {
+		t.Fatalf("expected no endpoints to be kept, got %d", got)
+	}
+}
+
+// TestResetDefaultEndpoints_MixedValidity_KeepsOnlyTheGoodOnes covers the same contract on a mixed
+// list: the bad entry is skipped and logged, not fatal, as long as at least one entry parses.
+func TestResetDefaultEndpoints_MixedValidity_KeepsOnlyTheGoodOnes(t *testing.T) {
+	quietLogs(t)
+	a := &ApiClient{
+		Credentials:  Credentials{Endpoints: []string{"not a valid host!!", "192.168.1.1:1234"}},
+		apiEndpoints: NewApiEndPoints(),
+	}
+	if err := a.resetDefaultEndpoints(context.Background()); err != nil {
+		t.Fatalf("expected no error when at least one endpoint parses, got %v", err)
+	}
+	if got := a.apiEndpoints.Len(); got != 1 {
+		t.Fatalf("expected exactly the one valid endpoint to be kept, got %d", got)
 	}
 }

--- a/pkg/wekafs/apistore.go
+++ b/pkg/wekafs/apistore.go
@@ -26,6 +26,8 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/rs/zerolog/log"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"github.com/wekafs/csi-wekafs/pkg/wekafs/apiclient"
 )
@@ -72,28 +74,34 @@ func (api *ApiStore) getByClusterGuid(guid uuid.UUID) (*apiclient.ApiClient, err
 
 // fromSecrets returns a pointer to API by secret contents
 func (api *ApiStore) fromSecrets(ctx context.Context, secrets map[string]string, hostname string) (*apiclient.ApiClient, error) {
-	endpointsRaw := strings.TrimSpace(strings.ReplaceAll(strings.TrimSuffix(secrets["endpoints"], "\n"), "\n", ","))
-	if endpointsRaw == "" {
-		return nil, errors.New("no valid endpoints defined in secret, cannot create API client")
+	endpointsRawValue, ok := secrets["endpoints"]
+	if !ok {
+		return nil, errors.New("no endpoints found in secret")
 	}
-	endpoints := func() []string {
-		var ret []string
-		for _, s := range strings.Split(endpointsRaw, ",") {
-			ret = append(ret, strings.TrimSpace(strings.TrimSuffix(s, "\n")))
+	endpointsRaw := strings.ReplaceAll(trimValue(endpointsRawValue), "\n", ",")
+	if endpointsRaw == "" {
+		return nil, status.Errorf(codes.NotFound, "no valid endpoints defined in secret, cannot create API client")
+	}
+	var endpoints []string
+	for _, s := range strings.Split(endpointsRaw, ",") {
+		if endpoint := trimValue(s); endpoint != "" {
+			endpoints = append(endpoints, endpoint)
 		}
-		return ret
-	}()
+	}
+	if len(endpoints) == 0 {
+		return nil, status.Errorf(codes.NotFound, "invalid endpoints defined in secret: %s", endpointsRawValue)
+	}
 
 	var nfsTargetIps []string
 	if _, ok := secrets["nfsTargetIps"]; ok {
-		nfsTargetIpsRaw := strings.TrimSpace(strings.ReplaceAll(strings.TrimSuffix(secrets["nfsTargetIps"], "\n"), "\n", ","))
+		nfsTargetIpsRaw := strings.ReplaceAll(trimValue(secrets["nfsTargetIps"]), "\n", ",")
 		nfsTargetIps = func() []string {
 			var ret []string
 			if nfsTargetIpsRaw == "" {
 				return ret
 			}
 			for _, s := range strings.Split(nfsTargetIpsRaw, ",") {
-				ret = append(ret, strings.TrimSpace(strings.TrimSuffix(s, "\n")))
+				ret = append(ret, trimValue(s))
 			}
 			return ret
 		}()
@@ -101,14 +109,14 @@ func (api *ApiStore) fromSecrets(ctx context.Context, secrets map[string]string,
 
 	localContainerName, ok := secrets["localContainerName"]
 	if ok {
-		localContainerName = strings.TrimSpace(strings.TrimSuffix(localContainerName, "\n"))
+		localContainerName = trimValue(localContainerName)
 	} else {
 		localContainerName = ""
 	}
 	autoUpdateEndpoints := false
 	autoUpdateEndpointsStr, ok := secrets["autoUpdateEndpoints"]
 	if ok {
-		autoUpdateEndpoints = strings.TrimSpace(strings.TrimSuffix(autoUpdateEndpointsStr, "\n")) == "true"
+		autoUpdateEndpoints = trimValue(autoUpdateEndpointsStr) == "true"
 	}
 	caCertificate, ok := secrets["caCertificate"]
 	if !ok {
@@ -119,30 +127,43 @@ func (api *ApiStore) fromSecrets(ctx context.Context, secrets map[string]string,
 
 	kmsVaultNamespaceForFilesystemEncryption, ok := secrets["kmsVaultNamespaceForFilesystemEncryption"]
 	if ok {
-		preexistingVaultCreds.Namespace = strings.TrimSpace(strings.TrimSuffix(kmsVaultNamespaceForFilesystemEncryption, "\n"))
+		preexistingVaultCreds.Namespace = trimValue(kmsVaultNamespaceForFilesystemEncryption)
 	}
 
 	kmsVaultKeyIdentifierForFilesystemEncryption, ok := secrets["kmsVaultKeyIdentifierForFilesystemEncryption"]
 	if ok {
-		preexistingVaultCreds.KeyIdentifier = strings.TrimSpace(strings.TrimSuffix(kmsVaultKeyIdentifierForFilesystemEncryption, "\n"))
+		preexistingVaultCreds.KeyIdentifier = trimValue(kmsVaultKeyIdentifierForFilesystemEncryption)
 	}
 
 	kmsVaultRoleIdForFilesystemEncryption, ok := secrets["kmsVaultRoleIdForFilesystemEncryption"]
 	if ok {
-		preexistingVaultCreds.RoleId = strings.TrimSpace(strings.TrimSuffix(kmsVaultRoleIdForFilesystemEncryption, "\n"))
+		preexistingVaultCreds.RoleId = trimValue(kmsVaultRoleIdForFilesystemEncryption)
 	}
 
 	kmsVaultSecretIdForFilesystemEncryption, ok := secrets["kmsVaultSecretIdForFilesystemEncryption"]
 	if ok {
-		preexistingVaultCreds.SecretId = strings.TrimSpace(strings.TrimSuffix(kmsVaultSecretIdForFilesystemEncryption, "\n"))
+		preexistingVaultCreds.SecretId = trimValue(kmsVaultSecretIdForFilesystemEncryption)
+	}
+
+	username, ok := secrets["username"]
+	if !ok {
+		return nil, errors.New("no username found in secret")
+	}
+	password, ok := secrets["password"]
+	if !ok {
+		return nil, errors.New("no password found in secret")
+	}
+	organization, ok := secrets["organization"]
+	if !ok {
+		return nil, errors.New("no organization found in secret")
 	}
 
 	credentials := apiclient.Credentials{
-		Username:            strings.TrimSpace(strings.TrimSuffix(secrets["username"], "\n")),
-		Password:            strings.TrimSuffix(secrets["password"], "\n"),
-		Organization:        strings.TrimSpace(strings.TrimSuffix(secrets["organization"], "\n")),
+		Username:            trimValue(username),
+		Password:            strings.TrimSuffix(password, "\n"),
+		Organization:        trimValue(organization),
 		Endpoints:           endpoints,
-		HttpScheme:          strings.TrimSpace(strings.TrimSuffix(secrets["scheme"], "\n")),
+		HttpScheme:          trimValue(secrets["scheme"]),
 		LocalContainerName:  localContainerName,
 		AutoUpdateEndpoints: autoUpdateEndpoints,
 		CaCertificate:       caCertificate,

--- a/pkg/wekafs/apistore_test.go
+++ b/pkg/wekafs/apistore_test.go
@@ -1,6 +1,8 @@
 package wekafs
 
 import (
+	"context"
+	"strings"
 	"sync"
 	"testing"
 
@@ -63,4 +65,89 @@ func TestApiStoreGetByHashLockedDoesNotRelock(t *testing.T) {
 		}
 	}()
 	<-done
+}
+
+// validFromSecretsInput is a secret map with every key fromSecrets requires. Each missing-key test
+// below starts from a copy of it and deletes exactly the key under test, so a failure can only be
+// attributed to that key.
+func validFromSecretsInput() map[string]string {
+	return map[string]string{
+		"endpoints":    "192.168.1.1:14000",
+		"username":     "admin",
+		"password":     "admin",
+		"organization": "Root",
+	}
+}
+
+// TestFromSecrets_MissingRequiredKey covers the new contract: endpoints, username, password and
+// organization are required. Before this, a missing key silently defaulted to an empty string,
+// producing a client that could never authenticate and failed obscurely later instead of at
+// construction time. fromSecrets returns before touching the network for all of these, so no live
+// cluster is needed.
+func TestFromSecrets_MissingRequiredKey(t *testing.T) {
+	tests := []struct {
+		missingKey string
+		wantSubstr string
+	}{
+		{missingKey: "endpoints", wantSubstr: "endpoints"},
+		{missingKey: "username", wantSubstr: "username"},
+		{missingKey: "password", wantSubstr: "password"},
+		{missingKey: "organization", wantSubstr: "organization"},
+	}
+
+	store := &ApiStore{apis: make(map[uint32]*apiclient.ApiClient)}
+	for _, tt := range tests {
+		t.Run(tt.missingKey, func(t *testing.T) {
+			secrets := validFromSecretsInput()
+			delete(secrets, tt.missingKey)
+
+			client, err := store.fromSecrets(context.Background(), secrets, "test-host")
+			if err == nil {
+				t.Fatalf("expected an error when %q is missing", tt.missingKey)
+			}
+			if client != nil {
+				t.Fatalf("expected a nil client alongside the error, got %v", client)
+			}
+			if !strings.Contains(err.Error(), tt.wantSubstr) {
+				t.Fatalf("expected error to name the missing key %q, got: %v", tt.wantSubstr, err)
+			}
+		})
+	}
+}
+
+// TestFromSecrets_NoValidEndpoints covers the "endpoints" key being present but empty or
+// comma-only, which the required-key check alone would not catch since the key exists.
+func TestFromSecrets_NoValidEndpoints(t *testing.T) {
+	store := &ApiStore{apis: make(map[uint32]*apiclient.ApiClient)}
+
+	tests := map[string]string{
+		"empty string": "",
+		"commas only":  ",,",
+	}
+	for name, endpoints := range tests {
+		t.Run(name, func(t *testing.T) {
+			secrets := validFromSecretsInput()
+			secrets["endpoints"] = endpoints
+
+			client, err := store.fromSecrets(context.Background(), secrets, "test-host")
+			if err == nil {
+				t.Fatalf("expected an error for endpoints value %q", endpoints)
+			}
+			if client != nil {
+				t.Fatalf("expected a nil client alongside the error, got %v", client)
+			}
+		})
+	}
+}
+
+// TestFromSecrets_HappyPath documents, rather than exercises, the success path. Once all required
+// keys are present and endpoints are non-empty, fromSecrets calls fromCredentials, which calls
+// apiclient.NewApiClient (no network) and then newClient.Init(ctx), which performs an actual Login
+// HTTP call and retries it with backoff on failure. There is no way to observe a genuine success, or
+// even a fast, deterministic failure, without a live cluster reachable at the configured endpoint -
+// so this is intentionally not asserted here. Exercising that path is left to the apiclient tests
+// that already skip themselves when no cluster is reachable on localhost:14000.
+func TestFromSecrets_HappyPath(t *testing.T) {
+	t.Skip("fromSecrets' success path only completes after apiclient.ApiClient.Init logs in over " +
+		"HTTP; that requires a live Weka cluster and is out of reach for this package's unit tests")
 }

--- a/pkg/wekafs/utilities.go
+++ b/pkg/wekafs/utilities.go
@@ -643,6 +643,11 @@ func getOwnNamespace() (string, error) {
 	return string(nsBytes), nil
 }
 
+// trimValue trims whitespace and trailing newlines from secret values
+func trimValue(value string) string {
+	return strings.TrimSpace(strings.TrimSuffix(value, "\n"))
+}
+
 func GetCsiPluginMode(mode *string) CsiPluginMode {
 	ret := CsiPluginMode(*mode)
 	switch ret {


### PR DESCRIPTION
### TL;DR
A malformed or incomplete API secret is now rejected with a message naming the problem, instead of failing later with a generic error.

### What changed?
- An endpoint that includes a URL scheme, or that is not a valid address, is rejected rather than quietly skipped
- If no endpoint in a secret is usable, creating the API client fails immediately instead of producing a client with nothing to talk to
- `username`, `password` and `organization` are now required in the secret, and a missing one is named in the error
- Refreshing the endpoint list from the cluster will no longer replace a working set with an empty one

### How to test?
1. Create an API secret whose `endpoints` value includes a scheme, for example `https://1.2.3.4:14000`.
2. Create a PVC using it, and confirm provisioning fails with an error naming the endpoint rather than a generic "no endpoints" message.
3. Repeat with `username` omitted from the secret and confirm the error names the missing key.

### Why make this change?
Endpoints that failed validation were skipped one by one, so a secret where every entry was malformed still produced an API client — just one with an empty endpoint list, which then failed at the first request, far from the secret that caused it. Missing credentials behaved the same way, defaulting to empty and surfacing later as an authentication failure. The error now arrives when the volume is created, and says which part of the secret is wrong.


This is a rework of the fixes originally made in #615 and #617, reimplemented against the endpoint
handling as it stands now, which was rewritten in the meantime. Neither of those pull requests
recorded a ticket.
