### PR TITLE
fix: stop the driver panicking when it cannot determine volume encryption

### DIFF
--- a/pkg/wekafs/volume.go
+++ b/pkg/wekafs/volume.go
@@ -189,7 +189,8 @@ func (v *Volume) isEncrypted(ctx context.Context) (bool, error) {
 
 	if v.encrypted == nil {
 		// TODO: maybe we should move it into a separate method that is explicitly invoked when Volume is constructed from VolumeID rather than doing it here
-		if exists, err := v.Exists(ctx); err == nil {
+		exists, existsErr := v.Exists(ctx)
+		if existsErr == nil {
 			if v.apiClient != nil {
 				fsObj, err := v.getFilesystemObj(ctx, true)
 				if err != nil {
@@ -215,6 +216,21 @@ func (v *Volume) isEncrypted(ctx context.Context) (bool, error) {
 					v.encrypted = &[]bool{false}[0]
 				}
 			}
+		}
+
+		// Nothing above is guaranteed to have set v.encrypted. Exists() can fail, and for a
+		// filesystem-backed volume with no API client bound it returns (false, nil) - so the error
+		// check passes, there is no client to query, and the field stays unset. Dereferencing it
+		// here is what made that a panic.
+		//
+		// Report it instead. "Not encrypted" would be the dangerous answer: callers act on this to
+		// decide whether to apply encryption, so a volume whose state we could not read would be
+		// treated as one we had read and found unencrypted.
+		if v.encrypted == nil {
+			if existsErr != nil {
+				return false, fmt.Errorf("cannot determine whether the volume is encrypted: %w", existsErr)
+			}
+			return false, errors.New("cannot determine whether the volume is encrypted: no API client is bound to the volume")
 		}
 	}
 	return *v.encrypted, nil

--- a/pkg/wekafs/volume_encryption_test.go
+++ b/pkg/wekafs/volume_encryption_test.go
@@ -1,0 +1,49 @@
+package wekafs
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestIsEncryptedWithoutApiClient covers a volume the driver has no way to ask about: a
+// filesystem-backed volume with no API client bound.
+//
+// Exists() reports (false, nil) for that case rather than an error, so isEncrypted walks straight
+// past its error check, finds no API client to query, and leaves v.encrypted unset. Dereferencing
+// it then panicked. The encryption state is genuinely unknown here, so the only safe answers are an
+// error or a panic - and reporting "not encrypted" would be worse than either, since callers act on
+// it.
+func TestIsEncryptedWithoutApiClient(t *testing.T) {
+	v := &Volume{FilesystemName: "some-filesystem"}
+	require.True(t, v.isFilesystem(), "test needs a filesystem-backed volume to reach the path")
+	require.Nil(t, v.apiClient, "test needs an unbound volume to reach the path")
+
+	encrypted, err := v.isEncrypted(context.Background())
+
+	assert.Error(t, err, "encryption state is unknown without an API client, and must not be reported as fact")
+	assert.False(t, encrypted)
+}
+
+// TestIsEncryptedSafeWithoutApiClient pins the same case through the convenience wrapper. It
+// discards the error by design, but it never discarded the panic.
+func TestIsEncryptedSafeWithoutApiClient(t *testing.T) {
+	v := &Volume{FilesystemName: "some-filesystem"}
+
+	assert.False(t, v.isEncryptedSafe(context.Background()))
+}
+
+// TestIsEncryptedReturnsCachedValue confirms the guard leaves the already-resolved path alone: once
+// the encryption state is known, it is returned without consulting anything.
+func TestIsEncryptedReturnsCachedValue(t *testing.T) {
+	for _, want := range []bool{true, false} {
+		v := &Volume{FilesystemName: "some-filesystem", encrypted: &want}
+
+		got, err := v.isEncrypted(context.Background())
+
+		assert.NoError(t, err)
+		assert.Equal(t, want, got)
+	}
+}


### PR DESCRIPTION
### TL;DR

Fixes a crash: the driver could panic when checking whether a volume is encrypted, taking the process down.

### What changed?

- Checking encryption on a filesystem-backed volume with no API credentials bound now returns a clear error instead of crashing.
- The error says the encryption state could not be determined, and includes the underlying reason when there is one.
- Volume creation that needs this answer fails with an `Internal` error rather than continuing.

### How to test?

1. Create a volume backed by a whole filesystem whose storage class has no API secret attached.
2. Perform an operation that touches encryption on it — for example creating a volume from it.
3. Confirm the driver reports an error and keeps running, rather than the controller pod restarting.

Automated coverage is included: the new test reproduces the crash against the unfixed code.

### Why make this change?

The check ended by reading a value that was not always set. For a filesystem-backed volume with no API client, the driver has no way to ask the cluster whether the volume is encrypted, so nothing filled that value in and reading it crashed the process.

Reporting an error is the safe answer rather than assuming "not encrypted". Callers use this to decide whether to apply encryption, so a volume whose state could not be read would otherwise be treated as one that had been read and found unencrypted.

Found by @kristina-solovyova in #692.
