### PR TITLE
docs: state that the PR description convention has no exceptions

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -92,6 +92,13 @@ Key components deployed:
 
 ## PR Descriptions
 
+**Every PR description follows the convention below, without exception.** It applies to
+drafts, refactors, CI changes, dependency bumps, one-line fixes, and PRs opened by tooling
+or reopened later. A PR whose description does not use these headers is not finished, and
+the description is written when the PR is opened rather than added afterwards. When editing
+an existing PR that predates this, bring it into the format rather than matching what is
+already there.
+
 PR descriptions are **copied into the release notes as they are**, so write them for
 whoever reads those — an operator or a customer, not the person who reviewed the diff.
 See PR #409 for the house example.


### PR DESCRIPTION
### TL;DR

Records in `CLAUDE.md` that the PR description convention applies to every PR, with no exceptions. Nothing changes for anyone running the driver.

### What changed?

- The PR Descriptions section now states the convention is mandatory, and lists the cases previously treated as exempt: drafts, refactors, CI changes, dependency bumps, one-line fixes, and PRs opened by tooling.
- Says a PR whose description does not use the four headers is not finished, and that the description is written when the PR is opened rather than added later.
- Covers editing an older PR: bring it into the format rather than matching what is already there.
- The convention itself — the four headers, the audience, the length target — is unchanged.

### How to test?

Nothing to run. Read `.claude/CLAUDE.md` and confirm the PR Descriptions section opens with the rule and that the existing guidance below it is untouched.

### Why make this change?

The convention was phrased as guidance, so PRs that did not obviously face a customer tended to get a description in whatever shape suited the change. Those descriptions still land in the release notes, and the moment a PR is opened is when the description is cheapest to write and most accurate.

This PR is written to its own rule, which is the point.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to agent/contributor workflow in CLAUDE.md; no product code or deployment impact.
> 
> **Overview**
> **Tightens contributor docs only:** the PR Descriptions section in `.claude/CLAUDE.md` now opens with an explicit **no-exceptions** rule before the existing four-header template and audience guidance.
> 
> The new text says the convention applies to drafts, refactors, CI, dependency bumps, one-line fixes, and tooling or reopened PRs; a PR without the required headers is **not finished**; descriptions should be written **when the PR opens**, not added later; and older PRs should be **reformatted** rather than left as-is. **Nothing in the driver, chart, or runtime behavior changes.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd02389656799ee1d1136859010bac65c1cd1ceb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->