### PR TITLE
feat: make the CSI sidecar Kubernetes API rate limit configurable

### DIFF
--- a/charts/csi-wekafsplugin/templates/controllerserver-deployment.yaml
+++ b/charts/csi-wekafsplugin/templates/controllerserver-deployment.yaml
@@ -242,6 +242,8 @@ spec:
             - "--v={{ .Values.logLevel | default 5 }}"
             - "--timeout=60s"
             - "--worker-threads={{ .Values.controller.maxConcurrentRequests }}"
+            - "--kube-api-qps={{ .Values.controller.kubeApiQps }}"
+            - "--kube-api-burst={{ .Values.controller.kubeApiBurst }}"
             {{- if .Values.metrics.enabled }}
             - "--http-endpoint=:{{ .Values.metrics.attacherPort | default 9095 }}"
             {{- end }}
@@ -282,6 +284,8 @@ spec:
             - "--timeout=60s"
             - "--prevent-volume-mode-conversion"
             - "--worker-threads={{ .Values.controller.maxConcurrentRequests }}"
+            - "--kube-api-qps={{ .Values.controller.kubeApiQps }}"
+            - "--kube-api-burst={{ .Values.controller.kubeApiBurst }}"
             - "--retry-interval-start=10s"
           {{- if .Values.metrics.enabled }}
             - "--http-endpoint=:{{ .Values.metrics.provisionerPort | default 9091 }}"
@@ -323,6 +327,8 @@ spec:
             - "--http-endpoint=:{{ .Values.metrics.resizerPort | default 9092 }}"
           {{- end }}
             - "--workers={{ .Values.controller.maxConcurrentRequests }}"
+            - "--kube-api-qps={{ .Values.controller.kubeApiQps }}"
+            - "--kube-api-burst={{ .Values.controller.kubeApiBurst }}"
             - "--retry-interval-start=10s"
           env:
             - name: ADDRESS
@@ -358,6 +364,8 @@ spec:
             - "--csi-address=$(ADDRESS)"
             - "--timeout=60s"
             - "--worker-threads={{ .Values.controller.maxConcurrentRequests }}"
+            - "--kube-api-qps={{ .Values.controller.kubeApiQps }}"
+            - "--kube-api-burst={{ .Values.controller.kubeApiBurst }}"
             - "--retry-interval-start=10s"
           {{- if .Values.metrics.enabled }}
             - "--http-endpoint=:{{ .Values.metrics.snapshotterPort | default 9093 }}"
@@ -405,6 +413,8 @@ spec:
                  Those paths read different flags, so set both from the same value. */}}
             - "--monitor-interval={{ .Values.controller.healthMonitor.monitorInterval }}"
             - "--list-volumes-interval={{ .Values.controller.healthMonitor.monitorInterval }}"
+            - "--kube-api-qps={{ .Values.controller.kubeApiQps }}"
+            - "--kube-api-burst={{ .Values.controller.kubeApiBurst }}"
           env:
             - name: ADDRESS
               value: unix:///csi/csi.sock

--- a/charts/csi-wekafsplugin/values.schema.json
+++ b/charts/csi-wekafsplugin/values.schema.json
@@ -54,6 +54,12 @@
                 "labels": {
                     "type": "object"
                 },
+                "kubeApiBurst": {
+                    "type": "integer"
+                },
+                "kubeApiQps": {
+                    "type": "integer"
+                },
                 "maxConcurrentRequests": {
                     "type": "integer"
                 },

--- a/charts/csi-wekafsplugin/values.yaml
+++ b/charts/csi-wekafsplugin/values.yaml
@@ -56,6 +56,14 @@ controller:
   healthPort: 8081
   # -- Maximum concurrent requests from sidecars (global)
   maxConcurrentRequests: 5
+  # -- Rate limit for Kubernetes API calls made by the CSI sidecars, in queries per second.
+  #    Each volume create or delete costs roughly 3 API calls, so this value divided by 3 is the
+  #    ceiling on volumes provisioned or deleted per second. The upstream sidecar default is 5,
+  #    which caps throughput at under 2 volumes/sec regardless of maxConcurrentRequests
+  kubeApiQps: 150
+  # -- Burst size for Kubernetes API calls made by the CSI sidecars, allowing short spikes above
+  #    kubeApiQps. The upstream sidecar default is 10
+  kubeApiBurst: 300
   # -- maximum concurrent operations per operation type
   concurrency:
     createVolume: 5


### PR DESCRIPTION
### TL;DR
Creating and deleting large numbers of volumes is now about ten times faster.

### What changed?
- New values `controller.kubeApiQps` (default 150) and `controller.kubeApiBurst` (default 300).
- Both are applied to every CSI sidecar, which until now ran at the upstream default of 5 Kubernetes API queries per second.

### How to test?
1. Deploy the chart, create a few hundred PVCs, then delete them.
2. Time how long the PVs take to disappear — expect well over 10 per second.
3. Setting `controller.kubeApiQps=5` and `controller.kubeApiBurst=10` restores the previous rate of under 2 per second.

### Why make this change?
Each volume create or delete costs about three Kubernetes API calls, so a limit of 5 per second held the driver to under 2 volumes per second however high `controller.maxConcurrentRequests` was set — the driver sat idle waiting on the sidecars rather than doing work. On a 10,000 PVC cluster, raising the limit took deletion from 1.7 to 16.7 volumes per second.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Raises default Kubernetes API traffic from CSI controller sidecars cluster-wide; mis-tuned values could stress the API server, though settings are operator-controlled.
> 
> **Overview**
> Adds **`controller.kubeApiQps`** (default **150**) and **`controller.kubeApiBurst`** (default **300**) so operators can tune how fast CSI sidecars talk to the Kubernetes API. Previously those containers relied on upstream defaults (**5 QPS / 10 burst**), which effectively capped bulk provision/delete throughput regardless of **`maxConcurrentRequests`**.
> 
> The chart passes **`--kube-api-qps`** and **`--kube-api-burst`** into every controller sidecar: attacher, provisioner, resizer, snapshotter, and the external health monitor. **`values.schema.json`** documents the new integers for validation.
> 
> Lowering the values back to **5/10** restores the old behavior for clusters that need stricter API load limits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1e1e60cc36b2f323576aea6a1450762ef003f19. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->