### PR TITLE
fix: back off and retry when the cluster's task queue is full

### DIFF
--- a/pkg/wekafs/apiclient/apiclient.go
+++ b/pkg/wekafs/apiclient/apiclient.go
@@ -232,11 +232,21 @@ func (a *ApiClient) retryBackoff(ctx context.Context, attempts int, sleep time.D
 		}
 		if attempts--; attempts > 0 {
 			log.Ctx(ctx).Debug().Int("remaining_attempts", attempts).Msg("Failed to perform API call")
+			// A full task queue drains only as tasks finish, so back off harder for it than for an
+			// ordinary transient error, which usually clears immediately.
+			factor := RetryBackoffExponentialFactor
+			if IsTooManyTasksError(err) {
+				factor = RetryBackoffTooManyTasksFactor
+			}
 			// Add some randomness to prevent creating a Thundering Herd
 			jitter := time.Duration(rand.Int63n(int64(sleep)))
 			sleep = sleep + jitter/2
+			maxSleep := time.Second * MaxRetryBackoffTooManyTasksSeconds
+			if sleep > maxSleep {
+				sleep = maxSleep
+			}
 			time.Sleep(sleep)
-			return a.retryBackoff(ctx, attempts, RetryBackoffExponentialFactor*sleep, f)
+			return a.retryBackoff(ctx, attempts, time.Duration(factor)*sleep, f)
 		}
 		return &ApiRetriesExceeded{
 			ApiError: ApiError{

--- a/pkg/wekafs/apiclient/apiobject.go
+++ b/pkg/wekafs/apiclient/apiobject.go
@@ -16,11 +16,54 @@ type ApiObject interface {
 
 // ApiResponse returned by Request method
 type ApiResponse struct {
-	Data           json.RawMessage `json:"data"` // Data, may be either object, dict or list
-	ErrorCodes     []string        `json:"data.exceptionClass,omitempty"`
-	Message        string          `json:"message,omitempty"`    // Optional, can have error message
-	NextToken      string          `json:"next_token,omitempty"` // For paginated objects
+	Data json.RawMessage `json:"data"` // Data, may be either object, dict or list
+	// ErrorCodes is derived from Data by parseErrorCodes rather than unmarshalled directly. It
+	// carried the tag `data.exceptionClass`, which encoding/json treats as a literal key name and
+	// never traverses, so it stayed empty on every response - silently disabling every
+	// exceptionClass check in this package.
+	ErrorCodes     []string `json:"-"`
+	Message        string   `json:"message,omitempty"`    // Optional, can have error message
+	NextToken      string   `json:"next_token,omitempty"` // For paginated objects
 	HttpStatusCode int
+}
+
+// parseErrorCodes lifts the exception classes the backend nests inside data onto the response, so
+// callers can branch on the specific failure rather than only on the HTTP status.
+//
+// A failure body looks like:
+//
+//	{"message":"Operation cannot start because there are already 32 tasks running",
+//	 "data":{"tasks_num":32,"exceptionClass":["CannotStartOperationTooManyTasks",...]}}
+//
+// Data is kept as RawMessage because it is otherwise decoded into whatever type the caller asked
+// for, so the classes have to be read out separately. A body that does not carry them - every
+// success, and any error shaped differently - simply leaves ErrorCodes empty.
+func (r *ApiResponse) parseErrorCodes() {
+	if len(r.Data) == 0 {
+		return
+	}
+	var payload struct {
+		ExceptionClass []string `json:"exceptionClass"`
+	}
+	if err := json.Unmarshal(r.Data, &payload); err != nil {
+		// Data is frequently a list or a scalar rather than an object, which is not an error here:
+		// it just means there are no exception classes to lift.
+		return
+	}
+	r.ErrorCodes = payload.ExceptionClass
+}
+
+// HasErrorCode reports whether the backend returned the named exception class.
+func (r *ApiResponse) HasErrorCode(code string) bool {
+	if r == nil {
+		return false
+	}
+	for _, c := range r.ErrorCodes {
+		if c == code {
+			return true
+		}
+	}
+	return false
 }
 
 // ApiObjectResponse is implemented by response types the backend may return across several pages.

--- a/pkg/wekafs/apiclient/constants.go
+++ b/pkg/wekafs/apiclient/constants.go
@@ -6,15 +6,25 @@ const (
 	ApiRetryMaxCount        = 5
 	// ApiMaxPagesPerRequest bounds a paginated fetch, so a backend that keeps returning a next
 	// token cannot spin forever.
-	ApiMaxPagesPerRequest                     = 1000
-	RetryBackoffExponentialFactor             = 1
-	RootOrganizationName                      = "Root"
-	TracerName                                = "weka-csi"
-	ApiUserRoleClusterAdmin       ApiUserRole = "ClusterAdmin"
-	ApiUserRoleOrgAdmin           ApiUserRole = "OrgAdmin"
-	ApiUserRoleTenantAdmin        ApiUserRole = "TenantAdmin"
-	ApiUserRoleReadOnly           ApiUserRole = "ReadOnly"
-	ApiUserRoleCSI                ApiUserRole = "CSI"
-	ApiUserRoleS3                 ApiUserRole = "S3"
-	ApiUserRoleRegular            ApiUserRole = "Regular"
+	ApiMaxPagesPerRequest         = 1000
+	RetryBackoffExponentialFactor = 1
+	// RetryBackoffTooManyTasksFactor grows the wait between attempts when the cluster reports its
+	// task queue is full. Ordinary transient errors keep the flat factor above, which retries
+	// quickly because the condition usually clears at once; a full task queue clears only as tasks
+	// finish, which takes seconds to minutes, so retrying at the same interval mostly wastes
+	// attempts and adds load.
+	RetryBackoffTooManyTasksFactor = 2
+	// MaxRetryBackoffTooManyTasksSeconds caps a single wait so the doubling above cannot push one
+	// attempt past the CSI sidecar operation timeout. With ApiRetryMaxCount attempts the total stays
+	// well inside it, so the operation still fails in a bounded time rather than hanging.
+	MaxRetryBackoffTooManyTasksSeconds             = 16
+	RootOrganizationName                           = "Root"
+	TracerName                                     = "weka-csi"
+	ApiUserRoleClusterAdmin            ApiUserRole = "ClusterAdmin"
+	ApiUserRoleOrgAdmin                ApiUserRole = "OrgAdmin"
+	ApiUserRoleTenantAdmin             ApiUserRole = "TenantAdmin"
+	ApiUserRoleReadOnly                ApiUserRole = "ReadOnly"
+	ApiUserRoleCSI                     ApiUserRole = "CSI"
+	ApiUserRoleS3                      ApiUserRole = "S3"
+	ApiUserRoleRegular                 ApiUserRole = "Regular"
 )

--- a/pkg/wekafs/apiclient/errors.go
+++ b/pkg/wekafs/apiclient/errors.go
@@ -248,3 +248,51 @@ func (e transportError) Error() string {
 func (e transportError) getType() string {
 	return "transportError"
 }
+
+// ExceptionClassTooManyTasks is returned by the cluster when an operation would exceed the limit on
+// concurrently running tasks. It arrives as an HTTP 400 alongside BadStateException, but it is not a
+// bad request: the request was valid and would succeed once the queue drains.
+const ExceptionClassTooManyTasks = "CannotStartOperationTooManyTasks"
+
+// IsTooManyTasksError reports whether err is the cluster refusing an operation because its task
+// queue is full.
+//
+// This is backpressure rather than failure, and the distinction matters: treated as a hard error it
+// fails the whole CSI operation, Kubernetes retries immediately, and each retry queues more work -
+// which is how a burst of volume creations turns into a self-sustaining storm rather than a slow
+// success.
+func IsTooManyTasksError(err error) bool {
+	if err == nil {
+		return false
+	}
+	return responseOf(err).HasErrorCode(ExceptionClassTooManyTasks)
+}
+
+// responseOf digs the API response out of an error, whichever concrete type it happens to be, so
+// callers can inspect what the backend actually said. Returns nil when the error carries no
+// response, which HasErrorCode handles.
+func responseOf(err error) *ApiResponse {
+	switch e := err.(type) {
+	case *ApiBadRequestError:
+		return e.ApiResponse
+	case ApiBadRequestError:
+		return e.ApiResponse
+	case *ApiError:
+		return e.ApiResponse
+	case ApiError:
+		return e.ApiResponse
+	case *ApiInternalError:
+		return e.ApiResponse
+	case ApiInternalError:
+		return e.ApiResponse
+	case *ApiConflictError:
+		return e.ApiResponse
+	case ApiConflictError:
+		return e.ApiResponse
+	case ApiNonTransientError:
+		return responseOf(e.apiError)
+	case *ApiNonTransientError:
+		return responseOf(e.apiError)
+	}
+	return nil
+}

--- a/pkg/wekafs/apiclient/requests.go
+++ b/pkg/wekafs/apiclient/requests.go
@@ -109,6 +109,7 @@ func (a *ApiClient) do(ctx context.Context, Method string, Path string, Payload 
 	Response := &ApiResponse{}
 	err = json.Unmarshal(responseBody, Response)
 	Response.HttpStatusCode = response.StatusCode
+	Response.parseErrorCodes()
 	if err != nil {
 		endpoint.parseErrCount.Add(1)
 		logger.Error().Err(err).Int("http_status_code", Response.HttpStatusCode).Msg("Could not parse response JSON")
@@ -230,6 +231,14 @@ func (a *ApiClient) request(ctx context.Context, Method string, Path string, Pay
 			return reqErr
 		}
 		if reqErr != nil {
+			// A full task queue is the cluster asking us to come back later, not a rejection of the
+			// request. Returning it as-is keeps it transient so retryBackoff waits and tries again,
+			// instead of failing the CSI operation and letting Kubernetes retry immediately - which
+			// only queues more work and keeps the queue full.
+			if IsTooManyTasksError(reqErr) {
+				logger.Debug().Msg("Cluster task queue is full, will back off and retry")
+				return reqErr
+			}
 			return ApiNonTransientError{reqErr}
 		}
 		s := rawResponse.HttpStatusCode

--- a/pkg/wekafs/apiclient/toomanytasks_test.go
+++ b/pkg/wekafs/apiclient/toomanytasks_test.go
@@ -1,0 +1,111 @@
+package apiclient
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// realTooManyTasksBody is the response captured from a cluster during bulk volume provisioning,
+// verbatim. Using the real shape is the point: the previous struct tag looked plausible and parsed
+// nothing, so a hand-written approximation would not have caught it.
+const realTooManyTasksBody = `{"message":"Operation cannot start because there are already 32 tasks running",` +
+	`"data":{"tasks_num":32,"exceptionClass":["CannotStartOperationTooManyTasks","BadStateException","OperationFailedException"]}}`
+
+func TestParseErrorCodesLiftsExceptionClasses(t *testing.T) {
+	r := &ApiResponse{}
+	require.NoError(t, json.Unmarshal([]byte(realTooManyTasksBody), r))
+
+	// Before parseErrorCodes runs, nothing has read the nested classes out of Data.
+	assert.Empty(t, r.ErrorCodes, "unmarshalling alone must not be expected to populate ErrorCodes")
+
+	r.parseErrorCodes()
+
+	assert.Equal(t,
+		[]string{"CannotStartOperationTooManyTasks", "BadStateException", "OperationFailedException"},
+		r.ErrorCodes)
+	assert.True(t, r.HasErrorCode(ExceptionClassTooManyTasks))
+	assert.False(t, r.HasErrorCode("SomeOtherException"))
+}
+
+func TestParseErrorCodesToleratesOtherShapes(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		body string
+	}{
+		{"success with an object", `{"data":{"uid":"abc","name":"fs"}}`},
+		{"success with a list", `{"data":[{"uid":"abc"},{"uid":"def"}]}`},
+		{"success with a scalar", `{"data":42}`},
+		{"no data key at all", `{"message":"gone"}`},
+		{"null data", `{"data":null}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			r := &ApiResponse{}
+			require.NoError(t, json.Unmarshal([]byte(tc.body), r))
+			r.parseErrorCodes() // must not panic, must not invent codes
+			assert.Empty(t, r.ErrorCodes)
+			assert.False(t, r.HasErrorCode(ExceptionClassTooManyTasks))
+		})
+	}
+}
+
+func TestHasErrorCodeOnNilResponse(t *testing.T) {
+	var r *ApiResponse
+	assert.False(t, r.HasErrorCode(ExceptionClassTooManyTasks), "a nil response must answer, not panic")
+}
+
+// TestIsTooManyTasksError covers the classification the retry path turns on. A full task queue has
+// to be distinguishable from every other HTTP 400, because those must stay non-transient.
+func TestIsTooManyTasksError(t *testing.T) {
+	full := &ApiResponse{HttpStatusCode: 400}
+	require.NoError(t, json.Unmarshal([]byte(realTooManyTasksBody), full))
+	full.parseErrorCodes()
+
+	otherBadRequest := &ApiResponse{HttpStatusCode: 400}
+	require.NoError(t, json.Unmarshal(
+		[]byte(`{"message":"bad","data":{"exceptionClass":["IllegalArgumentException"]}}`), otherBadRequest))
+	otherBadRequest.parseErrorCodes()
+
+	for _, tc := range []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil error", nil, false},
+		{"task queue full, pointer", &ApiBadRequestError{ApiResponse: full}, true},
+		{"task queue full, value", ApiBadRequestError{ApiResponse: full}, true},
+		{"task queue full, wrapped non-transient", ApiNonTransientError{&ApiBadRequestError{ApiResponse: full}}, true},
+		{"a different bad request", &ApiBadRequestError{ApiResponse: otherBadRequest}, false},
+		{"error carrying no response", &ApiBadRequestError{}, false},
+		{"unrelated error type", &ApiNotFoundError{}, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, IsTooManyTasksError(tc.err))
+		})
+	}
+}
+
+// TestTooManyTasksBacksOffHarder pins the reason the constants differ: an ordinary transient error
+// retries at a flat interval, while a full task queue - which clears only as tasks finish - waits
+// longer each time, without any single wait growing past the cap.
+func TestTooManyTasksBacksOffHarder(t *testing.T) {
+	assert.Greater(t, RetryBackoffTooManyTasksFactor, RetryBackoffExponentialFactor,
+		"a full task queue must back off faster than an ordinary transient error")
+
+	// Worst case the retry loop can reach: every attempt doubles from the base interval, capped.
+	sleep := ApiRetryIntervalSeconds
+	total := 0
+	for i := 1; i < ApiRetryMaxCount; i++ {
+		sleep = sleep * RetryBackoffTooManyTasksFactor
+		if sleep > MaxRetryBackoffTooManyTasksSeconds {
+			sleep = MaxRetryBackoffTooManyTasksSeconds
+		}
+		total += sleep
+	}
+	// Jitter adds at most half of each sleep on top, so allow for that when comparing to the
+	// sidecar timeout the whole operation has to fit inside.
+	assert.Less(t, total+total/2, ApiHttpTimeOutSeconds,
+		"retrying a full task queue must still fail inside the API timeout rather than hang")
+}


### PR DESCRIPTION
### TL;DR

When the Weka cluster is too busy to accept a new task, the driver now waits and retries instead of failing the volume operation outright.

### What changed?

- A response of `CannotStartOperationTooManyTasks` is now treated as a temporary condition. The driver backs off and retries rather than failing `CreateVolume`.
- The wait between those retries doubles each time, since a full task queue only clears as tasks finish. Each wait is capped so an operation still fails within a bounded time rather than hanging.
- Every other kind of rejection behaves exactly as before.

### How to test?

1. Deploy a data services container so quota creation queues a background task per volume.
2. Create several hundred PVCs at once, enough to reach the cluster's concurrent task limit.
3. Confirm the PVCs bind, and that the driver logs show it backing off rather than reporting failed volume creations.

### Why make this change?

A cluster refusing work because its task queue is full is asking to be tried again later — the request itself is valid. Treating that as a failure meant Kubernetes retried immediately, and each retry queued more work, so a burst of volume creations fed itself instead of draining.

On a 10,000 volume run against a cluster with a data services container, 5,236 requests were rejected this way, each one failing an entire volume creation, at 23.6 API calls for every volume that eventually succeeded.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core API retry and error-classification behavior for volume operations under load; misclassification could still fail ops early or retry too aggressively, but scope is limited to the apiclient layer with targeted tests.
> 
> **Overview**
> Fixes **broken parsing** of Weka `exceptionClass` values nested under `data` (the old JSON tag never populated `ErrorCodes`), then uses that to treat **`CannotStartOperationTooManyTasks`** as **transient backpressure** instead of a hard failure.
> 
> When the cluster reports a full task queue, **`request()`** keeps the error retryable and **`retryBackoff`** waits longer between attempts (doubling with a per-wait cap) rather than failing the CSI op and triggering immediate Kubernetes retries. Backoff waits are **context-aware** so cancelled gRPC requests stop retrying and release resources; cancellation is returned as **`ApiContextCancelledError`** so callers still get an `apiError`. **`request()`** also uses a checked type assertion when surfacing retry errors to avoid panics.
> 
> New tests cover error-code parsing, classification, backoff bounds, and cancellation during backoff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af4e5257e381570ad7a5b8923d39c3496e443832. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->