### PR TITLE
refactor: delete the unmount path that has had no callers since 2024

### DIFF
--- a/pkg/wekafs/interfaces.go
+++ b/pkg/wekafs/interfaces.go
@@ -20,7 +20,6 @@ type AnyMounter interface {
 	NewMount(fsName string, options MountOptions) AnyMount
 	mountWithOptions(ctx context.Context, fsName string, mountOptions MountOptions, apiClient *apiclient.ApiClient) (string, error, UnmountFunc)
 	Mount(ctx context.Context, fs string, apiClient *apiclient.ApiClient) (string, error, UnmountFunc)
-	unmountWithOptions(ctx context.Context, fsName string, options MountOptions) error
 	LogActiveMounts(ctx context.Context)
 	gcInactiveMounts(ctx context.Context)
 	schedulePeriodicMountGc(ctx context.Context)

--- a/pkg/wekafs/nfsmount.go
+++ b/pkg/wekafs/nfsmount.go
@@ -123,17 +123,6 @@ func (m *nfsMount) decRef(ctx context.Context) error {
 	return nil
 }
 
-func (m *nfsMount) locateMountIP() error {
-	if m.mountIpAddress == "" {
-		ipAddr, err := GetMountIpFromActualMountPoint(m.mountPoint)
-		if err != nil {
-			return err
-		}
-		m.mountIpAddress = ipAddr
-	}
-	return nil
-}
-
 func (m *nfsMount) doUnmount(ctx context.Context) error {
 	logger := log.Ctx(ctx).With().Str("mount_point", m.getMountPoint()).Str("filesystem", m.fsName).Logger()
 	logger.Trace().Strs("mount_options", m.getMountOptions().Strings()).Msg("Performing umount via k8s native mounter")

--- a/pkg/wekafs/nfsmounter.go
+++ b/pkg/wekafs/nfsmounter.go
@@ -101,22 +101,6 @@ func (m *nfsMounter) Mount(ctx context.Context, fs string, apiClient *apiclient.
 	return m.mountWithOptions(ctx, fs, getDefaultMountOptions(), apiClient)
 }
 
-func (m *nfsMounter) unmountWithOptions(ctx context.Context, fsName string, options MountOptions) error {
-	options.setSelinux(m.getSelinuxStatus(ctx), MountProtocolNfs)
-	options = options.AsNfs()
-	options.Merge(options, m.exclusiveMountOptions)
-	log.Ctx(ctx).Trace().Strs("mount_options", options.Strings()).Str("filesystem", fsName).Msg("Received an unmount request")
-	mnt := m.NewMount(fsName, options).(*nfsMount)
-	// since we are not aware of the IP address of the mount, we need to find the mount point by listing the mounts
-	err := mnt.locateMountIP()
-	if err != nil {
-		log.Ctx(ctx).Error().Err(err).Msg("Failed to locate mount IP")
-		return err
-	}
-
-	return mnt.decRef(ctx)
-}
-
 func (m *nfsMounter) LogActiveMounts(ctx context.Context) {
 	m.lock.Lock()
 	defer m.lock.Unlock()

--- a/pkg/wekafs/utilities.go
+++ b/pkg/wekafs/utilities.go
@@ -309,42 +309,6 @@ func PathIsWekaMount(ctx context.Context, path string) bool {
 	return false
 }
 
-func GetMountIpFromActualMountPoint(mountPointBase string) (string, error) {
-	file, err := os.Open("/proc/mounts")
-	if err != nil {
-		return "", errors.New("failed to open /proc/mounts")
-	}
-	defer func() { _ = file.Close() }()
-	var actualMountPoint string
-	scanner := bufio.NewScanner(file)
-	for scanner.Scan() {
-		fields := strings.Fields(scanner.Text())
-		if len(fields) >= 3 && strings.HasPrefix(fields[1], fmt.Sprintf("%s-", mountPointBase)) {
-			actualMountPoint = fields[1]
-			return strings.TrimLeft(actualMountPoint, mountPointBase+"-"), nil
-		}
-	}
-	return "", errors.New("mount point not found")
-}
-func GetMountContainerNameFromActualMountPoint(mountPointBase string) (string, error) {
-	file, err := os.Open(ProcMountsPath)
-	if err != nil {
-		return "", errors.New("failed to open /proc/mounts")
-	}
-	defer func() { _ = file.Close() }()
-	scanner := bufio.NewScanner(file)
-	for scanner.Scan() {
-		fields := strings.Fields(scanner.Text())
-		if len(fields) >= 4 && fields[2] == "wekafs" && strings.HasPrefix(fields[1], mountPointBase) {
-			optionsString := fields[3]
-			mountOptions := NewMountOptionsFromString(optionsString)
-			containerName := mountOptions.getOptionValue("container_name")
-			return containerName, nil
-		}
-	}
-	return "", fmt.Errorf("mount point not found: %s", mountPointBase)
-}
-
 func validateVolumeId(volumeId string) error {
 	// Volume New format:
 	// VolID format is as following:

--- a/pkg/wekafs/utilities_test.go
+++ b/pkg/wekafs/utilities_test.go
@@ -1,7 +1,6 @@
 package wekafs
 
 import (
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -37,70 +36,4 @@ func TestGetQuotaGracePeriodParam(t *testing.T) {
 	secs, err = getQuotaGracePeriodParam(map[string]string{"quotaGracePeriod": "garbage"})
 	assert.Error(t, err)
 	assert.Equal(t, uint64(0), secs)
-}
-
-func TestGetMountContainerNameFromActualMountPoint(t *testing.T) {
-	// Create a temporary file to mock /proc/mounts
-	tmpFile, err := os.CreateTemp("", "mounts")
-	assert.NoError(t, err)
-	defer os.Remove(tmpFile.Name())
-
-	// Write mock data to the temporary file
-	mockData := `
-dev/sdc1 /boot/efi vfat rw,relatime,fmask=0077,dmask=0077,codepage=437,iocharset=ascii,shortname=winnt,errors=remount-ro 0 0
-fusectl /sys/fs/fuse/connections fusectl rw,relatime 0 0
-binfmt_misc /proc/sys/fs/binfmt_misc binfmt_misc rw,relatime 0 0
-/etc/auto.misc /misc autofs rw,relatime,fd=7,pgrp=2304,timeout=300,minproto=5,maxproto=5,indirect,pipe_ino=34520 0 0
--hosts /net autofs rw,relatime,fd=13,pgrp=2304,timeout=300,minproto=5,maxproto=5,indirect,pipe_ino=36373 0 0
-/etc/auto.weka-smb /wekasmb autofs rw,relatime,fd=19,pgrp=2304,timeout=300,minproto=5,maxproto=5,indirect,pipe_ino=34528 0 0
-/etc/auto.weka-smb /wekasmb-persistent autofs rw,relatime,fd=25,pgrp=2304,timeout=0,minproto=5,maxproto=5,indirect,pipe_ino=34531 0 0
-/etc/auto.weka-kw /wekakwfs autofs rw,relatime,fd=31,pgrp=2304,timeout=300,minproto=5,maxproto=5,indirect,pipe_ino=34535 0 0
-/etc/auto.weka-kw /wekakwfs-persistent autofs rw,relatime,fd=37,pgrp=2304,timeout=0,minproto=5,maxproto=5,indirect,pipe_ino=35191 0 0
-tmpfs /run/user/0 tmpfs rw,nosuid,nodev,relatime,size=2238124k,mode=700 0 0
-10.108.97.126/default /mnt/weka wekafs rw,relatime,writecache,inode_bits=auto,readahead_kb=32768,dentry_max_age_positive=1000,dentry_max_age_negative=0,container_name=client 0 0
-10.108.97.126/default /mnt/weka wekafs rw,relatime,writecache,inode_bits=auto,readahead_kb=32768,dentry_max_age_positive=1000,dentry_max_age_negative=0,container_name=client 0 0
-default /run/weka-fs-mounts/default-DTQLAJ6KO6IUCZE23RBIM26YYUQNWKST-42b24381dc12client wekafs rw,relatime,writecache,inode_bits=auto,readahead_kb=32768,dentry_max_age_positive=1000,dentry_max_age_negative=0,container_name=42b24381dc12client 0 0
-default /run/weka-fs-mounts/default-DTQLAJ6KO6IUCZE23RBIM26YYUQNWKKK wekafs rw,relatime,writecache,inode_bits=auto,readahead_kb=32768,dentry_max_age_positive=1000,dentry_max_age_negative=0 0 0
-default /run/weka-fs-mounts/default-DTQLAJ6KO6IUCZE23RBIM26YYUQNWKSS wekafs rw,relatime,writecache,inode_bits=auto,readahead_kb=32768,dentry_max_age_positive=1000,dentry_max_age_negative=0,container_name=containername 0 0
-default /run/weka-fs-mounts/default-DTQLAJ6KO6IUCZE23RBIM26YYUQNWKAA-mystrangeclient wekafs rw,relatime,writecache,inode_bits=auto,readahead_kb=32768,dentry_max_age_positive=1000,dentry_max_age_negative=0 0 0
-
-`
-	_, err = tmpFile.WriteString(mockData)
-	assert.NoError(t, err)
-	tmpFile.Close()
-
-	// Redirect the function to read from the temporary file
-	originalProcMountsPath := ProcMountsPath
-	defer func() { ProcMountsPath = originalProcMountsPath }()
-	ProcMountsPath = tmpFile.Name()
-
-	// Call the function and check the result
-	containerName, err := GetMountContainerNameFromActualMountPoint("/mnt/weka")
-	assert.NoError(t, err)
-	assert.Equal(t, "client", containerName)
-
-	containerName, err = GetMountContainerNameFromActualMountPoint("/run/weka-fs-mounts/default-DTQLAJ6KO6IUCZE23RBIM26YYUQNWKST-42b24381dc12client")
-	assert.NoError(t, err)
-	assert.Equal(t, "42b24381dc12client", containerName)
-
-	containerName, err = GetMountContainerNameFromActualMountPoint("/run/weka-fs-mounts/default-DTQLAJ6KO6IUCZE23RBIM26YYUQNWKKK")
-	assert.NoError(t, err)
-	assert.Equal(t, "", containerName)
-
-	containerName, err = GetMountContainerNameFromActualMountPoint("/run/weka-fs-mounts/default-DTQLAJ6KO6IUCZE23RBIM26YYUQNWKSS")
-	assert.NoError(t, err)
-	assert.Equal(t, "containername", containerName)
-
-	containerName, err = GetMountContainerNameFromActualMountPoint("/run/weka-fs-mounts/default-DTQLAJ6KO6IUCZE23RBIM26YYUQNWKSS-NONEXISTENT")
-	assert.Error(t, err)
-	assert.Equal(t, "", containerName)
-
-	containerName, err = GetMountContainerNameFromActualMountPoint("/run/weka-fs-mounts/default-DTQLAJ6KO6IUCZE23RBIM26YYUQNWKAA-mystrangeclient")
-	assert.NoError(t, err)
-	assert.Equal(t, "", containerName)
-
-	containerName, err = GetMountContainerNameFromActualMountPoint("/run/weka-fs-mounts/default-NONEXISTENT")
-	assert.Error(t, err)
-	assert.Equal(t, "", containerName)
-
 }

--- a/pkg/wekafs/volume.go
+++ b/pkg/wekafs/volume.go
@@ -1071,29 +1071,6 @@ func (v *Volume) MountUnderlyingFS(ctx context.Context) (error, UnmountFunc) {
 	return err, retUmountFunc
 }
 
-// UnmountUnderlyingFS decreases refCount / unmounts volume using specific mount options
-func (v *Volume) UnmountUnderlyingFS(ctx context.Context) error {
-	op := "UnmountUnderlyingFS"
-	ctx, span := otel.Tracer(TracerName).Start(ctx, op)
-	defer span.End()
-	ctx = log.With().Str("trace_id", span.SpanContext().TraceID().String()).Str("span_id", span.SpanContext().SpanID().String()).Str("op", op).Logger().WithContext(ctx)
-	logger := log.Ctx(ctx)
-
-	if v.server.getMounter() == nil {
-		Die("Volume unmount could not be done since mounter not defined on it")
-	}
-
-	mountOpts := v.getMountOptions(ctx)
-	err := v.server.getMounter().unmountWithOptions(ctx, v.FilesystemName, mountOpts)
-
-	if err == nil {
-		v.mountPath = ""
-	} else {
-		logger.Error().Err(err).Msg("Failed to unmount volume")
-	}
-	return err
-}
-
 // Exists returns true if the actual data representing volume object exists,e.g. filesystem, snapshot and innerPath
 func (v *Volume) Exists(ctx context.Context) (exists bool, retErr error) {
 	op := "VolumeExists"

--- a/pkg/wekafs/wekafsmount.go
+++ b/pkg/wekafs/wekafsmount.go
@@ -127,17 +127,6 @@ func (m *wekafsMount) decRef(ctx context.Context) error {
 	return nil
 }
 
-func (m *wekafsMount) locateContainerName() error {
-	if m.containerName == "" {
-		containerName, err := GetMountContainerNameFromActualMountPoint(m.mountPoint)
-		if err != nil {
-			return err
-		}
-		m.containerName = containerName
-	}
-	return nil
-}
-
 func (m *wekafsMount) doUnmount(ctx context.Context) error {
 	logger := log.Ctx(ctx).With().Str("mount_point", m.getMountPoint()).Str("filesystem", m.fsName).Logger()
 	logger.Trace().Strs("mount_options", m.getMountOptions().Strings()).Msg("Performing umount via k8s native mounter")

--- a/pkg/wekafs/wekafsmounter.go
+++ b/pkg/wekafs/wekafsmounter.go
@@ -105,20 +105,6 @@ func (m *wekafsMounter) Mount(ctx context.Context, fs string, apiClient *apiclie
 	return m.mountWithOptions(ctx, fs, getDefaultMountOptions(), apiClient)
 }
 
-func (m *wekafsMounter) unmountWithOptions(ctx context.Context, fsName string, options MountOptions) error {
-	options.setSelinux(m.getSelinuxStatus(ctx), MountProtocolWekafs)
-	log.Ctx(ctx).Trace().Strs("mount_options", options.Strings()).Str("filesystem", fsName).Msg("Received an unmount request")
-	mnt := m.NewMount(fsName, options).(*wekafsMount)
-
-	err := mnt.locateContainerName()
-	if err != nil {
-		log.Ctx(ctx).Error().Err(err).Msg("Failed to locate containerName")
-		return err
-	}
-
-	return mnt.decRef(ctx)
-}
-
 func (m *wekafsMounter) LogActiveMounts(ctx context.Context) {
 	m.lock.Lock()
 	defer m.lock.Unlock()


### PR DESCRIPTION
### TL;DR

Removes an unmount code path that has had no callers since 2024, along with the helpers it alone kept alive. Nothing changes for anyone running the driver.

### What changed?

- Deleted `UnmountUnderlyingFS` and the chain of six functions reachable only through it, including two helpers that reconstructed mount identity by scanning `/proc/mounts`.
- Narrowed the internal mounter interface to the methods that are actually used.
- 179 lines removed, no behaviour change.

### How to test?

The existing unit tests and CSI sanity suites cover it: real unmounting goes through a different path, which is unchanged. Mount, publish, unpublish and delete a volume over both wekafs and NFS transports and confirm mounts are released as before.

### Why make this change?

The last caller went away in September 2024, when the node server stopped keeping redundant active mounts after publishing a volume. Real unmounting has gone through the closure returned when mounting ever since, which is bound to the mounter that created the mount.

Code that looks like it handles unmounting, but cannot run, is worse than no code: it invites changes that appear to take effect and do not, and the two `/proc/mounts` helpers existed only to reconstruct state that the live path already has.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Deletion-only refactor of uncalled paths; production unmount flow via mount closures is unchanged.
> 
> **Overview**
> Removes a **dead unmount stack** that has had no callers since 2024: `Volume.UnmountUnderlyingFS`, mounter `unmountWithOptions` on both NFS and wekafs transports, and mount helpers that re-derived identity from **`/proc/mounts`** (`locateMountIP`, `locateContainerName`, `GetMountIpFromActualMountPoint`, `GetMountContainerNameFromActualMountPoint`).
> 
> **`AnyMounter`** no longer exposes `unmountWithOptions`; live teardown still uses the **`UnmountFunc`** returned from `mountWithOptions` / `MountUnderlyingFS` (refcount + `decRef`). Associated unit tests for the removed utilities are dropped (~179 lines). **No intended runtime behavior change** for mount, publish, or unpublish.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 601ef6d00c1db5a2ac5d32a05fe7b25c688721fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->