### PR TITLE
ci: add make update-sidecars and repair the Renovate config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@
 CMDS=wekafsplugin
 all: build
 
-.PHONY: build-% build clean build-debug deploy-debug update-charts
+.PHONY: build-% build clean build-debug deploy-debug update-charts update-sidecars
 
 # understand what is the version tag
 VERSION ?= $(shell cat charts/csi-wekafsplugin/Chart.yaml | grep appVersion | awk '{print $$2}' | tr -d '"')
@@ -42,6 +42,12 @@ clean:
 # why the committed charts carry the last released version.
 update-charts:
 	@./hack/update-charts.sh
+
+# Report which CSI sidecars are behind their latest upstream release, and with APPLY=1 update
+# charts/csi-wekafsplugin/values.yaml in place. Renovate watches only some of them, so this
+# checks all seven. Exits non-zero when something is behind, so CI can use it as a check.
+update-sidecars:
+	@./hack/update-sidecars.sh
 
 # Build debug binaries locally (fast on native arch)
 .PHONY: build-debug-binaries

--- a/hack/update-sidecars.sh
+++ b/hack/update-sidecars.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Update the CSI sidecar image tags in the Helm chart to their latest upstream releases.
+#
+# The sidecars are published to registry.k8s.io/sig-storage but released from GitHub, so the
+# release tag is what this reads. Renovate covers only some of them, which is how csi-attacher and
+# external-health-monitor drifted several releases behind without anything noticing - this target
+# checks all of them, whatever Renovate is configured to watch.
+#
+#   make update-sidecars          report what is out of date, change nothing
+#   make update-sidecars APPLY=1  rewrite charts/csi-wekafsplugin/values.yaml in place
+#
+# Requires: gh (authenticated), and for APPLY=1 nothing beyond sed.
+set -euo pipefail
+
+VALUES="charts/csi-wekafsplugin/values.yaml"
+APPLY="${APPLY:-}"
+
+# image name in registry.k8s.io/sig-storage : GitHub repo under kubernetes-csi
+SIDECARS=(
+  "livenessprobe:livenessprobe"
+  "csi-attacher:external-attacher"
+  "csi-provisioner:external-provisioner"
+  "csi-node-driver-registrar:node-driver-registrar"
+  "csi-resizer:external-resizer"
+  "csi-snapshotter:external-snapshotter"
+  "csi-external-health-monitor-controller:external-health-monitor"
+)
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "gh is required to query upstream releases" >&2
+  exit 1
+fi
+if [[ ! -f "$VALUES" ]]; then
+  echo "run this from the repository root: $VALUES not found" >&2
+  exit 1
+fi
+
+# latest_release prints the highest release tag for a kubernetes-csi repo.
+#
+# Two traps here, both of which produced wrong answers before this was written as it is:
+#
+#  - external-snapshotter and external-health-monitor tag several components out of one repo
+#    ("client/v8.6.0" alongside "v8.6.0"), so the tag has to be filtered to a bare vX.Y.Z.
+#  - the newest release is not the first one GitHub returns. Releases come back newest-published
+#    first, and a patch on an older line is often published after a newer minor - at the time of
+#    writing external-provisioner's most recent release is v6.2.1, published after v6.3.0. Taking
+#    the first entry therefore proposes a downgrade. Sort by version and take the maximum.
+latest_release() {
+  local repo="$1"
+  gh api "repos/kubernetes-csi/${repo}/releases" --paginate \
+    --jq '.[] | select(.prerelease == false and .draft == false) | .tag_name | select(test("^v[0-9]+\\.[0-9]+\\.[0-9]+$"))' \
+    2>/dev/null | sort -V | tail -1
+}
+
+outdated=0
+checked=0
+for entry in "${SIDECARS[@]}"; do
+  image="${entry%%:*}"
+  repo="${entry##*:}"
+
+  current=$(grep -oE "sig-storage/${image}:v[0-9]+\.[0-9]+\.[0-9]+" "$VALUES" | head -1 | sed 's/.*://')
+  if [[ -z "$current" ]]; then
+    echo "  ?  ${image}: not found in ${VALUES}, skipping"
+    continue
+  fi
+  checked=$((checked + 1))
+
+  latest=$(latest_release "$repo")
+  if [[ -z "$latest" ]]; then
+    echo "  !  ${image}: could not determine the latest release of kubernetes-csi/${repo}"
+    continue
+  fi
+
+  if [[ "$current" == "$latest" ]]; then
+    printf "  ok %-42s %s\n" "$image" "$current"
+    continue
+  fi
+
+  outdated=$((outdated + 1))
+  printf "  UP %-42s %s -> %s\n" "$image" "$current" "$latest"
+  if [[ -n "$APPLY" ]]; then
+    sed -i.bak "s|sig-storage/${image}:${current}|sig-storage/${image}:${latest}|" "$VALUES"
+    rm -f "${VALUES}.bak"
+  fi
+done
+
+echo
+if [[ "$outdated" -eq 0 ]]; then
+  echo "all ${checked} sidecars are current"
+  exit 0
+fi
+
+if [[ -n "$APPLY" ]]; then
+  echo "${outdated} of ${checked} updated in ${VALUES}"
+  echo
+  echo "A sidecar bump is not only a version string. Before committing, check that:"
+  echo "  - every flag the chart passes still exists in the new release"
+  echo "  - no new RBAC is required"
+  echo "  - the minimum Kubernetes version is still satisfied"
+  echo "and read the release notes for anything that changes behaviour by default."
+else
+  echo "${outdated} of ${checked} sidecars are behind; re-run with APPLY=1 to update ${VALUES}"
+  exit 1
+fi

