### PR TITLE
feat: spread metrics server API calls across management nodes

### DIFF
--- a/cmd/metricsserver/main.go
+++ b/cmd/metricsserver/main.go
@@ -55,6 +55,9 @@ var (
 	// Higher than the plugin's default: a quota map fetch pulls every quota on a filesystem in one
 	// request, which on a large filesystem takes considerably longer than an ordinary call.
 	wekaApiTimeoutSeconds = flag.Int("wekaapitimeoutseconds", 180, "Timeout for a single Weka API request in seconds")
+	// On by default here: the metrics server polls the cluster continuously, so spreading requests
+	// across management nodes keeps any single one from carrying the whole load.
+	rotateApiEndpointOnEachRequest = flag.Bool("rotateapiendpointoneachrequest", true, "Send each Weka API request to a different management node rather than staying on one until it fails")
 
 	wekaMetricsFetchIntervalSeconds          = flag.Int("wekametricsfetchintervalseconds", 60, "Interval in seconds to fetch metrics from Weka cluster")
 	wekaMetricsFetchConcurrentRequests       = flag.Int("wekametricsfetchconcurrentrequests", 1, "Maximum concurrent requests to fetch metrics from Weka cluster")
@@ -99,10 +102,11 @@ func handle(ctx context.Context) {
 	// prefixes, per-operation concurrency - govern CSI request handling that this process never does,
 	// and NewDriverConfig supplies its own defaults for the metrics knobs left at zero.
 	config := wekafs.NewDriverConfig(wekafs.DriverConfigOptions{
-		Version:               version,
-		AllowInsecureHttps:    *allowInsecureHttps,
-		WekaApiTimeoutSeconds: *wekaApiTimeoutSeconds,
-		TracingUrl:            *tracingUrl,
+		Version:                        version,
+		AllowInsecureHttps:             *allowInsecureHttps,
+		WekaApiTimeoutSeconds:          *wekaApiTimeoutSeconds,
+		RotateApiEndpointOnEachRequest: *rotateApiEndpointOnEachRequest,
+		TracingUrl:                     *tracingUrl,
 
 		MetricsFetchIntervalSeconds:       *wekaMetricsFetchIntervalSeconds,
 		MetricsFetchConcurrentRequests:    *wekaMetricsFetchConcurrentRequests,

--- a/cmd/wekafsplugin/main.go
+++ b/cmd/wekafsplugin/main.go
@@ -70,23 +70,26 @@ var (
 	maxConcurrentNodeUnpublishVolumeReqs = flag.Int64("concurrency.nodeUnpublishVolume", 5, "Maximum concurrent NodeUnpublishVolume requests")
 	grpcRequestTimeoutSeconds            = flag.Int("grpcrequesttimeoutseconds", 30, "Time out requests waiting in queue after X seconds")
 	wekaApiTimeoutSeconds                = flag.Int("wekaapitimeoutseconds", 60, "Timeout for a single Weka API request in seconds")
-	healthProbeWekaTimeoutSeconds        = flag.Int("healthprobewekatimeoutseconds", 2, "Timeout in seconds for WekaFS health check in liveness probe")
-	allowProtocolContainers              = flag.Bool("allowprotocolcontainers", false, "Allow protocol containers to be used for mounting filesystems")
-	allowNfsFailback                     = flag.Bool("allownfsfailback", false, "Allow NFS failback")
-	useNfs                               = flag.Bool("usenfs", false, "Use NFS for mounting volumes")
-	interfaceGroupName                   = flag.String("interfacegroupname", "", "Name of the NFS interface group to use for mounting volumes")
-	clientGroupName                      = flag.String("clientgroupname", "", "Name of the NFS client group to use for managing NFS permissions")
-	nfsProtocolVersion                   = flag.String("nfsprotocolversion", "4.1", "NFS protocol version to use for mounting volumes")
-	wekafsContainerName                  = flag.String("wekafscontainername", "", "Name of the Weka container to use for mounting filesystems")
-	skipGarbageCollection                = flag.Bool("skipgarbagecollection", false, "Skip garbage collection of directory volumes data, only move to trash")
-	waitForObjectDeletion                = flag.Bool("waitforobjectdeletion", false, "Wait for object deletion before returning from DeleteVolume")
-	allowEncryptionWithoutKms            = flag.Bool("allowencryptionwithoutkms", false, "Allow encryption without KMS, for testing purposes only")
-	manageNodeTopologyLabels             = flag.Bool("managenodetopologylabels", false, "Manage node topology labels for CSI driver")
-	enforceDirVolTotalCapacity           = flag.Bool("enforcedirvoltotalcapacity", false, "Enforce total filesystem capacity for directory-backed volumes (prevents over-provisioning)")
-	setOwnershipOnDynamicFilesystems     = flag.Bool("setownershipondynamicfilesystems", false, "Set ownership on Dynamic Filesystems (only OrgAdmin/CSI user that created the filesystem will be able to mount it")
-	allowMountOptionOverrides            = flag.Bool("allowmountoptionoverrides", false, "Allow mount option overrides via PVC and pod annotations")
-	keepThinProvisioningRatioOnExpand    = flag.Bool("keepthinprovisioningratioonexpand", true, "On filesystem expansion, scale thin-provisioning min-SSD and max-SSD to preserve their ratios to total capacity")
-	advertiseVolumeHealthSupport         = flag.Bool("advertisevolumehealthsupport", true, "Expose GET_VOLUME and VOLUME_CONDITION, allowing the CSI health monitor to report volume condition and capacity")
+	// Off by default here: the plugin's API traffic is sparse and bursty, and staying on one
+	// endpoint until it misbehaves keeps its per-endpoint failure counters meaningful.
+	rotateApiEndpointOnEachRequest    = flag.Bool("rotateapiendpointoneachrequest", false, "Send each Weka API request to a different management node rather than staying on one until it fails")
+	healthProbeWekaTimeoutSeconds     = flag.Int("healthprobewekatimeoutseconds", 2, "Timeout in seconds for WekaFS health check in liveness probe")
+	allowProtocolContainers           = flag.Bool("allowprotocolcontainers", false, "Allow protocol containers to be used for mounting filesystems")
+	allowNfsFailback                  = flag.Bool("allownfsfailback", false, "Allow NFS failback")
+	useNfs                            = flag.Bool("usenfs", false, "Use NFS for mounting volumes")
+	interfaceGroupName                = flag.String("interfacegroupname", "", "Name of the NFS interface group to use for mounting volumes")
+	clientGroupName                   = flag.String("clientgroupname", "", "Name of the NFS client group to use for managing NFS permissions")
+	nfsProtocolVersion                = flag.String("nfsprotocolversion", "4.1", "NFS protocol version to use for mounting volumes")
+	wekafsContainerName               = flag.String("wekafscontainername", "", "Name of the Weka container to use for mounting filesystems")
+	skipGarbageCollection             = flag.Bool("skipgarbagecollection", false, "Skip garbage collection of directory volumes data, only move to trash")
+	waitForObjectDeletion             = flag.Bool("waitforobjectdeletion", false, "Wait for object deletion before returning from DeleteVolume")
+	allowEncryptionWithoutKms         = flag.Bool("allowencryptionwithoutkms", false, "Allow encryption without KMS, for testing purposes only")
+	manageNodeTopologyLabels          = flag.Bool("managenodetopologylabels", false, "Manage node topology labels for CSI driver")
+	enforceDirVolTotalCapacity        = flag.Bool("enforcedirvoltotalcapacity", false, "Enforce total filesystem capacity for directory-backed volumes (prevents over-provisioning)")
+	setOwnershipOnDynamicFilesystems  = flag.Bool("setownershipondynamicfilesystems", false, "Set ownership on Dynamic Filesystems (only OrgAdmin/CSI user that created the filesystem will be able to mount it")
+	allowMountOptionOverrides         = flag.Bool("allowmountoptionoverrides", false, "Allow mount option overrides via PVC and pod annotations")
+	keepThinProvisioningRatioOnExpand = flag.Bool("keepthinprovisioningratioonexpand", true, "On filesystem expansion, scale thin-provisioning min-SSD and max-SSD to preserve their ratios to total capacity")
+	advertiseVolumeHealthSupport      = flag.Bool("advertisevolumehealthsupport", true, "Expose GET_VOLUME and VOLUME_CONDITION, allowing the CSI health monitor to report volume condition and capacity")
 
 	// Metrics server settings. These only take effect when csimode is "metricsserver" -
 	// the metrics server itself is only ever constructed for that mode (see NewWekaFsDriver).
@@ -174,9 +177,10 @@ func handle(ctx context.Context) {
 		MaxNodePublishVolumeReqs:   *maxConcurrentNodePublishVolumeReqs,
 		MaxNodeUnpublishVolumeReqs: *maxConcurrentNodeUnpublishVolumeReqs,
 
-		GrpcRequestTimeoutSeconds:     *grpcRequestTimeoutSeconds,
-		WekaApiTimeoutSeconds:         *wekaApiTimeoutSeconds,
-		HealthProbeWekaTimeoutSeconds: *healthProbeWekaTimeoutSeconds,
+		GrpcRequestTimeoutSeconds:      *grpcRequestTimeoutSeconds,
+		WekaApiTimeoutSeconds:          *wekaApiTimeoutSeconds,
+		RotateApiEndpointOnEachRequest: *rotateApiEndpointOnEachRequest,
+		HealthProbeWekaTimeoutSeconds:  *healthProbeWekaTimeoutSeconds,
 
 		AllowNfsFailback:   *allowNfsFailback,
 		UseNfs:             *useNfs,

--- a/pkg/wekafs/apiclient/apiclient.go
+++ b/pkg/wekafs/apiclient/apiclient.go
@@ -58,6 +58,11 @@ type ApiClient struct {
 	clientHash                 uint32
 	hostname                   string
 	driverName                 string
+	// rotateEndpointOnEachRequest spreads requests across the cluster's management nodes instead of
+	// staying on one until it fails. Wanted for the metrics server, which issues a steady stream of
+	// read-only calls; not for the plugin, whose calls are sparse and where staying put keeps a
+	// working endpoint's stats meaningful.
+	rotateEndpointOnEachRequest bool
 	// nfsInterfaceGroups caches interface groups by name. It carries its own lock - see the type.
 	nfsInterfaceGroups    *interfaceGroups
 	ApiUserRole           ApiUserRole
@@ -91,6 +96,10 @@ type ApiClientOptions struct {
 	// ApiHttpTimeOutSeconds rather than to http.Client's own zero value, which means no timeout at
 	// all - a caller that forgot to set it would hang forever instead of failing.
 	ApiTimeout time.Duration
+	// RotateEndpointOnEachRequest sends each request to a different management node rather than
+	// staying on one until it fails. Intended for the metrics server; see the field of the same
+	// name on ApiClient.
+	RotateEndpointOnEachRequest bool
 }
 
 // apiTimeoutOrDefault keeps an unset or nonsensical timeout from disabling timeouts entirely.
@@ -125,13 +134,14 @@ func NewApiClient(ctx context.Context, credentials Credentials, opts ApiClientOp
 			Jar:           nil,
 			Timeout:       apiTimeoutOrDefault(opts.ApiTimeout),
 		},
-		ClusterGuid:        uuid.UUID{},
-		Credentials:        credentials,
-		CompatibilityMap:   &WekaCompatibilityMap{},
-		hostname:           opts.Hostname,
-		driverName:         opts.DriverName,
-		apiEndpoints:       NewApiEndPoints(),
-		nfsInterfaceGroups: newInterfaceGroups(),
+		ClusterGuid:                 uuid.UUID{},
+		Credentials:                 credentials,
+		CompatibilityMap:            &WekaCompatibilityMap{},
+		hostname:                    opts.Hostname,
+		rotateEndpointOnEachRequest: opts.RotateEndpointOnEachRequest,
+		driverName:                  opts.DriverName,
+		apiEndpoints:                NewApiEndPoints(),
+		nfsInterfaceGroups:          newInterfaceGroups(),
 	}
 	if len(a.Credentials.Endpoints) < 1 {
 		return nil, &ApiNoEndpointsError{

--- a/pkg/wekafs/apiclient/requests.go
+++ b/pkg/wekafs/apiclient/requests.go
@@ -24,6 +24,13 @@ func (a *ApiClient) do(ctx context.Context, Method string, Path string, Payload 
 			Err: errors.New("no endpoints could be found for API client"),
 		}
 	}
+	// Spread requests across the management nodes when the caller asked for it. This has to happen
+	// once, here, rather than inside getEndpoint: a single request resolves the endpoint twice - to
+	// build the URL and again to record stats - and rotating on each of those would attribute the
+	// request to a different endpoint than the one it was actually sent to.
+	if a.rotateEndpointOnEachRequest {
+		a.apiEndpoints.Rotate()
+	}
 	u, uErr := a.getUrl(ctx, Path)
 	if uErr != nil {
 		return &ApiResponse{}, uErr

--- a/pkg/wekafs/apiclient/rotateendpoint_test.go
+++ b/pkg/wekafs/apiclient/rotateendpoint_test.go
@@ -1,0 +1,66 @@
+package apiclient
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// newClientWithEndpoints builds a client over two known endpoints without contacting anything.
+func newClientWithEndpoints(t *testing.T, rotate bool) *ApiClient {
+	t.Helper()
+	a, err := NewApiClient(context.Background(), Credentials{
+		Username:     "admin",
+		Password:     "admin",
+		Organization: "Root",
+		HttpScheme:   "http",
+		Endpoints:    []string{"127.0.0.1:14000", "127.0.0.2:14000"},
+	}, ApiClientOptions{
+		Hostname:                    "rotate-test",
+		RotateEndpointOnEachRequest: rotate,
+		// Nothing is listening on these addresses. Without a short timeout each attempt would wait
+		// out the 60s default, and the test would take minutes to make its point.
+		ApiTimeout: 50 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("failed to build client: %v", err)
+	}
+	if a.apiEndpoints.Len() != 2 {
+		t.Fatalf("expected both endpoints to be usable, got %d", a.apiEndpoints.Len())
+	}
+	return a
+}
+
+// TestRotateEndpointOnEachRequest covers the metrics server's traffic pattern: a steady stream of
+// read-only calls should be spread over the management nodes rather than all landing on one. The
+// requests themselves fail (nothing is listening), which is irrelevant - rotation happens before
+// the request is sent, so the selected endpoint is what this asserts on.
+func TestRotateEndpointOnEachRequest(t *testing.T) {
+	quietLogs(t)
+	a := newClientWithEndpoints(t, true)
+
+	first := a.getEndpoint(context.Background()).String()
+	seen := map[string]bool{first: true}
+	for i := 0; i < 4; i++ {
+		_, _ = a.do(context.Background(), "GET", "cluster", nil, nil)
+		seen[a.getEndpoint(context.Background()).String()] = true
+	}
+	if len(seen) < 2 {
+		t.Fatalf("expected requests to be spread over both endpoints, only ever used %v", seen)
+	}
+}
+
+// TestNoRotationWhenDisabled is the other half: the plugin must stay on one endpoint until it
+// actually misbehaves, so its per-endpoint failure counters mean something.
+func TestNoRotationWhenDisabled(t *testing.T) {
+	quietLogs(t)
+	a := newClientWithEndpoints(t, false)
+
+	want := a.getEndpoint(context.Background()).String()
+	for i := 0; i < 4; i++ {
+		_, _ = a.do(context.Background(), "GET", "cluster", nil, nil)
+		if got := a.getEndpoint(context.Background()).String(); got != want {
+			t.Fatalf("iteration %d: endpoint moved from %s to %s with rotation disabled", i, want, got)
+		}
+	}
+}

--- a/pkg/wekafs/apistore.go
+++ b/pkg/wekafs/apistore.go
@@ -183,10 +183,11 @@ func (api *ApiStore) fromCredentials(ctx context.Context, credentials apiclient.
 	logger.Trace().Str("api_client", credentials.String()).Msg("Creating new Weka API client")
 	// doing this to fetch a client hash
 	newClient, err := apiclient.NewApiClient(ctx, credentials, apiclient.ApiClientOptions{
-		AllowInsecureHttps: api.config.allowInsecureHttps,
-		Hostname:           hostname,
-		DriverName:         api.driverName,
-		ApiTimeout:         api.config.wekaApiTimeout,
+		AllowInsecureHttps:          api.config.allowInsecureHttps,
+		Hostname:                    hostname,
+		DriverName:                  api.driverName,
+		ApiTimeout:                  api.config.wekaApiTimeout,
+		RotateEndpointOnEachRequest: api.config.rotateApiEndpointOnEachRequest,
 	})
 	if err != nil {
 		return nil, errors.New("could not create API client object from supplied params")

--- a/pkg/wekafs/driverconfig.go
+++ b/pkg/wekafs/driverconfig.go
@@ -18,22 +18,25 @@ func (i *MutuallyExclusiveMountOptsStrings) Set(value string) error {
 }
 
 type DriverConfig struct {
-	DynamicVolPath                    string
-	VolumePrefix                      string
-	SnapshotPrefix                    string
-	SeedSnapshotPrefix                string
-	allowAutoFsCreation               bool
-	allowAutoFsExpansion              bool
-	allowSnapshotsOfDirectoryVolumes  bool
-	advertiseSnapshotSupport          bool
-	advertiseVolumeCloneSupport       bool
-	advertiseVolumeHealthSupport      bool
-	debugPath                         string
-	allowInsecureHttps                bool
-	alwaysAllowSnapshotVolumes        bool
-	mutuallyExclusiveOptions          []mutuallyExclusiveMountOptionSet
-	maxConcurrencyPerOp               map[string]int64
-	wekaApiTimeout                    time.Duration // bounds a single Weka API request
+	DynamicVolPath                   string
+	VolumePrefix                     string
+	SnapshotPrefix                   string
+	SeedSnapshotPrefix               string
+	allowAutoFsCreation              bool
+	allowAutoFsExpansion             bool
+	allowSnapshotsOfDirectoryVolumes bool
+	advertiseSnapshotSupport         bool
+	advertiseVolumeCloneSupport      bool
+	advertiseVolumeHealthSupport     bool
+	debugPath                        string
+	allowInsecureHttps               bool
+	alwaysAllowSnapshotVolumes       bool
+	mutuallyExclusiveOptions         []mutuallyExclusiveMountOptionSet
+	maxConcurrencyPerOp              map[string]int64
+	wekaApiTimeout                   time.Duration // bounds a single Weka API request
+	// rotateApiEndpointOnEachRequest spreads Weka API calls across the cluster's management nodes.
+	// On for the metrics server, which polls continuously; off for the plugin.
+	rotateApiEndpointOnEachRequest    bool
 	grpcRequestTimeout                time.Duration
 	healthProbeWekaTimeout            time.Duration
 	allowProtocolContainers           bool
@@ -83,6 +86,7 @@ func (dc *DriverConfig) Log() {
 		Int64("max_node_unpublish_volume_reqs", dc.maxConcurrencyPerOp["NodeUnpublishVolume"]).
 		Int("grpc_request_timeout_seconds", int(dc.grpcRequestTimeout.Seconds())).
 		Dur("weka_api_timeout", dc.wekaApiTimeout).
+		Bool("rotate_api_endpoint_on_each_request", dc.rotateApiEndpointOnEachRequest).
 		Int("health_probe_weka_timeout_seconds", int(dc.healthProbeWekaTimeout.Seconds())).
 		Bool("allow_protocol_containers", dc.allowProtocolContainers).
 		Bool("allow_nfs_failback", dc.allowNfsFailback).
@@ -150,8 +154,11 @@ type DriverConfigOptions struct {
 	GrpcRequestTimeoutSeconds int
 	// WekaApiTimeoutSeconds bounds a single Weka API request. Zero falls back to the API client's own
 	// default, so a caller that does not care keeps today's behaviour.
-	WekaApiTimeoutSeconds         int
-	HealthProbeWekaTimeoutSeconds int
+	WekaApiTimeoutSeconds int
+	// RotateApiEndpointOnEachRequest spreads Weka API calls across management nodes instead of
+	// staying on one until it fails.
+	RotateApiEndpointOnEachRequest bool
+	HealthProbeWekaTimeoutSeconds  int
 
 	AllowNfsFailback   bool
 	UseNfs             bool
@@ -241,6 +248,7 @@ func NewDriverConfig(opts DriverConfigOptions) *DriverConfig {
 		maxConcurrencyPerOp:               concurrency,
 		grpcRequestTimeout:                time.Duration(opts.GrpcRequestTimeoutSeconds) * time.Second,
 		wekaApiTimeout:                    time.Duration(opts.WekaApiTimeoutSeconds) * time.Second,
+		rotateApiEndpointOnEachRequest:    opts.RotateApiEndpointOnEachRequest,
 		healthProbeWekaTimeout:            time.Duration(opts.HealthProbeWekaTimeoutSeconds) * time.Second,
 		allowProtocolContainers:           opts.AllowProtocolContainers,
 		allowNfsFailback:                  opts.AllowNfsFailback,


### PR DESCRIPTION
The metrics server polls the Weka cluster continuously, and every request went
to whichever endpoint was selected until that one failed, so a single management
node carried the entire load.

Add rotateApiEndpointOnEachRequest, propagated from the flag through the driver
config to the API client. On by default for the metrics server; off for the
plugin, whose API traffic is sparse and bursty, and where staying on one endpoint
until it misbehaves keeps its per-endpoint failure counters meaningful.

The rotation happens once at the top of do(), not inside getEndpoint: a single
request resolves the endpoint twice - once to build the URL and again to record
its metrics - so rotating on resolution would attribute a request to a different
endpoint than the one it was sent to.

Ported from #640 by @assafgi   
Co-Authored-By: Claude Opus 5 (1M context) [noreply@anthropic.com](mailto:noreply@anthropic.com)