### PR TITLE
chore(deps): update the CSI sidecars to their current releases

### DIFF
--- a/charts/csi-wekafsplugin/values.yaml
+++ b/charts/csi-wekafsplugin/values.yaml
@@ -8,19 +8,19 @@ csiDriverName: "csi.weka.io"
 csiDriverVersion: &csiDriverVersion 2.9.0
 images:
   # -- CSI liveness probe sidecar image URL
-  livenessprobesidecar: registry.k8s.io/sig-storage/livenessprobe:v2.18.0
+  livenessprobesidecar: registry.k8s.io/sig-storage/livenessprobe:v2.19.0
   # -- CSI attacher sidecar image URL
-  attachersidecar: registry.k8s.io/sig-storage/csi-attacher:v4.11.0
+  attachersidecar: registry.k8s.io/sig-storage/csi-attacher:v4.12.0
   # -- CSI provisioner sidecar image URL
-  provisionersidecar: registry.k8s.io/sig-storage/csi-provisioner:v6.2.0
+  provisionersidecar: registry.k8s.io/sig-storage/csi-provisioner:v6.3.0
   # -- CSI registrar sidercar
-  registrarsidecar: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.16.0
+  registrarsidecar: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.17.0
   # -- CSI resizer sidecar image URL
-  resizersidecar: registry.k8s.io/sig-storage/csi-resizer:v2.1.0
+  resizersidecar: registry.k8s.io/sig-storage/csi-resizer:v2.2.1
   # -- CSI snapshotter sidecar image URL
-  snapshottersidecar: registry.k8s.io/sig-storage/csi-snapshotter:v8.5.0
+  snapshottersidecar: registry.k8s.io/sig-storage/csi-snapshotter:v8.6.0
   # -- CSI external health monitor sidecar image URL
-  healthmonitorsidecar: registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.17.0
+  healthmonitorsidecar: registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.18.0
   # -- CSI driver main image URL
   csidriver: quay.io/weka.io/csi-wekafs
   # -- CSI driver tag


### PR DESCRIPTION
### TL;DR
Updates the Kubernetes CSI sidecar containers deployed alongside the driver.

### What changed?
- liveness probe, attacher, provisioner, node driver registrar, resizer, snapshotter and external health monitor all move to their current releases
- No configuration change is required: every option the chart passes still exists, and no new permissions are needed

### How to test?
1. Upgrade the chart and confirm all controller and node pods reach Running.
2. Create a PVC, expand it, snapshot it, and delete it.
3. Confirm no sidecar container restarts.

### Why make this change?
Routine currency, and these had drifted further behind than intended. Two things worth watching after upgrading: the provisioner now runs a periodic clean-up pass over snapshots in the cluster, which is new steady-state activity; and the external health monitor is at the last release that supports the volume health interface the driver implements today.