--- a/renovate.json
+++ b/renovate.json
@@ -1,59 +1,116 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "prHourlyLimit": 10,
-  "baseBranches": ["dev"],
-  "reviewers": ["sergeyberezansky", "dontbreakit"],
-  "labels": ["dependencies"],
+  "baseBranches": [
+    "dev"
+  ],
+  "reviewers": [
+    "sergeyberezansky",
+    "dontbreakit"
+  ],
+  "labels": [
+    "dependencies"
+  ],
   "extends": [
     "config:base"
   ],
   "regexManagers": [
     {
-      "fileMatch": ["^deploy\\/helm\\/csi-wekafsplugin\\/values\\.yaml$"],
-      "matchStrings": ["\\s\\slivenessprobesidecar:\\sregistry\\.k8s\\.io\\/sig-storage\\/livenessprobe:(?<currentValue>.*?)\\n"],
+      "fileMatch": [
+        "^charts\\/csi-wekafsplugin\\/values\\.yaml$"
+      ],
+      "matchStrings": [
+        "\\s\\slivenessprobesidecar:\\sregistry\\.k8s\\.io\\/sig-storage\\/livenessprobe:(?<currentValue>.*?)\\n"
+      ],
       "depNameTemplate": "registry.k8s.io/sig-storage/livenessprobe",
       "datasourceTemplate": "docker"
     },
     {
-      "fileMatch": ["^deploy\\/helm\\/csi-wekafsplugin\\/values\\.yaml$"],
-      "matchStrings": ["\\s\\sprovisionersidecar:\\sregistry\\.k8s\\.io\\/sig-storage\\/csi-provisioner:(?<currentValue>.*?)\\n"],
+      "fileMatch": [
+        "^charts\\/csi-wekafsplugin\\/values\\.yaml$"
+      ],
+      "matchStrings": [
+        "\\s\\sprovisionersidecar:\\sregistry\\.k8s\\.io\\/sig-storage\\/csi-provisioner:(?<currentValue>.*?)\\n"
+      ],
       "depNameTemplate": "registry.k8s.io/sig-storage/csi-provisioner",
       "datasourceTemplate": "docker"
     },
     {
-      "fileMatch": ["^deploy\\/helm\\/csi-wekafsplugin\\/values\\.yaml$"],
-      "matchStrings": ["\\s\\sregistrarsidecar:\\sregistry\\.k8s\\.io\\/sig-storage\\/csi-node-driver-registrar:(?<currentValue>.*?)\\n"],
+      "fileMatch": [
+        "^charts\\/csi-wekafsplugin\\/values\\.yaml$"
+      ],
+      "matchStrings": [
+        "\\s\\sregistrarsidecar:\\sregistry\\.k8s\\.io\\/sig-storage\\/csi-node-driver-registrar:(?<currentValue>.*?)\\n"
+      ],
       "depNameTemplate": "registry.k8s.io/sig-storage/csi-node-driver-registrar",
       "datasourceTemplate": "docker"
     },
     {
-      "fileMatch": ["^deploy\\/helm\\/csi-wekafsplugin\\/values\\.yaml$"],
-      "matchStrings": ["\\s\\sresizersidecar:\\sregistry\\.k8s\\.io\\/sig-storage\\/csi-resizer:(?<currentValue>.*?)\\n"],
+      "fileMatch": [
+        "^charts\\/csi-wekafsplugin\\/values\\.yaml$"
+      ],
+      "matchStrings": [
+        "\\s\\sresizersidecar:\\sregistry\\.k8s\\.io\\/sig-storage\\/csi-resizer:(?<currentValue>.*?)\\n"
+      ],
       "depNameTemplate": "registry.k8s.io/sig-storage/csi-resizer",
       "datasourceTemplate": "docker"
     },
     {
-      "fileMatch": ["^deploy\\/helm\\/csi-wekafsplugin\\/values\\.yaml$"],
-      "matchStrings": ["\\s\\ssnapshottersidecar:\\sregistry\\.k8s\\.io\\/sig-storage\\/csi-snapshotter:(?<currentValue>.*?)\\n"],
+      "fileMatch": [
+        "^charts\\/csi-wekafsplugin\\/values\\.yaml$"
+      ],
+      "matchStrings": [
+        "\\s\\ssnapshottersidecar:\\sregistry\\.k8s\\.io\\/sig-storage\\/csi-snapshotter:(?<currentValue>.*?)\\n"
+      ],
       "depNameTemplate": "registry.k8s.io/sig-storage/csi-snapshotter",
+      "datasourceTemplate": "docker"
+    },
+    {
+      "fileMatch": [
+        "^charts\\/csi-wekafsplugin\\/values\\.yaml$"
+      ],
+      "matchStrings": [
+        "\\s\\sattachersidecar:\\sregistry\\.k8s\\.io\\/sig-storage\\/csi-attacher:(?<currentValue>.*?)\\n"
+      ],
+      "depNameTemplate": "registry.k8s.io/sig-storage/csi-attacher",
+      "datasourceTemplate": "docker"
+    },
+    {
+      "fileMatch": [
+        "^charts\\/csi-wekafsplugin\\/values\\.yaml$"
+      ],
+      "matchStrings": [
+        "\\s\\shealthmonitorsidecar:\\sregistry\\.k8s\\.io\\/sig-storage\\/csi-external-health-monitor-controller:(?<currentValue>.*?)\\n"
+      ],
+      "depNameTemplate": "registry.k8s.io/sig-storage/csi-external-health-monitor-controller",
       "datasourceTemplate": "docker"
     }
   ],
   "packageRules": [
     {
-      "datasources": ["docker"],
-      "addLabels": ["docker"],
+      "datasources": [
+        "docker"
+      ],
+      "addLabels": [
+        "docker"
+      ],
       "commitMessageTopic": "{{{depName}}}"
     },
     {
-      "datasources": ["go"],
-      "addLabels": ["go"]
+      "datasources": [
+        "go"
+      ],
+      "addLabels": [
+        "go"
+      ]
     },
     {
-      "matchPackagePatterns": [".*sig-storage.*"],
-      "addLabels": ["sidecar"]
+      "matchPackagePatterns": [
+        ".*sig-storage.*"
+      ],
+      "addLabels": [
+        "sidecar"
+      ]
     }
-   ]
-
+  ]
 }
-


### PR DESCRIPTION
### TL;DR
Adds a command that reports which CSI sidecars are out of date, and repairs the automation that was supposed to be doing it.

### What changed?
- `make update-sidecars` reports which sidecars are behind their latest release; `make update-sidecars APPLY=1` updates the chart
- Fixed the automatic dependency configuration, which pointed at a directory that no longer exists and so had stopped updating anything
- Added the two sidecars that were never covered by it

### How to test?
1. Run `make update-sidecars` and confirm it reports every sidecar as current.
2. Edit one sidecar version in the chart to an older release and run it again; confirm it reports that one as behind and exits non-zero.

### Why make this change?
The sidecars had fallen several releases behind with nothing flagging it. The cause was that the automatic updater was watching a path left over from before the chart moved, so it silently matched no files. This repairs that and adds a check that does not depend on that configuration being correct.
