### PR TITLE
fix: give every container port a name unique within its pod

### DIFF
--- a/charts/csi-wekafsplugin/templates/controllerserver-deployment.yaml
+++ b/charts/csi-wekafsplugin/templates/controllerserver-deployment.yaml
@@ -259,7 +259,7 @@ spec:
           {{- if .Values.metrics.enabled }}
           ports:
             - containerPort: {{ .Values.metrics.attacherPort | default 9095 }}
-              name: pr-metrics
+              name: at-metrics
               protocol: TCP
           {{- end }}
           {{- if .Values.controller.resources.csiAttacher }}

--- a/charts/csi-wekafsplugin/templates/nodeserver-daemonset.yaml
+++ b/charts/csi-wekafsplugin/templates/nodeserver-daemonset.yaml
@@ -125,7 +125,7 @@ spec:
           ports:
           {{- if .Values.node.livenessProbeEnabled }}
             - containerPort: 9899
-              name: healthz
+              name: ns-healthz
               protocol: TCP
           {{- end }}
           {{- if .Values.metrics.enabled }}
@@ -139,7 +139,7 @@ spec:
             failureThreshold: 10
             httpGet:
               path: /healthz
-              port: healthz
+              port: ns-healthz
             initialDelaySeconds: 10
             timeoutSeconds: 10
             periodSeconds: 10
@@ -228,10 +228,10 @@ spec:
             - "--health-port=9809"
           ports:
             - containerPort: 9809
-              name: healthz
+              name: reg-healthz
           livenessProbe:
             httpGet:
-              port: healthz
+              port: reg-healthz
               path: /healthz
             initialDelaySeconds: 5
             timeoutSeconds: 5


### PR DESCRIPTION
### TL;DR

Fixes duplicate container port names in the node and controller pods, which could send metrics scrapes to the wrong sidecar.

### What changed?

- In the node DaemonSet, the two ports both named `healthz` are now `ns-healthz` (9899, node driver) and `reg-healthz` (9809, registrar).
- In the controller Deployment, the attacher metrics port is renamed from `pr-metrics` to `at-metrics`. The provisioner keeps `pr-metrics`.
- The liveness probes that referenced these ports by name were updated to match.

No ports, values or defaults change — only names.

### How to test?

1. Install or upgrade the chart with `metrics.enabled=true`.
2. Run `kubectl get pod <node-pod> -o jsonpath='{.spec.containers[*].ports[*].name}'` and confirm `ns-healthz` and `reg-healthz` appear instead of `healthz` twice.
3. Do the same for a controller pod and confirm `at-metrics` and `pr-metrics` are distinct.
4. Confirm both pods stay healthy — the liveness probes resolve the renamed ports.

### Why make this change?

A port name must be unique across a whole pod, not just within one container. Two pods reused a name, so anything resolving a port by name — a Service `targetPort`, a `PodMonitor` port selector — would get whichever one the cluster happened to keep. Metrics could be scraped from the wrong sidecar, or missed. Nothing in the chart selects by these names today, which is why it went unnoticed, but it makes the ports unsafe to reference.

Original fix by @assafgi in #682, reworked with the shorter names already used in the 3.0 branch so a second set of names does not follow behind it.
