### PR TITLE
docs: show a Source Code link on the chart page

### DIFF
--- a/.github/workflows/pull-request-v2.yaml
+++ b/.github/workflows/pull-request-v2.yaml
@@ -333,7 +333,7 @@ jobs:
             APP_VERSION="${{ steps.version.outputs.version }}"
             yq -i '.version = "'$CHART_VERSION'"' $BASEDIR/Chart.yaml
             yq -i '.appVersion = "'$APP_VERSION'"' $BASEDIR/Chart.yaml
-            yq -i '.sources[0] = "https://github.com/weka/csi-wekafs/tree/v$CHART_VERSION/charts/csi-wekafsplugin"' $BASEDIR/Chart.yaml
+            yq -i '.sources[0] = "https://github.com/weka/csi-wekafs/tree/v'$CHART_VERSION'/charts/csi-wekafsplugin"' $BASEDIR/Chart.yaml
             yq -i '.csiDriverVersion = "'$DRIVER_VERSION'"' $BASEDIR/values.yaml
             echo ------------------ values ------------------
             cat $BASEDIR/values.yaml
@@ -442,7 +442,7 @@ jobs:
             APP_VERSION="${{ steps.version.outputs.version }}"
             yq -i '.version = "'$CHART_VERSION'"' $BASEDIR/Chart.yaml
             yq -i '.appVersion = "'$APP_VERSION'"' $BASEDIR/Chart.yaml
-            yq -i '.sources[0] = "https://github.com/weka/csi-wekafs/tree/v$CHART_VERSION/charts/csi-wekafsplugin"' $BASEDIR/Chart.yaml
+            yq -i '.sources[0] = "https://github.com/weka/csi-wekafs/tree/v'$CHART_VERSION'/charts/csi-wekafsplugin"' $BASEDIR/Chart.yaml
             yq -i '.csiDriverVersion = "'$DRIVER_VERSION'"' $BASEDIR/values.yaml
             echo ------------------ values ------------------
             cat $BASEDIR/values.yaml

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ https://github.com/weka/csi-wekafs
 | ---- | ------ | --- |
 | WekaIO, Inc. | <csi@weka.io> | <https://weka.io> |
 
+## Source Code
+
+* <https://github.com/weka/csi-wekafs/tree/v2.9.1>
+
 ## Pre-requisite
 - Kubernetes cluster of version 1.20 or later is recommended. Minimum version is 1.17
 - Access to terminal with `kubectl` installed

--- a/README.md.gotmpl
+++ b/README.md.gotmpl
@@ -10,6 +10,8 @@
 
 {{ template "chart.maintainersSection" . }}
 
+{{ template "chart.sourcesSection" . }}
+
 ## Pre-requisite
 - Kubernetes cluster of version 1.20 or later is recommended. Minimum version is 1.17
 - Access to terminal with `kubectl` installed

--- a/charts/csi-wekafsplugin/README.md
+++ b/charts/csi-wekafsplugin/README.md
@@ -14,6 +14,10 @@ https://github.com/weka/csi-wekafs
 | ---- | ------ | --- |
 | WekaIO, Inc. | <csi@weka.io> | <https://weka.io> |
 
+## Source Code
+
+* <https://github.com/weka/csi-wekafs/tree/v2.9.1>
+
 ## Pre-requisite
 - Kubernetes cluster of version 1.18 and up, 1.19 and up recommended
 - Helm v3 must be installed and configured properly

--- a/charts/csi-wekafsplugin/README.md.gotmpl
+++ b/charts/csi-wekafsplugin/README.md.gotmpl
@@ -10,6 +10,8 @@
 
 {{ template "chart.maintainersSection" . }}
 
+{{ template "chart.sourcesSection" . }}
+
 ## Pre-requisite
 - Kubernetes cluster of version 1.18 and up, 1.19 and up recommended
 - Helm v3 must be installed and configured properly


### PR DESCRIPTION
### TL;DR

The chart page now shows a **Source Code** link, pointing at the tag the chart was built from.

### What changed?

- The chart README and the ArtifactHub listing render a `## Source Code` section, taken from the `sources` entry already in `Chart.yaml`.
- Fixed the source URL recorded by PR-built charts, which contained the literal text `$CHART_VERSION` instead of the version number. Released charts were not affected.

### How to test?

1. Open `charts/csi-wekafsplugin/README.md` and confirm a **Source Code** section appears under **Maintainers**, with a link ending in the chart version.
2. On a PR build, run `helm show chart <chart>` and confirm the `sources` URL contains a version number rather than `$CHART_VERSION`.

### Why make this change?

`Chart.yaml` has always recorded where the chart comes from, but nothing displayed it, so the published chart page gave no link back to the source at that version. Rendering it from `Chart.yaml` means it follows the value the release process already maintains, rather than becoming another thing to update by hand.

Both sections were originally raised by @ari in #582.
