### PR TITLE
fix(chart): use the configured logLevel for the csi-snapshotter sidecar

### DIFF
--- a/charts/csi-wekafsplugin/templates/controllerserver-deployment.yaml
+++ b/charts/csi-wekafsplugin/templates/controllerserver-deployment.yaml
@@ -353,7 +353,7 @@ spec:
           command: ["/shared/wait-for-leader"]
           args:
             - "/csi-snapshotter"
-            - "--v=5"
+            - "--v={{ .Values.logLevel | default 5 }}"
             - "--csi-address=$(ADDRESS)"
             - "--timeout=60s"
             - "--worker-threads={{ .Values.controller.maxConcurrentRequests }}"


### PR DESCRIPTION
### TL;DR
`logLevel` now applies to the snapshotter sidecar too, instead of it always logging at level 5.

### What changed?
- The `csi-snapshotter` container's verbosity came from a value written into the template rather than from `logLevel`. It now follows `logLevel` like every other container.
- No change at the default: the hardcoded value and the default are both 5.

### How to test?
1. Install with `--set logLevel=2`.
2. Run `kubectl get deploy <release>-controller -o yaml` and confirm the `csi-snapshotter` container is started with `--v=2`.
3. Confirm its logs are correspondingly quieter.

### Why make this change?
Reported in issue #687. Turning `logLevel` down quieted every container except the snapshotter, which kept logging at 5 — and on a busy controller that was most of the remaining log volume. While fixing it we checked every other container in both charts; this was the only one whose log level was not configurable.
