### PR TITLE
fix: refuse to provision from a seed snapshot that contains data (CSI-400)

### DIFF
--- a/pkg/wekafs/seedsnapshot_test.go
+++ b/pkg/wekafs/seedsnapshot_test.go
@@ -1,0 +1,66 @@
+package wekafs
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDirHoldsOnlySnapshots covers the decision both isFilesystemEmpty and isSeedSnapshotEmpty rest
+// on. The wrappers themselves need a mounted filesystem, so this exercises the part that decides
+// whether a seed snapshot is safe to provision from.
+func TestDirHoldsOnlySnapshots(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		entries []string
+		dirs    []string
+		want    bool
+	}{
+		{name: "empty directory", want: true},
+		{name: "only the snapshots directory", dirs: []string{SnapshotsSubDirectory}, want: true},
+		{name: "a single data file", entries: []string{"payload"}, want: false},
+		{name: "snapshots directory alongside data", dirs: []string{SnapshotsSubDirectory}, entries: []string{"payload"}, want: false},
+		{name: "a data directory", dirs: []string{"somedir"}, want: false},
+		// More entries than the two names read, to confirm the answer does not depend on which two
+		// the filesystem happens to return first.
+		{name: "many data files", entries: []string{"a", "b", "c", "d", "e"}, want: false},
+		{name: "many data files beside snapshots", dirs: []string{SnapshotsSubDirectory}, entries: []string{"a", "b", "c", "d", "e"}, want: false},
+		// A dotfile is data like any other; only SnapshotsSubDirectory is exempt.
+		{name: "an unrelated dotfile", entries: []string{".hidden"}, want: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			for _, d := range tc.dirs {
+				require.NoError(t, os.Mkdir(filepath.Join(root, d), 0o750))
+			}
+			for _, f := range tc.entries {
+				require.NoError(t, os.WriteFile(filepath.Join(root, f), []byte("x"), 0o600))
+			}
+
+			dir, err := os.Open(root)
+			require.NoError(t, err)
+			defer func() { _ = dir.Close() }()
+
+			got, err := dirHoldsOnlySnapshots(dir)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestDirHoldsOnlySnapshotsFailsClosed pins the behaviour that matters most: a directory that
+// cannot be read must report an error rather than "empty". Answering "empty" here would wave
+// through the exact case the seed snapshot check exists to catch.
+func TestDirHoldsOnlySnapshotsFailsClosed(t *testing.T) {
+	root := t.TempDir()
+	dir, err := os.Open(root)
+	require.NoError(t, err)
+	require.NoError(t, dir.Close()) // reading from it now fails
+
+	empty, err := dirHoldsOnlySnapshots(dir)
+	assert.Error(t, err, "a directory that cannot be read must not be reported as empty")
+	assert.False(t, empty)
+}

--- a/pkg/wekafs/volume.go
+++ b/pkg/wekafs/volume.go
@@ -1219,11 +1219,46 @@ func (v *Volume) isFilesystemEmpty(ctx context.Context) (empty bool, retErr erro
 	}
 	defer func() { _ = dir.Close() }()
 
-	fileNames, err := dir.Readdirnames(2)
-	if err == io.EOF {
-		return true, nil
+	return dirHoldsOnlySnapshots(dir)
+}
+
+// isSeedSnapshotEmpty returns true if the seed snapshot holds nothing but SnapshotsSubDirectory.
+// A seed snapshot is meant to capture the filesystem while it was still empty; anything visible
+// inside it means it no longer represents that state, and every volume seeded from it would
+// silently start life carrying that data.
+func (v *Volume) isSeedSnapshotEmpty(ctx context.Context) (empty bool, retErr error) {
+	err, umount := v.MountUnderlyingFS(ctx)
+	if err != nil {
+		return false, err
 	}
-	for _, name := range fileNames {
+	defer deferUmount(umount, &retErr)
+
+	seedSnapshotPath := filepath.Join(v.getMountPath(), SnapshotsSubDirectory, v.getSeedSnapshotAccessPoint())
+	dir, err := os.Open(seedSnapshotPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, errors.New("seed snapshot directory not found in filesystem")
+		}
+		return false, err
+	}
+	defer func() { _ = dir.Close() }()
+
+	return dirHoldsOnlySnapshots(dir)
+}
+
+// dirHoldsOnlySnapshots reports whether dir contains nothing besides the SnapshotsSubDirectory
+// entry. It reads at most two names, which is all it takes to tell empty from non-empty, so the
+// cost does not grow with the directory.
+//
+// An unreadable directory is an error, never "empty": both callers use this to decide whether to
+// refuse an operation, and answering "empty" on a failed read would wave through exactly the case
+// the check exists to catch.
+func dirHoldsOnlySnapshots(dir *os.File) (bool, error) {
+	names, err := dir.Readdirnames(2)
+	if err != nil && err != io.EOF {
+		return false, err
+	}
+	for _, name := range names {
 		if name == SnapshotsSubDirectory {
 			continue
 		}
@@ -1338,6 +1373,19 @@ func (v *Volume) ensureSeedSnapshot(ctx context.Context) (*apiclient.Snapshot, e
 
 		if snap, err = v.createSeedSnapshot(ctx); err != nil {
 			return nil, err
+		}
+	} else if !v.server.isInDevMode() {
+		// The snapshot already existed, so nothing above established that it is still empty.
+		// Validate it before seeding anything from it: a seed snapshot that has been written into
+		// would hand its contents to every volume created from it, silently and permanently.
+		empty, err := v.isSeedSnapshotEmpty(ctx)
+		if err != nil {
+			logger.Error().Err(err).Msg("Failed to validate that the seed snapshot is empty")
+			return nil, fmt.Errorf("failed to validate seed snapshot is empty: %w", err)
+		}
+		if !empty {
+			logger.Error().Msg("Seed snapshot is not empty, it has been modified and now contains data")
+			return nil, errors.New("seed snapshot is not empty, cannot provision new volumes from a seed snapshot that contains data")
 		}
 	}
 


### PR DESCRIPTION
### TL;DR

The driver now refuses to create a volume from a seed snapshot that has had data written into it, instead of silently handing that data to every new volume.

### What changed?

- Before provisioning from an existing seed snapshot, the driver checks that the snapshot is still empty.
- If it is not, `CreateVolume` fails with a message saying the seed snapshot contains data, rather than succeeding.
- A seed snapshot that cannot be read is treated as a failure too, instead of being assumed empty.

### How to test?

1. Create a storage class backed by a filesystem and provision one PVC, so the seed snapshot is created.
2. Write a file into the seed snapshot's directory under `.snapshots`.
3. Create another PVC from the same storage class, and confirm it fails with a message that the seed snapshot is not empty.
4. Remove the file, create the PVC again, and confirm it binds normally.

### Why make this change?

A seed snapshot is captured while the filesystem is still empty, and every volume from that filesystem is created from it. Emptiness was only ever checked at the moment the snapshot was created; after that it was trusted forever. If anyone wrote into it, the snapshot stopped representing an empty filesystem and every volume seeded from it afterwards started out holding that data — permanently, and with nothing to indicate anything was wrong.

Original work by @assafgi in #636, ported onto the 2.10 line.

This is a behaviour change, not a pure fix: a setup that is today provisioning from a seed snapshot containing data will start failing after this. That is the point of the change, but it is why this targets 2.10 rather than going out in a patch release.

<!-- /CURSOR_SUMMARY -->