### PR TITLE
feat: attribute per-volume metrics to the API Secret they authenticate with

### DIFF
--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -132,7 +132,14 @@ timestamp, so it behaves like an ordinary gauge.
 
 ### Labels
 Volume metrics carry `csi_driver_name`, `pv_name`, `cluster_guid`, `storage_class_name`,
-`filesystem_name`, `volume_type`, `organization`, `pvc_name`, `pvc_namespace`, `pvc_uid`.
+`filesystem_name`, `volume_type`, `organization`, `pvc_name`, `pvc_namespace`, `pvc_uid`,
+`secret_name`.
+
+`organization` and `secret_name` both identify the tenant a volume belongs to - the WEKA
+organization, and the Kubernetes Secret holding the credentials used to reach it. A tenant is
+expected to use one Secret, so neither adds series to a per-volume metric; they make capacity
+groupable and attributable by tenant. Where one tenant is spread over several Secrets, its series
+split accordingly.
 
 The shipped PodMonitor relabels away the scrape-identity labels that would otherwise fork a series
 per pod for this family - see [PodMonitors](#podmonitors) below for exactly which labels, on which

--- a/docs/prometheus-metrics.md
+++ b/docs/prometheus-metrics.md
@@ -181,7 +181,7 @@ than probing WEKA inline, which is what keeps those RPCs cheap (see family 2).
 
 | Metric | Type | Labels | Meaning |
 |---|---|---|---|
-| `weka_csi_volume_health_status` | GaugeVec | `LabelsForCsiVolumes` (the same 10 labels as family 5 — this metric does **not** add `csi_driver_name` on top, since that label is already part of the set) | Last health condition the reconciler determined for this volume: `1` = healthy, `0` = abnormal, `-1` = unknown, including a cached result older than `volumeHealthMaxAge` (30 minutes) |
+| `weka_csi_volume_health_status` | GaugeVec | `LabelsForCsiVolumes` (the same 11 labels as family 5 — this metric does **not** add `csi_driver_name` on top, since that label is already part of the set) | Last health condition the reconciler determined for this volume: `1` = healthy, `0` = abnormal, `-1` = unknown, including a cached result older than `volumeHealthMaxAge` (30 minutes) |
 | `weka_csi_volume_health_volumes` | GaugeVec | `csi_driver_name`, `status` (`healthy`/`abnormal`/`unknown`/`failed`) | Fleet-wide tally as of the last completed sweep. `failed` counts probes that errored during the sweep — it is not one of the values `status` on the per-volume gauge takes, and a failed probe leaves that volume's previous status in place rather than overwriting it |
 | `weka_csi_volume_health_sweep_duration_seconds` | HistogramVec | `csi_driver_name` | Duration of one complete reconciliation sweep. Uses the wide `HistogramDurationBuckets` (up to 1000s), not Prometheus's 10s-capped defaults, since a sweep over a large fleet runs for minutes |
 | `weka_csi_volume_health_last_sweep_timestamp_seconds` | GaugeVec | `csi_driver_name` | Unix time the last sweep completed. Lets a stalled reconciler (lost leadership, or a hung sweep) be alerted on independent of whether any volume's status changed |
@@ -323,7 +323,7 @@ values come from a WEKA API read on the collector's own schedule, not from the s
 
 ### Labels
 
-One series per PersistentVolume, identified by `LabelsForCsiVolumes` in `volumemetrics.go` — 10
+One series per PersistentVolume, identified by `LabelsForCsiVolumes` in `prometheus.go` — 11
 labels:
 
 | Label | Meaning |
@@ -338,6 +338,7 @@ labels:
 | `pvc_name` | PersistentVolumeClaim name (blank if the PV has no claim ref) |
 | `pvc_namespace` | PersistentVolumeClaim namespace (blank if unbound) |
 | `pvc_uid` | PersistentVolumeClaim UID (blank if unbound) |
+| `secret_name` | The WEKA API Secret the volume authenticates with, as `namespace/name`. Blank when the volume carries no secret reference, which a statically provisioned volume need not |
 
 ### Metrics
 

--- a/pkg/wekafs/prometheus.go
+++ b/pkg/wekafs/prometheus.go
@@ -20,7 +20,11 @@ var (
 	// organization is the Weka tenant a volume belongs to, taken from the credentials its API client
 	// authenticated with. Every volume has exactly one, so it adds no series - it only makes the
 	// existing ones groupable by tenant.
-	LabelsForCsiVolumes    = []string{"csi_driver_name", "pv_name", "cluster_guid", "storage_class_name", "filesystem_name", "volume_type", "organization", "pvc_name", "pvc_namespace", "pvc_uid"}
+	// secret_name is the API Secret a volume authenticates with, as "namespace/name". A tenant is
+	// expected to use one Secret, so like organization it adds no series to a per-volume metric - it
+	// makes API load and capacity attributable to the credentials that produced them. Where that
+	// expectation is broken and one tenant spans several Secrets, the tenant's series split.
+	LabelsForCsiVolumes    = []string{"csi_driver_name", "pv_name", "cluster_guid", "storage_class_name", "filesystem_name", "volume_type", "organization", "pvc_name", "pvc_namespace", "pvc_uid", "secret_name"}
 	LabelsForFilesystemOps = []string{"csi_driver_name", "cluster_guid", "filesystem_name"}
 
 	HistogramDurationBuckets = []float64{.01, .05, .1, .25, .5, 1, 2.5, 5, 10, 25, 50, 100, 250, 500, 1000}
@@ -54,7 +58,21 @@ func csiVolumeLabelValues(driverName string, pv *v1.PersistentVolume, clusterGui
 	} else {
 		labelValues = append(labelValues, "", "", "")
 	}
-	return labelValues
+	// Taken from the PersistentVolume rather than passed in: CSI hands the driver a Secret's
+	// contents and never its name, so the object is the only place the name survives. Both callers
+	// resolve credentials through preferredSecretRef, so labelling with the same ref keeps the
+	// per-volume capacity and volume-health series attributable to the same Secret.
+	return append(labelValues, secretRefLabel(pv))
+}
+
+// secretRefLabel renders a volume's API Secret as "namespace/name", or blank when the volume
+// carries no usable ref - a statically provisioned volume need not reference one at all.
+func secretRefLabel(pv *v1.PersistentVolume) string {
+	ref := preferredSecretRef(pv)
+	if ref == nil {
+		return ""
+	}
+	return ref.Namespace + "/" + ref.Name
 }
 
 type PrometheusMetrics struct {

--- a/pkg/wekafs/volumehealthreconciler_metrics_test.go
+++ b/pkg/wekafs/volumehealthreconciler_metrics_test.go
@@ -222,10 +222,30 @@ func TestReconcileOnceReportsVolumeHealthMetrics(t *testing.T) {
 }
 
 // healthMetricLabels returns a distinct, well-formed LabelsForCsiVolumes value for handle, so tests
-// below don't need a real PersistentVolume or fake Weka cluster just to give the Status gauge
-// something to key on.
+// below don't need a fake Weka cluster just to give the Status gauge something to key on.
+//
+// It goes through csiVolumeLabelValues rather than listing the values itself. Spelling them out by
+// hand meant every label added to LabelsForCsiVolumes broke these tests with a cardinality panic at
+// run time instead of a compile error, and the fix was to append one more string in a place with no
+// indication of which label it was meant to be.
 func healthMetricLabels(handle string) []string {
-	return []string{"csi.weka.io", "pv-" + handle, "guid-" + handle, "wekafs-sc", "fs-" + handle, "dir", "default", "pvc-" + handle, "default", "uid-" + handle}
+	pv := &v1.PersistentVolume{
+		ObjectMeta: metav1.ObjectMeta{Name: "pv-" + handle},
+		Spec: v1.PersistentVolumeSpec{
+			StorageClassName: "wekafs-sc",
+			ClaimRef: &v1.ObjectReference{
+				Name:      "pvc-" + handle,
+				Namespace: "default",
+				UID:       types.UID("uid-" + handle),
+			},
+			PersistentVolumeSource: v1.PersistentVolumeSource{
+				CSI: &v1.CSIPersistentVolumeSource{
+					NodePublishSecretRef: &v1.SecretReference{Name: "api-secret", Namespace: "csi-wekafs"},
+				},
+			},
+		},
+	}
+	return csiVolumeLabelValues("csi.weka.io", pv, "guid-"+handle, "fs-"+handle, "dir", "default")
 }
 
 // TestDeleteVolumeForgetsHealthMetricsImmediately is the regression test for the fix this change
@@ -364,5 +384,52 @@ func TestReconcileOncePrunesRemovedVolumeSeries(t *testing.T) {
 	}
 	if _, ok := cache.lookup("weka/v2/default"); !ok {
 		t.Fatal("expected the staying volume to remain cached")
+	}
+}
+
+// TestCsiVolumeLabelValuesCarriesSecretName covers the secret_name label. A volume's API Secret is
+// the credential its capacity and API traffic are attributable to, and CSI never hands the driver
+// that name - it passes the Secret's contents - so the PersistentVolume is the only place it
+// survives. Both the metrics server's capacity series and the controller's volume-health series go
+// through this one builder, so labelling here is what keeps them attributable to the same Secret.
+func TestCsiVolumeLabelValuesCarriesSecretName(t *testing.T) {
+	indexOfSecretName := -1
+	for i, l := range LabelsForCsiVolumes {
+		if l == "secret_name" {
+			indexOfSecretName = i
+		}
+	}
+	if indexOfSecretName == -1 {
+		t.Fatal("secret_name is not part of LabelsForCsiVolumes")
+	}
+
+	withRef := func(ref *v1.SecretReference) *v1.PersistentVolume {
+		return &v1.PersistentVolume{
+			ObjectMeta: metav1.ObjectMeta{Name: "pv-1"},
+			Spec: v1.PersistentVolumeSpec{
+				PersistentVolumeSource: v1.PersistentVolumeSource{
+					CSI: &v1.CSIPersistentVolumeSource{ControllerExpandSecretRef: ref},
+				},
+			},
+		}
+	}
+
+	for _, tt := range []struct {
+		name string
+		pv   *v1.PersistentVolume
+		want string
+	}{
+		{"secret ref present", withRef(&v1.SecretReference{Name: "api-secret", Namespace: "csi-wekafs"}), "csi-wekafs/api-secret"},
+		{"no ref at all - a static volume need not carry one", withRef(nil), ""},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got := csiVolumeLabelValues("csi.weka.io", tt.pv, "guid", "fs", "dir", "Root")
+			if len(got) != len(LabelsForCsiVolumes) {
+				t.Fatalf("built %d values for %d labels", len(got), len(LabelsForCsiVolumes))
+			}
+			if got[indexOfSecretName] != tt.want {
+				t.Fatalf("secret_name = %q, want %q", got[indexOfSecretName], tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Volume capacity and volume health are already groupable by WEKA organization, but
not by the credentials used to reach it, so on a fleet spread over several API
Secrets there was no way to tell which one a volume's traffic and capacity
belonged to.

Add secret_name to LabelsForCsiVolumes as "namespace/name". It is derived from
the PersistentVolume rather than passed in, because CSI hands the driver a
Secret's contents and never its name - the object is the only place the name
survives. Both consumers already resolve credentials through preferredSecretRef,
so labelling from the same ref keeps the metrics server's capacity series and the
controller's volume-health series attributable to the same Secret. Blank for a
volume that references none, which a statically provisioned volume need not.

A tenant is expected to use one Secret, so this adds no series to a metric that
is already per-volume. Where that expectation does not hold, a tenant's series
split by Secret, which is the intended reading.

The test helper that built these label values by hand now goes through
csiVolumeLabelValues. Listing them itself meant every added label broke the tests
with a cardinality panic at run time rather than a compile error, and the fix was
to append another bare string to a list with no indication of which label it was.

Ported from #640 by Assaf Ginzburg.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>