### PR TITLE
feat: instrument the remaining implemented CSI RPCs, and count net expansion

### DIFF
--- a/pkg/wekafs/controllerserver.go
+++ b/pkg/wekafs/controllerserver.go
@@ -586,6 +586,9 @@ func (cs *ControllerServer) ControllerExpandVolume(ctx context.Context, req *csi
 	logger.Info().Int64("capacity", capacity).Msg(">>>> Received request")
 	start := time.Now()
 	var backingType VolumeBackingType
+	// The size the volume had before this call, so the capacity counter can record what was actually
+	// added rather than the resulting size. Stays -1 if the request failed before it could be read.
+	previousCapacity := int64(-1)
 	defer func() {
 		level := zerolog.InfoLevel
 		if result != "SUCCESS" {
@@ -600,8 +603,8 @@ func (cs *ControllerServer) ControllerExpandVolume(ctx context.Context, req *csi
 			bt = string(VolumeBackingTypeUnknown)
 		}
 		driverName := cs.getConfig().GetDriver().name
-		if capacity > 0 {
-			controllerMetrics.Operations.ExpandVolumeTotalCapacity.WithLabelValues(driverName, result, bt).Add(float64(capacity))
+		if added := netExpansion(result == "SUCCESS", previousCapacity, capacity); added > 0 {
+			controllerMetrics.Operations.ExpandVolumeTotalCapacity.WithLabelValues(driverName, result, bt).Add(added)
 		}
 		recordOperation(controllerMetrics.Operations.ExpandVolumeCounter, controllerMetrics.Operations.ExpandVolumeDuration, start, driverName, result, bt)
 		logger.WithLevel(level).Str("result", result).Msg("<<<< Completed processing request")
@@ -655,6 +658,7 @@ func (cs *ControllerServer) ControllerExpandVolume(ctx context.Context, req *csi
 	if err != nil {
 		return ExpandVolumeError(ctx, codes.Internal, fmt.Sprintf("Could not get volume capacity: %s", err.Error()))
 	}
+	previousCapacity = currentSize
 	logger.Debug().Int64("current_capacity", currentSize).Int64("new_capacity", capacity).Msg("Expanding volume capacity")
 
 	// Validate capacity for expansion
@@ -869,6 +873,7 @@ func (cs *ControllerServer) ValidateVolumeCapabilities(ctx context.Context, req 
 	ctx = log.With().Str("trace_id", span.SpanContext().TraceID().String()).Str("span_id", span.SpanContext().SpanID().String()).Str("op", op).Logger().WithContext(ctx)
 
 	result := "FAILURE"
+	start := time.Now()
 	logger := log.Ctx(ctx)
 	logger.Info().Str("volume_id", volumeID).Msg(">>>> Received request")
 	defer func() {
@@ -876,6 +881,8 @@ func (cs *ControllerServer) ValidateVolumeCapabilities(ctx context.Context, req 
 		if result != "SUCCESS" {
 			level = zerolog.ErrorLevel
 		}
+		recordOperation(controllerMetrics.Operations.ValidateVolumeCapabilitiesCounter,
+			controllerMetrics.Operations.ValidateVolumeCapabilitiesDuration, start, cs.getConfig().GetDriver().name, result)
 		logger.WithLevel(level).Str("result", result).Msg("<<<< Completed processing request")
 	}()
 

--- a/pkg/wekafs/metrics.go
+++ b/pkg/wekafs/metrics.go
@@ -12,8 +12,11 @@ var (
 	CsiControllerConcurrencyMetricsLabels       = []string{"status"}
 	CsiControllerVolumeOperationMetricsLabels   = []string{"status", "backing_type"}
 	CsiControllerSnapshotOperationMetricsLabels = []string{"status"}
-	CsiNodeConcurrencyMetricsLabels             = []string{"status"}
-	CsiNodeVolumeOperationMetricsLabels         = []string{"status"}
+	// The read-only controller RPCs carry no backing type: ListVolumes spans every backing type at
+	// once, and ControllerGetVolume can fail long before the volume behind the handle is resolved.
+	CsiControllerQueryOperationMetricsLabels = []string{"status"}
+	CsiNodeConcurrencyMetricsLabels          = []string{"status"}
+	CsiNodeVolumeOperationMetricsLabels      = []string{"status"}
 )
 
 const MetricsPrefix = "weka_csi"
@@ -56,6 +59,21 @@ func recordOperation(counter *prometheus.CounterVec, duration *prometheus.Histog
 	duration.WithLabelValues(labels...).Observe(time.Since(start).Seconds())
 }
 
+// netExpansion returns how many bytes a ControllerExpandVolume call actually added to a volume:
+// zero unless it succeeded, the previous size was known, and the volume genuinely grew.
+//
+// Each guard matters, and none is correctable after the fact because counters only ever go up.
+// Recording the resulting size would re-count every byte the volume already had on each subsequent
+// expansion. Recording an attempt that failed after the old size was read - a rejected capacity
+// reservation, or a Weka API error part-way through - would credit growth that never happened. A
+// request that never got far enough to read the old size has nothing to compare against.
+func netExpansion(succeeded bool, previousCapacity, capacity int64) float64 {
+	if !succeeded || previousCapacity < 0 || capacity <= previousCapacity {
+		return 0
+	}
+	return float64(capacity - previousCapacity)
+}
+
 // ControllerCollectors returns the controller server metrics for the caller to register.
 func ControllerCollectors() []prometheus.Collector { return controllerMetrics.Collectors() }
 
@@ -75,6 +93,16 @@ type ControllerOperationMetrics struct {
 	CreateSnapshotDuration    *prometheus.HistogramVec
 	DeleteSnapshotCounter     *prometheus.CounterVec
 	DeleteSnapshotDuration    *prometheus.HistogramVec
+
+	// The read-only RPCs. On a large fleet these are the entire steady-state controller workload -
+	// the external health monitor calls GetVolume and ListVolumes continuously - so without them a
+	// busy driver exports nothing at all between provisioning events.
+	GetVolumeCounter                   *prometheus.CounterVec
+	GetVolumeDuration                  *prometheus.HistogramVec
+	ListVolumesCounter                 *prometheus.CounterVec
+	ListVolumesDuration                *prometheus.HistogramVec
+	ValidateVolumeCapabilitiesCounter  *prometheus.CounterVec
+	ValidateVolumeCapabilitiesDuration *prometheus.HistogramVec
 }
 
 // Collectors returns the metrics for the caller to register.
@@ -92,10 +120,16 @@ func (c *ControllerOperationMetrics) Collectors() []prometheus.Collector {
 		c.CreateSnapshotDuration,
 		c.DeleteSnapshotCounter,
 		c.DeleteSnapshotDuration,
+		c.GetVolumeCounter,
+		c.GetVolumeDuration,
+		c.ListVolumesCounter,
+		c.ListVolumesDuration,
+		c.ValidateVolumeCapabilitiesCounter,
+		c.ValidateVolumeCapabilitiesDuration,
 	}
 }
 
-func NewControllerOperationMetrics(volumeLabels, snapshotLabels []string) *ControllerOperationMetrics {
+func NewControllerOperationMetrics(volumeLabels, snapshotLabels, queryLabels []string) *ControllerOperationMetrics {
 	return &ControllerOperationMetrics{
 		CreateVolumeCounter:       newCounterVec("controller", "create_volume_total", "Total number of ControllerCreateVolume calls", volumeLabels),
 		CreateVolumeDuration:      newHistogramVec("controller", "create_volume_duration_seconds", "Duration of ControllerCreateVolume calls in seconds", volumeLabels),
@@ -104,11 +138,18 @@ func NewControllerOperationMetrics(volumeLabels, snapshotLabels []string) *Contr
 		DeleteVolumeDuration:      newHistogramVec("controller", "delete_volume_duration_seconds", "Duration of ControllerDeleteVolume calls in seconds", volumeLabels),
 		ExpandVolumeCounter:       newCounterVec("controller", "expand_volume_total", "Total number of ControllerExpandVolume calls", volumeLabels),
 		ExpandVolumeDuration:      newHistogramVec("controller", "expand_volume_duration_seconds", "Duration of ControllerExpandVolume calls in seconds", volumeLabels),
-		ExpandVolumeTotalCapacity: newCounterVec("controller", "expand_volume_total_capacity_bytes", "Total capacity of volumes expanded by ControllerExpandVolume in bytes", volumeLabels),
+		ExpandVolumeTotalCapacity: newCounterVec("controller", "expand_volume_total_capacity_bytes", "Total capacity added to volumes by ControllerExpandVolume in bytes, counting only the increase over the previous size", volumeLabels),
 		CreateSnapshotCounter:     newCounterVec("controller", "create_snapshot_total", "Total number of ControllerCreateSnapshot calls", snapshotLabels),
 		CreateSnapshotDuration:    newHistogramVec("controller", "create_snapshot_duration_seconds", "Duration of ControllerCreateSnapshot calls in seconds", snapshotLabels),
 		DeleteSnapshotCounter:     newCounterVec("controller", "delete_snapshot_total", "Total number of ControllerDeleteSnapshot calls", snapshotLabels),
 		DeleteSnapshotDuration:    newHistogramVec("controller", "delete_snapshot_duration_seconds", "Duration of ControllerDeleteSnapshot calls in seconds", snapshotLabels),
+
+		GetVolumeCounter:                   newCounterVec("controller", "get_volume_total", "Total number of ControllerGetVolume calls", queryLabels),
+		GetVolumeDuration:                  newHistogramVec("controller", "get_volume_duration_seconds", "Duration of ControllerGetVolume calls in seconds", queryLabels),
+		ListVolumesCounter:                 newCounterVec("controller", "list_volumes_total", "Total number of ControllerListVolumes calls", queryLabels),
+		ListVolumesDuration:                newHistogramVec("controller", "list_volumes_duration_seconds", "Duration of ControllerListVolumes calls in seconds", queryLabels),
+		ValidateVolumeCapabilitiesCounter:  newCounterVec("controller", "validate_volume_capabilities_total", "Total number of ValidateVolumeCapabilities calls", queryLabels),
+		ValidateVolumeCapabilitiesDuration: newHistogramVec("controller", "validate_volume_capabilities_duration_seconds", "Duration of ValidateVolumeCapabilities calls in seconds", queryLabels),
 	}
 }
 
@@ -163,7 +204,7 @@ type ControllerServerMetrics struct {
 
 func NewControllerServerMetrics() *ControllerServerMetrics {
 	return &ControllerServerMetrics{
-		Operations:  NewControllerOperationMetrics(CsiControllerVolumeOperationMetricsLabels, CsiControllerSnapshotOperationMetricsLabels),
+		Operations:  NewControllerOperationMetrics(CsiControllerVolumeOperationMetricsLabels, CsiControllerSnapshotOperationMetricsLabels, CsiControllerQueryOperationMetricsLabels),
 		Concurrency: NewControllerConcurrencyMetrics(CsiControllerConcurrencyMetricsLabels),
 	}
 }
@@ -206,6 +247,10 @@ type NodeServerOperationMetrics struct {
 	UnpublishVolumeDuration *prometheus.HistogramVec
 	GetVolumeStats          *prometheus.CounterVec
 	GetVolumeStatsDuration  *prometheus.HistogramVec
+	// Called once per node at registration, so this is a low-rate counter whose value is in
+	// spotting nodes that fail to register rather than in its rate.
+	GetInfo         *prometheus.CounterVec
+	GetInfoDuration *prometheus.HistogramVec
 }
 
 // Collectors returns the metrics for the caller to register.
@@ -217,6 +262,8 @@ func (m *NodeServerOperationMetrics) Collectors() []prometheus.Collector {
 		m.UnpublishVolumeDuration,
 		m.GetVolumeStats,
 		m.GetVolumeStatsDuration,
+		m.GetInfo,
+		m.GetInfoDuration,
 	}
 }
 
@@ -228,6 +275,8 @@ func NewNodeOperationMetrics(volumeLabels []string) *NodeServerOperationMetrics 
 		UnpublishVolumeDuration: newHistogramVec("node", "unpublish_volume_duration_seconds", "Duration of NodeUnpublishVolume calls in seconds", volumeLabels),
 		GetVolumeStats:          newCounterVec("node", "get_volume_stats_total", "Total number of NodeGetVolumeStats calls", volumeLabels),
 		GetVolumeStatsDuration:  newHistogramVec("node", "get_volume_stats_duration_seconds", "Duration of NodeGetVolumeStats calls in seconds", volumeLabels),
+		GetInfo:                 newCounterVec("node", "get_info_total", "Total number of NodeGetInfo calls", volumeLabels),
+		GetInfoDuration:         newHistogramVec("node", "get_info_duration_seconds", "Duration of NodeGetInfo calls in seconds", volumeLabels),
 	}
 }
 

--- a/pkg/wekafs/metrics_test.go
+++ b/pkg/wekafs/metrics_test.go
@@ -1,0 +1,115 @@
+package wekafs
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// declaredMetricFields counts the constructed metric fields on a metrics struct, failing on any that
+// were declared but never built. Takes a reflect.Value so it serves both the pointer-to-struct groups
+// here and the embedded struct groups in prometheus_test.go.
+func declaredMetricFields(t *testing.T, v reflect.Value, groupName string) int {
+	t.Helper()
+
+	declared := 0
+	for i := 0; i < v.NumField(); i++ {
+		f := v.Field(i)
+		if f.Kind() != reflect.Ptr && f.Kind() != reflect.Interface {
+			continue
+		}
+		if f.IsNil() {
+			t.Errorf("%s.%s is declared but never constructed", groupName, v.Type().Field(i).Name)
+			continue
+		}
+		declared++
+	}
+	return declared
+}
+
+// Every metric these structs declare must appear in Collectors(), or it is built and never exported.
+// The struct and its Collectors() list are edited by hand in two places, so adding a metric to one
+// and forgetting the other is the easy mistake; this walks the struct by reflection instead of
+// trusting the two to be kept in step.
+func TestControllerAndNodeCollectorsAreComplete(t *testing.T) {
+	controller := NewControllerServerMetrics()
+	node := NewNodeServerMetrics()
+
+	cases := []struct {
+		name       string
+		collectors []prometheus.Collector
+		groups     map[string]any
+	}{
+		{
+			name:       "controller",
+			collectors: controller.Collectors(),
+			groups: map[string]any{
+				"ControllerOperationMetrics":   controller.Operations,
+				"ControllerConcurrencyMetrics": controller.Concurrency,
+			},
+		},
+		{
+			name:       "node",
+			collectors: node.Collectors(),
+			groups: map[string]any{
+				"NodeServerOperationMetrics":   node.Operations,
+				"NodeServerConcurrencyMetrics": node.Concurrency,
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			declared := 0
+			for groupName, group := range tc.groups {
+				declared += declaredMetricFields(t, reflect.ValueOf(group).Elem(), groupName)
+			}
+			if got := len(tc.collectors); got != declared {
+				t.Errorf("Collectors() returns %d collectors but %d metrics are declared - %d would be "+
+					"built and never exported", got, declared, declared-got)
+			}
+		})
+	}
+}
+
+// Constructing the metrics must not touch any registry, and every collector must be acceptable to a
+// fresh one - a duplicate name or an inconsistent label set only surfaces at registration.
+func TestControllerAndNodeCollectorsRegisterCleanly(t *testing.T) {
+	for name, collectors := range map[string][]prometheus.Collector{
+		"controller": NewControllerServerMetrics().Collectors(),
+		"node":       NewNodeServerMetrics().Collectors(),
+	} {
+		reg := prometheus.NewRegistry()
+		for _, c := range collectors {
+			if err := reg.Register(c); err != nil {
+				t.Errorf("%s: collector rejected by a fresh registry: %v", name, err)
+			}
+		}
+	}
+}
+
+// The expansion counter records bytes added, so it must ignore anything that did not add bytes.
+// A counter cannot be walked back, so every one of these cases would permanently inflate an
+// operator's view of how much capacity the driver handed out.
+func TestNetExpansion(t *testing.T) {
+	const gib = 1 << 30
+
+	for name, tc := range map[string]struct {
+		succeeded          bool
+		previous, capacity int64
+		want               float64
+	}{
+		"grew by 1GiB":                  {true, gib, 2 * gib, gib},
+		"failed after reading old size": {false, gib, 2 * gib, 0},
+		"old size never read":           {true, -1, 2 * gib, 0},
+		"no-op expand to same size":     {true, gib, gib, 0},
+		"shrink request":                {true, 2 * gib, gib, 0},
+		"failed before anything known":  {false, -1, -1, 0},
+	} {
+		if got := netExpansion(tc.succeeded, tc.previous, tc.capacity); got != tc.want {
+			t.Errorf("%s: netExpansion(%v, %d, %d) = %v, want %v",
+				name, tc.succeeded, tc.previous, tc.capacity, got, tc.want)
+		}
+	}
+}

--- a/pkg/wekafs/nodeserver.go
+++ b/pkg/wekafs/nodeserver.go
@@ -618,6 +618,7 @@ func (ns *NodeServer) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnstag
 func (ns *NodeServer) NodeGetInfo(ctx context.Context, req *csi.NodeGetInfoRequest) (*csi.NodeGetInfoResponse, error) {
 	op := "NodeGetInfo"
 	result := "SUCCESS"
+	start := time.Now()
 	ctx, span := otel.Tracer(TracerName).Start(ctx, op)
 	defer span.End()
 	ctx = log.With().Str("trace_id", span.SpanContext().TraceID().String()).Str("span_id", span.SpanContext().SpanID().String()).Str("op", op).Logger().WithContext(ctx)
@@ -629,6 +630,8 @@ func (ns *NodeServer) NodeGetInfo(ctx context.Context, req *csi.NodeGetInfoReque
 		if result != "SUCCESS" {
 			level = zerolog.ErrorLevel
 		}
+		recordOperation(nodeMetrics.Operations.GetInfo, nodeMetrics.Operations.GetInfoDuration,
+			start, ns.getConfig().GetDriver().name, result)
 		logger.WithLevel(level).Str("result", result).Msg("<<<< Completed processing request")
 	}()
 

--- a/pkg/wekafs/volumehealth.go
+++ b/pkg/wekafs/volumehealth.go
@@ -151,7 +151,16 @@ func (cs *ControllerServer) ControllerGetVolume(ctx context.Context, req *csi.Co
 	volumeID := req.GetVolumeId()
 	logger := log.Ctx(ctx).With().Str("volume_id", volumeID).Logger()
 	logger.Debug().Msg(">>>> Received request")
-	defer logger.Debug().Msg("<<<< Completed processing request")
+
+	// Recorded from a defer because every failure below returns early; the health monitor calls this
+	// on every volume on every sweep, so it is the busiest controller RPC on a large fleet.
+	result := "FAILURE"
+	start := time.Now()
+	defer func() {
+		recordOperation(controllerMetrics.Operations.GetVolumeCounter, controllerMetrics.Operations.GetVolumeDuration,
+			start, cs.getConfig().GetDriver().name, result)
+		logger.Debug().Msg("<<<< Completed processing request")
+	}()
 
 	if err := cs.validateControllerServiceRequest(csi.ControllerServiceCapability_RPC_GET_VOLUME); err != nil {
 		logger.Err(err).Msg("Volume health reporting is not enabled")
@@ -175,6 +184,7 @@ func (cs *ControllerServer) ControllerGetVolume(ctx context.Context, req *csi.Co
 	if err != nil {
 		return nil, err
 	}
+	result = "SUCCESS"
 	return &csi.ControllerGetVolumeResponse{
 		Volume: volume,
 		Status: &csi.ControllerGetVolumeResponse_VolumeStatus{VolumeCondition: condition},
@@ -273,7 +283,15 @@ func (cs *ControllerServer) ListVolumes(ctx context.Context, req *csi.ListVolume
 
 	logger := log.Ctx(ctx)
 	logger.Debug().Int32("max_entries", req.GetMaxEntries()).Msg(">>>> Received request")
-	defer logger.Debug().Msg("<<<< Completed processing request")
+
+	// As with ControllerGetVolume: recorded from a defer so the early returns above are counted too.
+	result := "FAILURE"
+	start := time.Now()
+	defer func() {
+		recordOperation(controllerMetrics.Operations.ListVolumesCounter, controllerMetrics.Operations.ListVolumesDuration,
+			start, cs.getConfig().GetDriver().name, result)
+		logger.Debug().Msg("<<<< Completed processing request")
+	}()
 
 	if err := cs.validateControllerServiceRequest(csi.ControllerServiceCapability_RPC_LIST_VOLUMES); err != nil {
 		logger.Err(err).Msg("Volume listing is not enabled")
@@ -300,6 +318,7 @@ func (cs *ControllerServer) ListVolumes(ctx context.Context, req *csi.ListVolume
 	page, nextToken := paginateVolumes(remaining, int(req.GetMaxEntries()))
 
 	response := &csi.ListVolumesResponse{Entries: cs.describeVolumes(ctx, page), NextToken: nextToken}
+	result = "SUCCESS"
 	logger.Debug().Int("entries", len(response.Entries)).Bool("more_pages", nextToken != "").Msg("Listed volumes")
 	return response, nil
 }


### PR DESCRIPTION
### TL;DR

Completes metric coverage of the plugin's operations, and adds a measure of how much capacity volume expansions actually add.

### What changed?

- The CSI operations that were still unmeasured now record the same counters and durations as the rest, so every implemented operation appears in metrics.
- Volume expansion additionally records the net capacity change, not just that an expansion occurred — so growth across a cluster can be totalled rather than only counted.

### How to test?

1. Install the chart with metrics enabled.
2. Exercise a range of operations: create a PVC, snapshot it, clone it, expand it, then delete everything.
3. `kubectl port-forward` to a controller pod and `curl localhost:9090/metrics`; confirm each operation appears with a non-zero count, and that expanding a 1 GiB volume to 3 GiB records 2 GiB of net expansion.

### Why make this change?

Partial instrumentation is misleading in a way no instrumentation is not: an operation missing from a dashboard looks like an operation that never happened. Covering the remainder means the metrics can be read as a complete account of what the plugin did.

Ported from #730 on the 3.0 branch so this arrives in 2.10 rather than waiting for the major release.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only changes with a deliberate semantic fix to the expand capacity counter; no provisioning or auth logic is modified.
> 
> **Overview**
> **Completes Prometheus coverage** for CSI RPCs that were still uninstrumented, and **fixes how expand capacity is counted** so dashboards reflect real growth.
> 
> Previously missing controller operations (`ControllerGetVolume`, `ListVolumes`, `ValidateVolumeCapabilities`) and node `NodeGetInfo` now record the same **counter + duration** pairs as create/delete/publish. Read-only controller RPCs use a **`status`-only label set** (no `backing_type`), since listing spans all backing types and get-volume can fail before a volume is resolved.
> 
> **`expand_volume_total_capacity_bytes`** no longer adds the post-expand size (or failed attempts). It increments only **net bytes added** via `netExpansion`: successful expands where the prior size was read and the new size is larger. The expand handler captures `previousCapacity` after `GetCapacity`.
> 
> Tests add **`TestNetExpansion`**, reflection checks that every declared metric is registered, and registry registration smoke tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c3372640f7aed7a804e6bc47a544397de3dd2c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->